### PR TITLE
Fix #170 - AllKnownEEsResolutionHints is missing equals/hashcode causing target resolution for every project

### DIFF
--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/target/ee/AllKnownEEsResolutionHints.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/target/ee/AllKnownEEsResolutionHints.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.metadata.IRequirement;
@@ -60,6 +61,23 @@ public class AllKnownEEsResolutionHints implements ExecutionEnvironmentResolutio
     @Override
     public Collection<IInstallableUnit> getTemporaryAdditions() {
         return temporaryUnits.values();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(temporaryUnits);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        AllKnownEEsResolutionHints other = (AllKnownEEsResolutionHints) obj;
+        return Objects.equals(temporaryUnits, other.temporaryUnits);
     }
 
 }


### PR DESCRIPTION


Signed-off-by: Christoph Läubrich <laeubi@laeubi-soft.de>