### PR TITLE
Skip Tycho dependency-resolution for clean-only builds by default (#166)

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
@@ -236,13 +236,9 @@ public class TychoMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
 
     private boolean disableLifecycleParticipation(MavenSession session) {
         // command line property to disable Tycho lifecycle participant
-        if ("maven".equals(session.getUserProperties().get("tycho.mode"))) {
-            return true;
-        }
-        if (session.getUserProperties().containsKey("m2e.version")) {
-            return true;
-        }
-        return false;
+        return "maven".equals(session.getUserProperties().get("tycho.mode"))
+                || session.getUserProperties().containsKey("m2e.version")
+                || session.getGoals().equals(List.of("clean")); // disable for clean-only session
     }
 
     private void configureComponents(MavenSession session) {


### PR DESCRIPTION
This PR intends to solve issue #166 by skipping Tycho's dependency resolution by default for builds whose only goal is `clean`.

@mickaelistria do you know if there is any Constant for the `"clean"` goal String?