### PR TITLE
Tycho p2 metadata mojo classifier support

### DIFF
--- a/tycho-p2/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/P2MetadataMojo.java
+++ b/tycho-p2/tycho-p2-plugin/src/main/java/org/eclipse/tycho/plugins/p2/P2MetadataMojo.java
@@ -65,6 +65,9 @@ public class P2MetadataMojo extends AbstractMojo {
     @Parameter(defaultValue = "true")
     protected boolean attachP2Metadata;
 
+    @Parameter
+    protected String p2ArtifactClassifier;
+
     @Component
     protected MavenProjectHelper projectHelper;
 
@@ -129,7 +132,7 @@ public class P2MetadataMojo extends AbstractMojo {
 
         File targetDir = new File(project.getBuild().getDirectory());
 
-        ArtifactFacade projectDefaultArtifact = new ArtifactFacade(project.getArtifact());
+        ArtifactFacade projectDefaultArtifact = getProjectArtifact();
 
         try {
             List<IArtifactFacade> artifacts = new ArrayList<>();
@@ -184,6 +187,22 @@ public class P2MetadataMojo extends AbstractMojo {
 
         File localArtifactsFile = new File(project.getBuild().getDirectory(), FILE_NAME_LOCAL_ARTIFACTS);
         writeArtifactLocations(localArtifactsFile, getAllProjectArtifacts(project));
+    }
+
+    private ArtifactFacade getProjectArtifact() {
+        Artifact artifact = project.getArtifact();
+        if (p2ArtifactClassifier != null && !p2ArtifactClassifier.trim().isEmpty()) {
+            List<Artifact> attachedArtifacts = project.getAttachedArtifacts();
+            for (Artifact attachedArtifact : attachedArtifacts) {
+                if (p2ArtifactClassifier.equals(attachedArtifact.getClassifier())) {
+                    artifact = attachedArtifact;
+                    break;
+                }
+            }
+        }
+
+        ArtifactFacade projectDefaultArtifact = new ArtifactFacade(artifact);
+        return projectDefaultArtifact;
     }
 
     private static boolean hasAttachedArtifact(MavenProject project, String classifier) {


### PR DESCRIPTION
Hi,

I created a patch that allows users to define a classifier for plugins etc.
I need this feature, because I obfuscate my plugins and the obfuscated version has a classifier.
Without that patch the product configuration will always use the "normal" jar. Thus the generated p2 repository or the created ZIPs did not contain the obfuscated jar. 

With my patch I can now configure the tycho-p2-plugin in this way

				<plugin>
					<groupId>org.eclipse.tycho</groupId>
					<artifactId>tycho-p2-plugin</artifactId>
					<configuration>
						<p2ArtifactClassifier>obfuscated</p2ArtifactClassifier>
					</configuration>
				</plugin>

It would be very nice if you would merge that commit.
Don't hesitate to contact me, if you have any questions.

Greetings
René Link