### PR TITLE
#166: consider all clean-lifecylce phases and add release-notes entry

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -86,6 +86,11 @@ Tycho now understands the `additional.bundles` directive in the `build.propertie
 
 A new mojo [tycho-p2-repository-plugin:assemble-maven-repository](https://www.eclipse.org/tycho/sitedocs/tycho-p2-repository-plugin/assemble-maven-repository.html) was added to enable creation of p2 repositories directly from Maven artifact references. This removes the usual need to create a target definition and a category.xml for this task.
 
+### [Skip Tycho dependency-resolution for clean-only builds by default](https://github.com/eclipse/tycho/issues/166)
+
+To speed up Maven `clean`-only builds, Tycho's dependency resolution is now skipped, if the only phase specified is one from the clean lifecycle, namely `clean`,`pre-clean`,`post-clean`.
+Previously one had to specify the property `-Dtycho.mode=maven` to skip dependency resolution.
+
 ## 2.3.0
 
 ### Official Equinox Resolver used for dependency resolution (stricter and can produce errors for split packages)

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
@@ -234,11 +234,13 @@ public class TychoMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
         }
     }
 
+    private static final Set<String> CLEAN_PHASES = Set.of("pre-clean", "clean", "post-clean");
+
     private boolean disableLifecycleParticipation(MavenSession session) {
         // command line property to disable Tycho lifecycle participant
         return "maven".equals(session.getUserProperties().get("tycho.mode"))
                 || session.getUserProperties().containsKey("m2e.version")
-                || session.getGoals().equals(List.of("clean")); // disable for clean-only session
+                || (session.getGoals().size() == 1 && CLEAN_PHASES.contains(session.getGoals().get(0))); // disable for clean-only session
     }
 
     private void configureComponents(MavenSession session) {

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
@@ -240,7 +240,7 @@ public class TychoMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
         // command line property to disable Tycho lifecycle participant
         return "maven".equals(session.getUserProperties().get("tycho.mode"))
                 || session.getUserProperties().containsKey("m2e.version")
-                || (session.getGoals().size() == 1 && CLEAN_PHASES.contains(session.getGoals().get(0))); // disable for clean-only session
+                || CLEAN_PHASES.containsAll(session.getGoals());
     }
 
     private void configureComponents(MavenSession session) {


### PR DESCRIPTION
This PR adds an release-notes entry for issue #166 and extends the first solution for that issue by additionally considering the other two phases of the clean life-cycle.

What makes me wonder is that maven usually talks about phases when referring to the different 'steps' of a lifecycle.
But the session (and its request) only provides a List of goals. Are specified phases considered as goals in Maven?
The content of the goals list seems to be as expected when I attached a debugger and I did not find the word 'phase' in the `MavenSession` or `MavenExecutionRequest` class.
