### PR TITLE
Signed-off-by: Pere Joseph Rodríguez <perelengo@hotmail.com>

### DIFF
--- a/tycho-release/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/SynchronizeMetadataMojo.java
+++ b/tycho-release/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/SynchronizeMetadataMojo.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2008, 2015 Sonatype Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Sonatype Inc. - initial API and implementation
+ *    Sebastien Arod - update version ranges
+ *    Pere Joseph Rodríguez - synchronize metadata with pom version
+ *******************************************************************************/
+package org.eclipse.tycho.versions;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.eclipse.tycho.versions.engine.ProjectMetadataReader;
+import org.eclipse.tycho.versions.engine.SynchronizeVersionsEngine;
+
+/**
+ * <p>
+ * Synchronizes the metadata version of the current project and child projects with their
+ * corresponding pom version.
+ * </p>
+ * <p>
+ * Allows updating properties.
+ * </p>
+ * <p>
+ * By default bounds of OSGI version ranges referencing the version of an element that changed
+ * version will be updated to match the newVersion.
+ * </p>
+ * <p>
+ * Only executes in the root project of an aggregation project, due to it updates all child
+ * projects, it's not necessary to execute again in child projects.
+ * </p>
+ */
+@Mojo(name = "synchronize-version", aggregator = true, requiresDirectInvocation = true, inheritByDefault = false)
+public class SynchronizeMetadataMojo extends AbstractVersionsMojo {
+
+    /**
+     * <p>
+     * When true bounds of OSGI version ranges referencing the version of an element that changed
+     * version will be updated to match the newVersion.
+     * </p>
+     */
+    @Parameter(property = "updateVersionRangeMatchingBounds", defaultValue = "true")
+    private boolean updateVersionRangeMatchingBounds;
+
+    /**
+     * <p>
+     * Comma separated list of names of POM properties to set the new version to. Note that
+     * properties are only changed in the projects explicitly listed by the {@link #artifacts}
+     * parameter.
+     * </p>
+     * 
+     * @since 0.18.0
+     */
+    @Parameter(property = "properties")
+    private String properties;
+
+    /**
+     * skip inherited goal execution
+     */
+    @Parameter(property = "skipExecution", defaultValue = "false")
+    private boolean skipExecution;
+
+    /**
+     * baseDir of the current execution
+     */
+    @Parameter(property = "basedir", readonly = true, defaultValue = "${project.basedir}")
+    protected File basedir;
+
+    /**
+     * Check if the current goal is executing for the root project of the invocation
+     * 
+     * @return
+     * @throws MojoExecutionException
+     */
+    private boolean isReactorRootProject() throws MojoExecutionException {
+        try {
+            String executionRootPath = new File(session.getExecutionRootDirectory()).getCanonicalFile()
+                    .getAbsolutePath();
+            String basedirPath = basedir.getCanonicalFile().getAbsolutePath();
+            return executionRootPath.equals(basedirPath);
+        } catch (IOException e) {
+            throw new MojoExecutionException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if (!skipExecution && isReactorRootProject()) {
+            SynchronizeVersionsEngine engine = newEngine();
+            engine.setUpdateVersionRangeMatchingBounds(updateVersionRangeMatchingBounds);
+            ProjectMetadataReader metadataReader = newProjectMetadataReader();
+
+            try {
+                metadataReader.addBasedir(session.getCurrentProject().getBasedir());
+
+                engine.setProjects(metadataReader.getProjects());
+
+                engine.apply();
+            } catch (IOException e) {
+                throw new MojoExecutionException("Could not set version", e);
+            }
+        }
+    }
+
+    private SynchronizeVersionsEngine newEngine() throws MojoFailureException {
+        return lookup(SynchronizeVersionsEngine.class);
+    }
+
+    private static List<String> split(String str) {
+        ArrayList<String> result = new ArrayList<>();
+        if (str != null) {
+            StringTokenizer st = new StringTokenizer(str, ",");
+            while (st.hasMoreTokens()) {
+                result.add(st.nextToken().trim());
+            }
+        }
+        return result;
+    }
+}

--- a/tycho-release/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/manipulation/BundleManifestManipulator.java
+++ b/tycho-release/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/manipulation/BundleManifestManipulator.java
@@ -76,7 +76,7 @@ public class BundleManifestManipulator extends AbstractMetadataManipulator {
         }
     }
 
