### PR TITLE
itest demonstrate regression from 2.2 -> 2.3 as of #169

### DIFF
--- a/tycho-its/projects/resolver.differentVersions/bundle1/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/resolver.differentVersions/bundle1/META-INF/MANIFEST.MF
@@ -1,0 +1,11 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Bundle1
+Bundle-SymbolicName: version.bundle1
+Bundle-Version: 1.0.0
+Require-Bundle: org.apache.batik.svggen;bundle-version="1.7.0",
+ org.apache.batik.dom;bundle-version="1.7.0",
+ org.apache.batik.ext.awt;bundle-version="1.7.0"
+Bundle-ActivationPolicy: lazy
+Import-Package: org.osgi.framework;version="1.10.0"
+

--- a/tycho-its/projects/resolver.differentVersions/bundle1/build.properties
+++ b/tycho-its/projects/resolver.differentVersions/bundle1/build.properties
@@ -1,0 +1,4 @@
+jars.compile.order = .
+source.. = src/
+output.. = target/classes
+bin.includes = META-INF/, .

--- a/tycho-its/projects/resolver.differentVersions/bundle1/pom.xml
+++ b/tycho-its/projects/resolver.differentVersions/bundle1/pom.xml
@@ -1,0 +1,17 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.tycho.its.resolver.versions</groupId>
+		<artifactId>versions-parent</artifactId>
+		<version>1.0.0</version>
+	</parent>
+
+
+	<artifactId>version.bundle1</artifactId>
+
+	<packaging>eclipse-plugin</packaging>
+
+</project>

--- a/tycho-its/projects/resolver.differentVersions/bundle1/src/test/Activator.java
+++ b/tycho-its/projects/resolver.differentVersions/bundle1/src/test/Activator.java
@@ -1,0 +1,24 @@
+package test;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+
+public class Activator
+    implements BundleActivator
+{
+
+    public static BundleContext context;
+
+    public void start( BundleContext context )
+        throws Exception
+    {
+        Activator.context = context;
+    }
+
+    public void stop( BundleContext context )
+        throws Exception
+    {
+        Activator.context = null;
+    }
+
+}

--- a/tycho-its/projects/resolver.differentVersions/feature.new.batik/build.properties
+++ b/tycho-its/projects/resolver.differentVersions/feature.new.batik/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/tycho-its/projects/resolver.differentVersions/feature.new.batik/feature.xml
+++ b/tycho-its/projects/resolver.differentVersions/feature.new.batik/feature.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="feature.new.batik"
+      label="Batik New"
+      version="1.0.0">
+
+   <description url="http://www.example.com/description">
+      [Enter Feature Description here.]
+   </description>
+
+   <copyright url="http://www.example.com/copyright">
+      [Enter Copyright Description here.]
+   </copyright>
+
+   <license url="http://www.example.com/license">
+      [Enter License Description here.]
+   </license>
+   
+    <plugin
+         id="org.apache.batik.anim"
+         download-size="0"
+         install-size="0"
+         version="1.14.0.v20210324-0332"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.batik.bridge"
+         download-size="0"
+         install-size="0"
+         version="1.14.0.v20210324-0332"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.batik.css"
+         download-size="0"
+         install-size="0"
+         version="1.14.0.v20210324-0332"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.batik.gvt"
+         download-size="0"
+         install-size="0"
+         version="1.14.0.v20210324-0332"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.batik.util"
+         download-size="0"
+         install-size="0"
+         version="1.14.0.v20210324-0332"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.batik.transcoder"
+         download-size="0"
+         install-size="0"
+         version="1.14.0.v20210324-0332"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.batik.dom"
+         download-size="0"
+         install-size="0"
+         version="1.14.0.v20210324-0332"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.batik.dom.svg"
+         download-size="0"
+         install-size="0"
+         version="1.14.0.v20210324-0332"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.batik.ext"
+         download-size="0"
+         install-size="0"
+         version="1.14.0.v20210324-0332"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.batik.xml"
+         download-size="0"
+         install-size="0"
+         version="1.14.0.v20210324-0332"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.batik.parser"
+         download-size="0"
+         install-size="0"
+         version="1.14.0.v20210324-0332"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.batik.script"
+         download-size="0"
+         install-size="0"
+         version="1.14.0.v20210324-0332"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.batik.i18n"
+         download-size="0"
+         install-size="0"
+         version="1.14.0.v20210324-0332"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.batik.constants"
+         download-size="0"
+         install-size="0"
+         version="1.14.0.v20210324-0332"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.batik.awt.util"
+         download-size="0"
+         install-size="0"
+         version="1.14.0.v20210324-0332"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.batik.svggen"
+         download-size="0"
+         install-size="0"
+         version="1.14.0.v20210324-0332"
+         unpack="false"/>
+
+</feature>

