### PR TITLE
Fix broken link (documentation) in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ Tycho is a manifest-first way to build
   
 with Maven.
 
-  * [Project Homepage](http://www.eclipse.org/tycho/)
-  * [Documentation](http://eclipse.org/tycho/documentation.php)
+  * [Project Homepage](https://www.eclipse.org/tycho/)
+  * [Documentation](https://www.eclipse.org/tycho/sitedocs/)
   * [Bug Tracker](https://bugs.eclipse.org/bugs/buglist.cgi?product=Tycho)
-  * [How to Contribute](http://wiki.eclipse.org/Tycho/Contributor_Guide)
+  * [How to Contribute](https://wiki.eclipse.org/Tycho/Contributor_Guide)
   * [Contact Us](https://dev.eclipse.org/mailman/listinfo/tycho-user)
 
 Building Tycho from sources:
 
     mvn clean install
 
-For more details, see [Developing Tycho](http://wiki.eclipse.org/Developing_Tycho).
+For more details, see [Developing Tycho](https://wiki.eclipse.org/Developing_Tycho).
 
 You can also [set up the Tycho Development Environment using the Eclipse Installer](setup/README.md).


### PR DESCRIPTION
also change some links from http to https.

___

I understand that GH repo is mirror-only but this fix not worth the time to get in gerrit.
So treat it as an issue. 