### PR TITLE
Potential fix for Feature request 389757

### DIFF
--- a/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/plugin.xml
+++ b/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/plugin.xml
@@ -15,7 +15,7 @@
          id="headlesstest"
          point="org.eclipse.core.runtime.applications">
       <application
-            cardinality="singleton-global"
+            cardinality="1"
             thread="main"
             visible="true">
          <run


### PR DESCRIPTION
OSGi-Application
- allow to launch other OSGi-Applications while running the headless
  application
