### PR TITLE
Revert caching of ModuleWiring wires (Bug 572427'/#47)

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
@@ -104,6 +104,9 @@ public class OsgiBundleProject extends AbstractTychoProject implements BundlePro
     private EquinoxResolver resolver;
 
     @Requirement
+    private DependencyComputer dependencyComputer;
+
+    @Requirement
     private Logger logger;
 
     @Requirement
@@ -210,7 +213,6 @@ public class OsgiBundleProject extends AbstractTychoProject implements BundlePro
         // dependencies
         List<AccessRule> strictBootClasspathAccessRules = new ArrayList<>();
         strictBootClasspathAccessRules.add(new DefaultAccessRule("java/**", false));
-        DependencyComputer dependencyComputer = new DependencyComputer(state);
         List<DependencyEntry> dependencies = dependencyComputer.computeDependencies(bundleDescription);
         for (DependencyEntry entry : dependencies) {
             if (Constants.SYSTEM_BUNDLE_ID == entry.module.getRevisions().getModule().getId()) {

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/test/DependencyComputerTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/test/DependencyComputerTest.java
@@ -53,12 +53,20 @@ import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
 
 public class DependencyComputerTest extends AbstractTychoMojoTestCase {
+    private DependencyComputer dependencyComputer;
     private EquinoxResolver resolver;
 
     @Override
     protected void setUp() throws Exception {
         super.setUp();
+        dependencyComputer = lookup(DependencyComputer.class);
         resolver = lookup(EquinoxResolver.class);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        dependencyComputer = null;
+        super.tearDown();
     }
 
     @Test
@@ -77,7 +85,6 @@ public class DependencyComputerTest extends AbstractTychoMojoTestCase {
         ModuleContainer state = resolver.newResolvedState(reactorProject, null, executionEnvironment, platform);
         ModuleRevision bundle = state.getModule(project.getBasedir().getAbsolutePath()).getCurrentRevision();
 
-        DependencyComputer dependencyComputer = new DependencyComputer(state);
         List<DependencyEntry> dependencies = dependencyComputer.computeDependencies(bundle);
         Assert.assertEquals(3, dependencies.size());
         Assert.assertEquals("dep", dependencies.get(0).module.getSymbolicName());
@@ -119,7 +126,6 @@ public class DependencyComputerTest extends AbstractTychoMojoTestCase {
         ModuleContainer state = resolver.newResolvedState(reactorProject, null, customProfile, platform);
         ModuleRevision bundle = state.getModule(project.getBasedir().getAbsolutePath()).getCurrentRevision();
 
-        DependencyComputer dependencyComputer = new DependencyComputer(state);
         List<DependencyEntry> dependencies = dependencyComputer.computeDependencies(bundle);
 
         if (dependencies.size() > 0) {
@@ -159,7 +165,6 @@ public class DependencyComputerTest extends AbstractTychoMojoTestCase {
         ModuleContainer state = resolver.newResolvedState(DefaultReactorProject.adapt(project), null,
                 ExecutionEnvironmentUtils.getExecutionEnvironment("J2SE-1.4", null, null, new SilentLog()), platform);
         ModuleRevision bundle = state.getModule(project.getBasedir().getAbsolutePath()).getCurrentRevision();
-        DependencyComputer dependencyComputer = new DependencyComputer(state);
         return dependencyComputer.computeDependencies(bundle);
     }
 
@@ -168,7 +173,6 @@ public class DependencyComputerTest extends AbstractTychoMojoTestCase {
                 .getContextValue(TychoConstants.CTX_DEPENDENCY_ARTIFACTS);
         ModuleContainer state = resolver.newResolvedState(DefaultReactorProject.adapt(project), null, null, platform);
         ModuleRevision bundle = state.getModule(project.getBasedir().getAbsolutePath()).getCurrentRevision();
-        DependencyComputer dependencyComputer = new DependencyComputer(state);
         return dependencyComputer.computeDependencies(bundle);
     }
 

--- a/tycho-pomgenerator-plugin/src/main/java/org/eclipse/tycho/pomgenerator/GeneratePomsMojo.java
+++ b/tycho-pomgenerator-plugin/src/main/java/org/eclipse/tycho/pomgenerator/GeneratePomsMojo.java
@@ -193,6 +193,9 @@ public class GeneratePomsMojo extends AbstractMojo {
     @Component(role = EquinoxResolver.class)
     private EquinoxResolver resolver;
 
+    @Component(role = DependencyComputer.class)
+    private DependencyComputer dependencyComputer;
+
     MavenXpp3Reader modelReader = new MavenXpp3Reader();
     MavenXpp3Writer modelWriter = new MavenXpp3Writer();
 
@@ -634,7 +637,6 @@ public class GeneratePomsMojo extends AbstractMojo {
                 ModuleContainer state = resolver.newResolvedState(basedir, session, ee, platform);
                 ModuleRevision bundle = state.getModule(basedir.getAbsolutePath()).getCurrentRevision();
                 if (bundle != null) {
-                    DependencyComputer dependencyComputer = new DependencyComputer(state);
                     for (DependencyComputer.DependencyEntry entry : dependencyComputer.computeDependencies(bundle)) {
                         ModuleRevision supplier = entry.module;
                         File suppliedDir = (File) supplier.getRevisionInfo();


### PR DESCRIPTION
This PR reverts the caching introduced to resolve [Bug 572427](https://bugs.eclipse.org/bugs/show_bug.cgi?id=572427)'/#47, except for the removal of the `BundleReader` and the addition of some doc.

Caching the Wires of a Wirings in the DependencyComputer is not necessary anymore since [Equinox-Framework Bug 572605](https://bugs.eclipse.org/bugs/show_bug.cgi?id=572605) is resolved and improved the internal storage layout of ModuleWiring-objects, which now effectively store/cache their wires per namespace. This fix was published with `org.eclipse.osgi-3.16.300`.

I've verified the runtime of the initial dependency resolution of my Maven/Tycho build and the runtime is exactly same to the second with and without caching:
```
From Scanning for projects to to long line before the reactor summary
Tycho 2.2.0 - 25sec (from which 7sec are Scanning for projects)
Tycho 2.3.0 - 147sec (from which 7sec are Scanning for projects)
Tycho 2.4.0-SNAPSHOT - 48sec (from which 7sec are Scanning for projects)
```
The following arguments were used to display a timestamp next to each printed line from which the runtime was derived:
`-Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss`