### PR TITLE
Bug 572420 - Tycho-Surefire should be executable for eclipse-plugin

### DIFF
--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/TestsInBundleTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/TestsInBundleTest.java
@@ -13,10 +13,12 @@
 package org.eclipse.tycho.test.surefire;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.util.Arrays;
 
+import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.junit.Test;
@@ -25,12 +27,9 @@ public class TestsInBundleTest extends AbstractTychoIntegrationTest {
 
     @Test
     public void testCompile() throws Exception {
-
         Verifier verifier = getVerifier("surefire.combinedtests/bundle.test");
-
         verifier.executeGoals(Arrays.asList("clean", "test-compile"));
         verifier.verifyErrorFreeLog();
-
         assertTrue("compiled class file do not exists",
                 new File(verifier.getBasedir(), "target/classes/bundle/test/Counter.class").exists());
         assertTrue("compiled test-class file do not exists",
@@ -44,7 +43,38 @@ public class TestsInBundleTest extends AbstractTychoIntegrationTest {
         verifier.verifyErrorFreeLog();
         assertTrue("tests where not run",
                 new File(verifier.getBasedir(), "target/surefire-reports/bundle.test.AdderTest.txt").exists());
+    }
 
+    @Test
+    public void testPackage() throws Exception {
+        Verifier verifier = getVerifier("surefire.combinedtests/bundle.test");
+        verifier.executeGoals(Arrays.asList("clean", "package"));
+        verifier.verifyErrorFreeLog();
+        assertTrue("test fragment not found",
+                new File(verifier.getBasedir(), "target/bundle.test-1.0.0_fragment.jar").exists());
+    }
+
+    @Test
+    public void testIntegrationTest() throws Exception {
+        Verifier verifier = getVerifier("surefire.combinedtests/bundle.test");
+        verifier.executeGoals(Arrays.asList("clean", "integration-test"));
+        verifier.verifyErrorFreeLog();
+        assertTrue("summary report not found",
+                new File(verifier.getBasedir(), "target/failsafe-reports/failsafe-summary.xml").exists());
+        verifier.verifyTextInLog("Tests run: 2, Failures: 1, Errors: 0, Skipped: 0");
+        verifier.verifyTextInLog("OSGiRunningIT.willFail:30 This fail is intentional");
+    }
+
+    @Test
+    public void testVerify() throws Exception {
+        Verifier verifier = getVerifier("surefire.combinedtests/bundle.test");
+        try {
+            verifier.executeGoals(Arrays.asList("clean", "verify"));
+            fail("the build succeed but test-failures are expected!");
+        } catch (VerificationException e) {
+            //thats good indeed...
+            verifier.verifyTextInLog("There are test failures");
+        }
     }
 
 }

--- a/tycho-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/tycho-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -37,7 +37,12 @@
                 org.eclipse.tycho:tycho-packaging-plugin:${project.version}:package-plugin,
                 org.eclipse.tycho:tycho-p2-plugin:${project.version}:p2-metadata-default
               </package>
-              <integration-test></integration-test>
+              <integration-test>
+               org.eclipse.tycho:tycho-surefire-plugin:${project.version}:integration-test
+              </integration-test>
+              <verify>
+               org.apache.maven.plugins:maven-failsafe-plugin:${surefire-plugin.version}:verify
+              </verify>
               <install>
                 org.apache.maven.plugins:maven-install-plugin:${install-plugin.version}:install,
                 org.eclipse.tycho:tycho-p2-plugin:${project.version}:update-local-index

--- a/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/META-INF/MANIFEST.MF
+++ b/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/META-INF/MANIFEST.MF
@@ -8,7 +8,8 @@ Bundle-ClassPath: .,
  jars/surefire-booter-2.22.2.jar,
  jars/surefire-api-2.22.2.jar,
  jars/surefire-logger-api-2.22.2.jar,
- jars/maven-surefire-common-2.22.2.jar
+ jars/maven-surefire-common-2.22.2.jar,
+ jars/maven-failsafe-plugin-2.22.2.jar
 Bundle-Name: Tycho Surefire OSGi Booter Eclipse Application
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.tycho.surefire.osgibooter;singleton:=true

--- a/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/build.properties
+++ b/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/build.properties
@@ -9,9 +9,10 @@
 #    Sonatype Inc. - initial API and implementation
 ###############################################################################
 bin.includes = plugin.xml,\
-               jars/,\
                .,\
-               META-INF/
+               META-INF/,\
+               jars/,\
+               jars/maven-failsafe-plugin-2.22.2.jar
 jars.compile.order = .
 source.. = src/main/java/,src/main/resources
 output.. = target/classes/

--- a/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/pom.xml
+++ b/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/pom.xml
@@ -72,6 +72,11 @@
 									<artifactId>maven-surefire-common</artifactId>
 									<version>${surefire-version}</version>
 								</artifactItem>
+								<artifactItem>
+									<groupId>org.apache.maven.plugins</groupId>
+									<artifactId>maven-failsafe-plugin</artifactId>
+									<version>${surefire-version}</version>
+								</artifactItem>
 							</artifactItems>
 						</configuration>
 					</execution>

--- a/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/src/main/java/org/eclipse/tycho/surefire/osgibooter/OsgiSurefireBooter.java
+++ b/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/src/main/java/org/eclipse/tycho/surefire/osgibooter/OsgiSurefireBooter.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import org.apache.maven.plugin.failsafe.util.FailsafeSummaryXmlUtils;
 import org.apache.maven.plugin.surefire.StartupReportConfiguration;
 import org.apache.maven.plugin.surefire.log.api.PrintStreamLogger;
 import org.apache.maven.plugin.surefire.report.ConsoleReporter;
@@ -115,6 +116,10 @@ public class OsgiSurefireBooter {
         // to load surefire classes using this classloader
         RunResult result = ProviderFactory.invokeProvider(null, createCombinedClassLoader(testPlugin), reporterFactory,
                 providerConfiguration, false, startupConfiguration, true);
+        String failsafe = testProps.getProperty("failsafe");
+        if (failsafe != null && !failsafe.isBlank()) {
+            FailsafeSummaryXmlUtils.writeSummary(result, new File(failsafe), false);
+        }
         // counter-intuitive, but null indicates OK here
         return result.getFailsafeCode() == null ? 0 : result.getFailsafeCode();
     }
@@ -223,5 +228,11 @@ public class OsgiSurefireBooter {
         protected Enumeration<URL> findResources(String name) throws IOException {
             return bundle.getResources(name);
         }
+
+        @Override
+        public String toString() {
+            return bundle.getSymbolicName() + " [" + bundle.getVersion() + "]";
+        }
     }
+
 }

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TestPluginMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TestPluginMojo.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * Copyright (c) 2008, 2021 Sonatype Inc. and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Sonatype Inc. - initial API and implementation
+ *    SAP SE - port to surefire 2.10
+ *    Mickael Istria (Red Hat Inc.) - 386988 Support for provisioned applications
+ *    Bachmann electrontic GmbH - 510425 parallel mode requires threadCount>1 or useUnlimitedThreads=true
+ *    Christoph Läubrich - improve error message in case of failures
+ ******************************************************************************/
+package org.eclipse.tycho.surefire;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.surefire.booter.PropertiesWrapper;
+import org.eclipse.tycho.PackagingType;
+import org.eclipse.tycho.surefire.provider.spi.TestFrameworkProvider;
+
+/**
+ * <p>
+ * Executes tests in an OSGi runtime.
+ * </p>
+ * <p>
+ * The goal launches an OSGi runtime and executes the project's tests in that runtime. The "test
+ * runtime" consists of the bundle built in this project and its transitive dependencies, plus some
+ * Equinox and test harness bundles. The bundles are resolved from the target platform of the
+ * project. Note that the test runtime does typically <em>not</em> contain the entire target
+ * platform. If there are implicitly required bundles (e.g. <tt>org.apache.felix.scr</tt> to make
+ * declarative services work), they need to be added manually through an <tt>extraRequirements</tt>
+ * configuration on the <tt>target-platform-configuration</tt> plugin.
+ * </p>
+ */
+@Mojo(name = "test", defaultPhase = LifecyclePhase.INTEGRATION_TEST, requiresDependencyResolution = ResolutionScope.RUNTIME, threadSafe = true)
+public class TestPluginMojo extends AbstractTestMojo {
+
+    /**
+     * The directory containing generated test classes of the project being tested.
+     */
+    @Parameter(property = "project.build.outputDirectory")
+    private File testClassesDirectory;
+
+    /**
+     * Base directory where all reports are written to.
+     */
+    @Parameter(defaultValue = "${project.build.directory}/surefire-reports")
+    protected File reportsDirectory;
+
+    /**
+     * If set to "false" the test execution will not fail in case there are no tests found.
+     */
+    @Parameter(property = "failIfNoTests", defaultValue = "true")
+    private boolean failIfNoTests;
+
+    /**
+     * Set this to true to ignore a failure during testing. Its use is NOT RECOMMENDED, but quite
+     * convenient on occasion.
+     */
+    @Parameter(property = "maven.test.failure.ignore", defaultValue = "false")
+    private boolean testFailureIgnore;
+
+    @Override
+    protected boolean shouldRun() {
+        if (PackagingType.TYPE_ECLIPSE_PLUGIN.equals(project.getPackaging())) {
+            return false;
+        }
+        if (!PackagingType.TYPE_ECLIPSE_TEST_PLUGIN.equals(project.getPackaging())) {
+            getLog().warn("Unsupported packaging type " + project.getPackaging());
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    protected List<String> getDefaultInclude() {
+        return Arrays.asList("**/Test*.class", "**/*Test.class", "**/*Tests.class", "**/*TestCase.class");
+    }
+
+    @Override
+    protected File getTestClassesDirectory() {
+        return testClassesDirectory;
+    }
+
+    @Override
+    protected File getReportsDirectory() {
+        return reportsDirectory;
+    }
+
+    @Override
+    protected PropertiesWrapper createSurefireProperties(TestFrameworkProvider provider) throws MojoExecutionException {
+
+        PropertiesWrapper properties = super.createSurefireProperties(provider);
+        properties.setProperty("failifnotests", String.valueOf(failIfNoTests));
+        return properties;
+    }
+
+    @Override
+    protected void handleNoTestsFound() throws MojoFailureException {
+        String message = "No tests found.";
+        if (failIfNoTests) {
+            throw new MojoFailureException(message);
+        } else {
+            getLog().warn(message);
+        }
+
+    }
+
+    @Override
+    protected void handleSuccess() {
+        getLog().info("All tests passed!");
+    }
+
+    @Override
+    protected void handleTestFailures() throws MojoFailureException {
+        String errorMessage = "There are test failures.\n\nPlease refer to " + reportsDirectory
+                + " for the individual test results.";
+        if (testFailureIgnore) {
+            getLog().error(errorMessage);
+        } else {
+            throw new MojoFailureException(errorMessage);
+        }
+
+    }
+
+}

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TychoIntegrationTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TychoIntegrationTestMojo.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Sonatype Inc. and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ ******************************************************************************/
+package org.eclipse.tycho.surefire;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.surefire.booter.PropertiesWrapper;
+import org.eclipse.tycho.PackagingType;
+import org.eclipse.tycho.surefire.provider.spi.TestFrameworkProvider;
+
+/**
+ * <p>
+ * Executes integration-tests in an OSGi runtime.
+ * </p>
+ * <p>
+ * The goal launches an OSGi runtime and executes the project's integration-tests (default patterns
+ * are <code>PluginTest*.class, *IT.class</code>) in that runtime. The "test runtime" consists of
+ * the bundle built in this project and its transitive dependencies, plus some Equinox and test
+ * harness bundles. The bundles are resolved from the target platform of the project. Note that the
+ * test runtime does typically <em>not</em> contain the entire target platform. If there are
+ * implicitly required bundles (e.g. <tt>org.apache.felix.scr</tt> to make declarative services
+ * work), they need to be added manually through an <tt>extraRequirements</tt> configuration on the
+ * <tt>target-platform-configuration</tt> plugin.
+ * </p>
+ * <p>
+ * This goal adopts the maven-failsafe paradigm, that works in the following way:
+ * <ol>
+ * <li><code>pre-integration-test</code> phase could be used to prepare any prerequisite (e.g.
+ * starting web-server, files, ...)</li>
+ * <li><code>integration-test</code> phase does not fail the build if there are test failures but a
+ * summary file is written</li>
+ * <li><code>post-integration-test</code> could be used to cleanup/tear down any resources from the
+ * <code>pre-integration-test</code> phase
+ * <li>test outcome is checked in the <code>verify</code> phase that might fail the build if there
+ * are test failures
+ * </ol>
+ * </p>
+ * summary files are generated according to the default maven-surefire-plugin for integration with
+ * tools that already work with maven-surefire-plugin (e.g. CI servers)
+ */
+@Mojo(name = "integration-test", defaultPhase = LifecyclePhase.INTEGRATION_TEST, requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
+public class TychoIntegrationTestMojo extends AbstractTestMojo {
+
+    /**
+     * The directory containing generated test classes of the project being tested.
+     */
+    @Parameter(property = "project.build.testOutputDirectory")
+    private File testClassesDirectory;
+
+    @Parameter(property = "skipITs")
+    private boolean skipITs;
+
+    @Parameter(defaultValue = "${project.build.directory}/failsafe-reports/failsafe-summary.xml", required = true)
+    private File summaryFile;
+
+    @Parameter(defaultValue = "${project.build.directory}/failsafe-reports", required = true)
+    private File reportDirectory;
+
+    @Override
+    protected boolean shouldRun() {
+        return PackagingType.TYPE_ECLIPSE_PLUGIN.equals(project.getPackaging()) && scanForTests().size() > 0;
+    }
+
+    @Override
+    protected List<String> getDefaultInclude() {
+        return Arrays.asList("**/PluginTest*.class", "**/*IT.class");
+    }
+
+    @Override
+    protected File getTestClassesDirectory() {
+        return testClassesDirectory;
+    }
+
+    @Override
+    protected File getReportsDirectory() {
+        return reportDirectory;
+    }
+
+    @Override
+    protected boolean shouldSkip() {
+        return skipITs || super.shouldSkip();
+    }
+
+    @Override
+    protected PropertiesWrapper createSurefireProperties(TestFrameworkProvider provider) throws MojoExecutionException {
+
+        PropertiesWrapper properties = super.createSurefireProperties(provider);
+        properties.setProperty("failifnotests", String.valueOf(false));
+        properties.setProperty("failsafe", summaryFile.getAbsolutePath());
+        return properties;
+    }
+
+    @Override
+    protected void handleNoTestsFound() throws MojoFailureException {
+        getLog().info("No tests found");
+    }
+
+    @Override
+    protected void handleSuccess() {
+        //nothing to do will be handled in verify phase
+    }
+
+    @Override
+    protected void handleTestFailures() throws MojoFailureException {
+        //nothing to do will be handled in verify phase
+    }
+}

--- a/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/TestMojoTest.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/TestMojoTest.java
@@ -41,7 +41,7 @@ public class TestMojoTest {
 
     @Test
     public void testSplitArgLineNull() throws Exception {
-        TestMojo testMojo = new TestMojo();
+        AbstractTestMojo testMojo = new TestPluginMojo();
         String[] parts = testMojo.splitArgLine(null);
         assertNotNull(parts);
         assertEquals(0, parts.length);
@@ -49,7 +49,7 @@ public class TestMojoTest {
 
     @Test
     public void testSplitArgLineMultipleArgs() throws Exception {
-        TestMojo testMojo = new TestMojo();
+        AbstractTestMojo testMojo = new TestPluginMojo();
         String[] parts = testMojo.splitArgLine(" -Dfoo=bar -Dkey2=value2 \"-Dkey3=spacy value\"");
         assertEquals(3, parts.length);
         assertEquals("-Dfoo=bar", parts[0]);
@@ -59,7 +59,7 @@ public class TestMojoTest {
 
     @Test
     public void testSplitArgLineUnbalancedQuotes() throws Exception {
-        TestMojo testMojo = new TestMojo();
+        AbstractTestMojo testMojo = new TestPluginMojo();
         try {
             testMojo.splitArgLine("\"'missing closing double-quote'");
             fail("unreachable code");
@@ -71,7 +71,7 @@ public class TestMojoTest {
     @Test
     public void testAddProgramArgsWithSpaces() throws Exception {
         EquinoxLaunchConfiguration cli = createEquinoxConfiguration();
-        TestMojo testMojo = new TestMojo();
+        AbstractTestMojo testMojo = new TestPluginMojo();
         testMojo.addProgramArgs(cli, "-data", "/path with spaces ");
         assertEquals(2, cli.getProgramArguments().length);
         assertEquals("-data", cli.getProgramArguments()[0]);
@@ -81,7 +81,7 @@ public class TestMojoTest {
     @Test
     public void testAddProgramArgsNullArg() throws Exception {
         EquinoxLaunchConfiguration cli = createEquinoxConfiguration();
-        TestMojo testMojo = new TestMojo();
+        AbstractTestMojo testMojo = new TestPluginMojo();
         // null arg must be ignored
         testMojo.addProgramArgs(cli, "-data", null);
         assertEquals(1, cli.getProgramArguments().length);
@@ -89,27 +89,27 @@ public class TestMojoTest {
 
     @Test
     public void testShouldSkipWithNoValueSet() {
-        TestMojo testMojo = new TestMojo();
+        AbstractTestMojo testMojo = new TestPluginMojo();
         assertFalse(testMojo.shouldSkip());
     }
 
     @Test
     public void testShouldSkipWithSkipTestsSetToTrue() throws Exception {
-        TestMojo testMojo = new TestMojo();
+        AbstractTestMojo testMojo = new TestPluginMojo();
         setParameter(testMojo, "skipTests", Boolean.TRUE);
         assertTrue(testMojo.shouldSkip());
     }
 
     @Test
     public void testShouldSkipWithMavenTestSkipSetToTrue() throws Exception {
-        TestMojo testMojo = new TestMojo();
+        AbstractTestMojo testMojo = new TestPluginMojo();
         setParameter(testMojo, "skip", Boolean.TRUE);
         assertTrue(testMojo.shouldSkip());
     }
 
     @Test
     public void testShouldSkipThatSkipTestsWillBePrefered() throws Exception {
-        TestMojo testMojo = new TestMojo();
+        AbstractTestMojo testMojo = new TestPluginMojo();
         setParameter(testMojo, "skip", Boolean.FALSE);
         setParameter(testMojo, "skipTests", Boolean.TRUE);
         assertTrue(testMojo.shouldSkip());
@@ -117,7 +117,7 @@ public class TestMojoTest {
 
     @Test
     public void testShouldSkipWithSkipExeSetToTrue() throws Exception {
-        TestMojo testMojo = new TestMojo();
+        AbstractTestMojo testMojo = new TestPluginMojo();
         setParameter(testMojo, "skipExec", Boolean.TRUE);
         assertTrue(testMojo.shouldSkip());
     }
@@ -145,7 +145,7 @@ public class TestMojoTest {
 
     @Test
     public void testParallelModeMissingThreadCountParameter() throws Exception {
-        TestMojo testMojo = new TestMojo();
+        AbstractTestMojo testMojo = new TestPluginMojo();
         setParameter(testMojo, "parallel", ParallelMode.both);
         try {
             testMojo.getMergedProviderProperties();
@@ -157,7 +157,7 @@ public class TestMojoTest {
 
     @Test
     public void testParallelModeThreadCountSetTo1() throws Exception {
-        TestMojo testMojo = new TestMojo();
+        AbstractTestMojo testMojo = new TestPluginMojo();
         setParameter(testMojo, "parallel", ParallelMode.both);
         setParameter(testMojo, "threadCount", 1);
         try {
@@ -170,7 +170,7 @@ public class TestMojoTest {
 
     @Test
     public void testParallelModeWithThreadCountSet() throws Exception {
-        TestMojo testMojo = new TestMojo();
+        AbstractTestMojo testMojo = new TestPluginMojo();
         setParameter(testMojo, "parallel", ParallelMode.both);
         setParameter(testMojo, "threadCount", 2);
         Properties providerProperties = testMojo.getMergedProviderProperties();
@@ -180,7 +180,7 @@ public class TestMojoTest {
 
     @Test
     public void testParallelModeWithUseUnlimitedThreads() throws Exception {
-        TestMojo testMojo = new TestMojo();
+        AbstractTestMojo testMojo = new TestPluginMojo();
         setParameter(testMojo, "parallel", ParallelMode.both);
         setParameter(testMojo, "useUnlimitedThreads", Boolean.TRUE);
         Properties providerProperties = testMojo.getMergedProviderProperties();
@@ -190,7 +190,7 @@ public class TestMojoTest {
 
     @Test(expected = MojoExecutionException.class)
     public void testParallelModeWithPerCoreThreadCountMissingCount() throws Exception {
-        TestMojo testMojo = new TestMojo();
+        AbstractTestMojo testMojo = new TestPluginMojo();
         setParameter(testMojo, "parallel", ParallelMode.both);
         setParameter(testMojo, "perCoreThreadCount", true);
         testMojo.getMergedProviderProperties();
@@ -198,7 +198,7 @@ public class TestMojoTest {
 
     @Test
     public void testParallelModeWithPerCoreThreadCount() throws Exception {
-        TestMojo testMojo = new TestMojo();
+        AbstractTestMojo testMojo = new TestPluginMojo();
         setParameter(testMojo, "parallel", ParallelMode.both);
         setParameter(testMojo, "perCoreThreadCount", true);
         setParameter(testMojo, "threadCount", 1);
@@ -211,7 +211,7 @@ public class TestMojoTest {
     public ScanResult createDirectoryAndScanForTests(List<String> includes, List<String> excludes) throws Exception {
         File directory = null;
         try {
-            TestMojo testMojo = new TestMojo();
+            AbstractTestMojo testMojo = new TestPluginMojo();
             directory = Files.createTempDirectory(this.getClass().getName()).toFile();
             File aTestFile = new File(directory, "ATest.class");
             aTestFile.createNewFile();

--- a/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/TestMojoToolchainTests.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/TestMojoToolchainTests.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 public class TestMojoToolchainTests {
 
     private ToolchainManager toolchainManager;
-    private TestMojo testMojo;
+    private AbstractTestMojo testMojo;
     private MavenSession session;
     private MavenProject project;
     private DefaultJavaToolChain breeToolchain;
@@ -53,7 +53,7 @@ public class TestMojoToolchainTests {
         systemToolchain = mock(Toolchain.class);
         toolchainProvider = mock(ToolchainProvider.class);
         project = new MavenProject();
-        testMojo = new TestMojo();
+        testMojo = new TestPluginMojo();
         setParameter(testMojo, "useJDK", JDKUsage.SYSTEM);
         setParameter(testMojo, "toolchainManager", toolchainManager);
         setParameter(testMojo, "toolchainProvider", toolchainProvider);
@@ -99,7 +99,8 @@ public class TestMojoToolchainTests {
         setParameter(testMojo, "useJDK", JDKUsage.BREE);
         ExecutionEnvironmentConfiguration envConf = mock(ExecutionEnvironmentConfiguration.class);
         when(envConf.getProfileName()).thenReturn("myId");
-        DefaultReactorProject.adapt(project).setContextValue(TychoConstants.CTX_EXECUTION_ENVIRONMENT_CONFIGURATION, envConf);
+        DefaultReactorProject.adapt(project).setContextValue(TychoConstants.CTX_EXECUTION_ENVIRONMENT_CONFIGURATION,
+                envConf);
     }
 
     private void setParameter(Object object, String variable, Object value)


### PR DESCRIPTION
package type

- refactor test-mojo for extensibility
- add integration-test and verify-phase
- write summary file from OSGi booter
- enhance integration test
- rename TestMojo -> AbstractTestMojo

Change-Id: Id83fcb19cecf7c0c93efa6b17883c8fad85b9d13
Signed-off-by: Christoph Läubrich <laeubi@laeubi-soft.de>