-    private Set<PackageVersionChange> computeExportedPackageChanges(ProjectMetadata project,
+    protected Set<PackageVersionChange> computeExportedPackageChanges(ProjectMetadata project,
             VersionChangesDescriptor versionChangeContext) {
         VersionChange versionChangeForProject = findVersionChangeForProject(project, versionChangeContext);
         if (versionChangeForProject == null) {
@@ -100,7 +100,7 @@ public class BundleManifestManipulator extends AbstractMetadataManipulator {
         return packageVersionChanges;
     }
 
-    private VersionChange findVersionChangeForProject(ProjectMetadata project,
+    protected VersionChange findVersionChangeForProject(ProjectMetadata project,
             VersionChangesDescriptor versionChangeContext) {
         MutableBundleManifest mf = getBundleManifest(project);
         VersionChange versionChangeForProject = versionChangeContext
@@ -112,7 +112,7 @@ public class BundleManifestManipulator extends AbstractMetadataManipulator {
         }
     }
 
-    private void updateBundleAndExportPackageVersions(ProjectMetadata project,
+    protected void updateBundleAndExportPackageVersions(ProjectMetadata project,
             VersionChangesDescriptor versionChangeContext) {
         MutableBundleManifest mf = getBundleManifest(project);
         VersionChange versionChangeForProject = findVersionChangeForProject(project, versionChangeContext);
@@ -136,7 +136,7 @@ public class BundleManifestManipulator extends AbstractMetadataManipulator {
         }
     }
 
-    private void updateFragmentHostVersion(ProjectMetadata project, VersionChangesDescriptor versionChangeContext) {
+    protected void updateFragmentHostVersion(ProjectMetadata project, VersionChangesDescriptor versionChangeContext) {
         MutableBundleManifest mf = getBundleManifest(project);
         if (mf.isFragment()) {
             VersionChange versionChange = versionChangeContext
@@ -152,7 +152,7 @@ public class BundleManifestManipulator extends AbstractMetadataManipulator {
         }
     }
 
-    private void updateRequireBundleVersions(ProjectMetadata project, VersionChangesDescriptor versionChangeContext) {
+    protected void updateRequireBundleVersions(ProjectMetadata project, VersionChangesDescriptor versionChangeContext) {
         MutableBundleManifest mf = getBundleManifest(project);
         Map<String, String> requiredBundleVersions = mf.getRequiredBundleVersions();
         Map<String, String> versionsToUpdate = new HashMap<>();
@@ -168,7 +168,7 @@ public class BundleManifestManipulator extends AbstractMetadataManipulator {
         mf.updateRequiredBundleVersions(versionsToUpdate);
     }
 
-    private void updateImportPackageVersions(ProjectMetadata project, VersionChangesDescriptor versionChangeContext) {
+    protected void updateImportPackageVersions(ProjectMetadata project, VersionChangesDescriptor versionChangeContext) {
         MutableBundleManifest mf = getBundleManifest(project);
         Map<String, String> importedPackageNewVersions = new HashMap<>();
         for (Entry<String, String> importPackageVersions : mf.getImportPackagesVersions().entrySet()) {
@@ -189,7 +189,7 @@ public class BundleManifestManipulator extends AbstractMetadataManipulator {
         mf.updateImportedPackageVersions(importedPackageNewVersions);
     }
 
-    private MutableBundleManifest getBundleManifest(ProjectMetadata project) {
+    protected MutableBundleManifest getBundleManifest(ProjectMetadata project) {
         MutableBundleManifest mf = project.getMetadata(MutableBundleManifest.class);
         if (mf == null) {
             File file = getManifestFile(project);
@@ -203,7 +203,7 @@ public class BundleManifestManipulator extends AbstractMetadataManipulator {
         return mf;
     }
 
-    private File getManifestFile(ProjectMetadata project) {
+    protected File getManifestFile(ProjectMetadata project) {
         return new File(project.getBasedir(), "META-INF/MANIFEST.MF");
     }
 

--- a/tycho-release/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/manipulation/CategoryXmlManipulator.java
+++ b/tycho-release/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/manipulation/CategoryXmlManipulator.java
@@ -47,7 +47,7 @@ public class CategoryXmlManipulator extends AbstractMetadataManipulator {
         }
     }
 
-    private void updateFeatureReferences(VersionChange featureVersionChange, ProjectMetadata project) {
+    protected void updateFeatureReferences(VersionChange featureVersionChange, ProjectMetadata project) {
         Category categoryXml = getCategoryXml(project);
         if (categoryXml == null) {
             return;
@@ -55,7 +55,7 @@ public class CategoryXmlManipulator extends AbstractMetadataManipulator {
         for (SiteFeatureRef feature : categoryXml.getFeatures()) {
             String featureId = featureVersionChange.getArtifactId();
             String srcFeatureId = featureId + SOURCE_FEATURE_SUFFIX;
-            if ((featureId.equals(feature.getId()) || srcFeatureId.equals(feature.getId())) 
+            if ((featureId.equals(feature.getId()) || srcFeatureId.equals(feature.getId()))
                     && featureVersionChange.getVersion().equals(feature.getVersion())) {
                 logger.info("  category.xml//site/feature[@id=" + feature.getId() + "]/@version: "
                         + featureVersionChange.getVersion() + " => " + featureVersionChange.getNewVersion());

--- a/tycho-release/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/manipulation/synchronize/BundleManifestSynchronzier.java
+++ b/tycho-release/tycho-versions-plugin/src/main/java/org/eclipse/tycho/versions/manipulation/synchronize/BundleManifestSynchronzier.java
@@ -1,0 +1,22 @@
+package org.eclipse.tycho.versions.manipulation.synchronize;
+
+import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.tycho.versions.bundle.MutableBundleManifest;
+import org.eclipse.tycho.versions.engine.MetadataManipulator;
+import org.eclipse.tycho.versions.engine.ProjectMetadata;
+import org.eclipse.tycho.versions.engine.VersionChange;
+import org.eclipse.tycho.versions.engine.VersionChangesDescriptor;
+import org.eclipse.tycho.versions.manipulation.BundleManifestManipulator;
+
+@Component(role = MetadataManipulator.class, hint = "bundle-manifest-synchronizer")
+public class BundleManifestSynchronzier extends BundleManifestManipulator {
+
+    @Override
+    protected VersionChange findVersionChangeForProject(ProjectMetadata project,
+            VersionChangesDescriptor versionChangeContext) {
+        MutableBundleManifest mf = getBundleManifest(project);
+        VersionChange versionChangeForProject = versionChangeContext
+                .findVersionChangeByArtifactId(mf.getSymbolicName());
+        return versionChangeForProject;
+    }
+}


### PR DESCRIPTION
As I do releases of eclipse based projects with maven-release-plugin, I needed some utility to update tycho based projects metadata after version change. I think it's a interesting utility, for wider use of tycho.

I created a new Mojo to do such task:

Synchronizes the metadata version of the current project and child projects with their corresponding pom version.

Allows updating properties.

By default bounds of OSGI version ranges referencing the version of an element that changed version will be updated to match the newVersion.

Only executes in the root project of an aggregation project, due to it updates all child projects, it's not necessary to execute again in child projects.