### PR TITLE
[Setup] use m2e-latest repository

### DIFF
--- a/setup/Tycho.setup
+++ b/setup/Tycho.setup
@@ -101,7 +101,7 @@
     <repository
         url="http://ianbrandt.github.io/m2e-maven-dependency-plugin/"/>
     <repository
-        url="https://download.eclipse.org/technology/m2e/releases/"/>
+        url="https://download.eclipse.org/technology/m2e/releases/latest/"/>
     <description>P2 Update Sites for the m2e connectors</description>
   </setupTask>
   <setupTask


### PR DESCRIPTION
The composite repository at https://download.eclipse.org/technology/m2e/releases is not actively maintained and only includes releases up to m2e 1.15.

This PR changes Tycho's Oomph-setup to always use the m2e-latest repository when installing p2-requirements.