--- a/tycho-its/projects/resolver.differentVersions/feature.new.batik/pom.xml
+++ b/tycho-its/projects/resolver.differentVersions/feature.new.batik/pom.xml
@@ -1,0 +1,17 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.tycho.its.resolver.versions</groupId>
+		<artifactId>versions-parent</artifactId>
+		<version>1.0.0</version>
+	</parent>
+
+
+	<artifactId>feature.new.batik</artifactId>
+
+	<packaging>eclipse-feature</packaging>
+
+</project>

--- a/tycho-its/projects/resolver.differentVersions/feature.old.batik/build.properties
+++ b/tycho-its/projects/resolver.differentVersions/feature.old.batik/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/tycho-its/projects/resolver.differentVersions/feature.old.batik/feature.xml
+++ b/tycho-its/projects/resolver.differentVersions/feature.old.batik/feature.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="feature.old.batik"
+      label="Batik Old"
+      version="1.0.0">
+
+   <description url="http://www.example.com/description">
+      [Enter Feature Description here.]
+   </description>
+
+   <copyright url="http://www.example.com/copyright">
+      [Enter Copyright Description here.]
+   </copyright>
+
+   <license url="http://www.example.com/license">
+      [Enter License Description here.]
+   </license>
+
+   <plugin
+         id="org.apache.batik.svggen"
+         download-size="0"
+         install-size="0"
+         version="1.9.1.v20190730-1743"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.batik.ext.awt"
+         download-size="0"
+         install-size="0"
+         version="1.9.1.v20190730-1743"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.batik.dom"
+         download-size="0"
+         install-size="0"
+         version="1.9.1.v20190730-1743"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.batik.util"
+         download-size="0"
+         install-size="0"
+         version="1.9.1.v20180703-1553"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.batik.constants"
+         download-size="0"
+         install-size="0"
+         version="1.9.1.v20180227-1645"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.batik.css"
+         download-size="0"
+         install-size="0"
+         version="1.9.1.v20181015-1528"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.batik.i18n"
+         download-size="0"
+         install-size="0"
+         version="1.9.1.v20180227-1645"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.batik.xml"
+         download-size="0"
+         install-size="0"
+         version="1.9.1.v20190730-1743"
+         unpack="false"/>
+
+</feature>

--- a/tycho-its/projects/resolver.differentVersions/feature.old.batik/pom.xml
+++ b/tycho-its/projects/resolver.differentVersions/feature.old.batik/pom.xml
@@ -1,0 +1,17 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.tycho.its.resolver.versions</groupId>
+		<artifactId>versions-parent</artifactId>
+		<version>1.0.0</version>
+	</parent>
+
+
+	<artifactId>feature.old.batik</artifactId>
+
+	<packaging>eclipse-feature</packaging>
+
+</project>

--- a/tycho-its/projects/resolver.differentVersions/pom.xml
+++ b/tycho-its/projects/resolver.differentVersions/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.eclipse.tycho.its.resolver.versions</groupId>
+	<artifactId>versions-parent</artifactId>
+	<version>1.0.0</version>
+	<packaging>pom</packaging>
+
+	<properties> 
+		<tycho-version>2.4.0-SNAPSHOT</tycho-version>
+		<platform-url>https://download.eclipse.org/releases/2021-03/</platform-url>
+		<orbit-url>https://download.eclipse.org/tools/orbit/downloads/2021-06/</orbit-url>
+	</properties>
+
+	<modules>
+		<module>bundle1</module>
+<!-- 		<module>bundle2</module> -->
+	</modules>
+
+	<repositories>
+		<repository>
+			<id>platform</id>
+			<layout>p2</layout>
+			<url>${platform-url}</url>
+		</repository>
+		<repository>
+			<id>orbit</id>
+			<layout>p2</layout>
+			<url>${orbit-url}</url>
+		</repository>
+	</repositories>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<environments>
+						<environment>
+							<os>linux</os>
+							<ws>gtk</ws>
+							<arch>x86</arch>
+						</environment>
+					</environments>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/tycho-its/projects/resolver.differentVersions/pom.xml
+++ b/tycho-its/projects/resolver.differentVersions/pom.xml
@@ -9,7 +9,7 @@
 	<version>1.0.0</version>
 	<packaging>pom</packaging>
 
-	<properties> 
+	<properties>
 		<tycho-version>2.4.0-SNAPSHOT</tycho-version>
 		<platform-url>https://download.eclipse.org/releases/2021-03/</platform-url>
 		<orbit-url>https://download.eclipse.org/tools/orbit/downloads/2021-06/</orbit-url>
@@ -17,7 +17,9 @@
 
 	<modules>
 		<module>bundle1</module>
-<!-- 		<module>bundle2</module> -->
+		<!-- <module>bundle2</module> -->
+		<module>feature.new.batik</module>
+		<module>feature.old.batik</module>
 	</modules>
 
 	<repositories>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/DifferentVersionsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/DifferentVersionsTest.java
@@ -1,0 +1,15 @@
+package org.eclipse.tycho.test.resolver;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.Test;
+
+public class DifferentVersionsTest extends AbstractTychoIntegrationTest {
+
+    @Test
+    public void testBundleNativeCode() throws Exception {
+        Verifier verifier = getVerifier("resolver.differentVersions");
+        verifier.executeGoal("compile");
+        verifier.verifyErrorFreeLog();
+    }
+}


### PR DESCRIPTION
This demonstrate the issue #169 with a trivial use-case, just a single bundle with a plain requirement to an older version of a library and a newer one in the target.

Build with `mvn clean verify -Dtycho-version=2.2.0` succeeds while build with `mvn clean verify -Dtycho-version=2.3.0` fails with

```
[ERROR] Internal error: java.lang.RuntimeException: org.osgi.framework.BundleException: Bundle version.bundle1 cannot be resolved:version.bundle1 [21]
[ERROR]   Bundle was not resolved because of a uses constraint violation.
[ERROR]   org.apache.felix.resolver.reason.ReasonException: Uses constraint violation. Unable to resolve resource version.bundle1 [osgi.identity; osgi.identity="version.bundle1"; type="osgi.bundle"; version:Version="1.0.0"] because it is exposed to package 'org.apache.batik.ext.awt.g2d' from resources org.apache.batik.ext.awt [osgi.identity; osgi.identity="org.apache.batik.ext.awt"; type="osgi.bundle"; version:Version="1.9.1.v20190730-1743"] and org.apache.batik.awt.util [osgi.identity; osgi.identity="org.apache.batik.awt.util"; type="osgi.bundle"; version:Version="1.14.0.v20210324-0332"] via two dependency chains.
[ERROR] 
[ERROR] Chain 1:
[ERROR]   version.bundle1 [osgi.identity; osgi.identity="version.bundle1"; type="osgi.bundle"; version:Version="1.0.0"]
[ERROR]     require: (&(osgi.wiring.bundle=org.apache.batik.ext.awt)(bundle-version>=1.7.0))
[ERROR]      |
[ERROR]     provide: osgi.wiring.bundle: org.apache.batik.ext.awt
[ERROR]   org.apache.batik.ext.awt [osgi.identity; osgi.identity="org.apache.batik.ext.awt"; type="osgi.bundle"; version:Version="1.9.1.v20190730-1743"]
[ERROR] 
[ERROR] Chain 2:
[ERROR]   version.bundle1 [osgi.identity; osgi.identity="version.bundle1"; type="osgi.bundle"; version:Version="1.0.0"]
[ERROR]     require: (&(osgi.wiring.bundle=org.apache.batik.svggen)(bundle-version>=1.7.0))
[ERROR]      |
[ERROR]     provide: osgi.wiring.bundle; bundle-version:Version="1.14.0.v20210324-0332"; osgi.wiring.bundle="org.apache.batik.svggen"
[ERROR]   org.apache.batik.svggen [osgi.identity; osgi.identity="org.apache.batik.svggen"; type="osgi.bundle"; version:Version="1.14.0.v20210324-0332"]
[ERROR]     import: (&(osgi.wiring.package=org.apache.batik.ext.awt.g2d)(&(version>=1.14.0)(!(version>=2.0.0))))
[ERROR]      |
[ERROR]     export: osgi.wiring.package: org.apache.batik.ext.awt.g2d
[ERROR]   org.apache.batik.awt.util [osgi.identity; osgi.identity="org.apache.batik.awt.util"; type="osgi.bundle"; version:Version="1.14.0.v20210324-0332"]
[ERROR] -> [Help 1]
```

For me this is a blocker for the upcomming 2.4.x release ...
