### PR TITLE
[justj] example for "Full specification of custom profile is not (yet) determined" error

### DIFF
--- a/tycho-its/projects/justj/bundle-product/pom.xml
+++ b/tycho-its/projects/justj/bundle-product/pom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.tycho.tycho-its</groupId>
+    <artifactId>parent-justj</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>just-j-product-bundles</artifactId>
+  <packaging>eclipse-repository</packaging>
+</project>

--- a/tycho-its/projects/justj/bundle-product/product-with-bundles.product
+++ b/tycho-its/projects/justj/bundle-product/product-with-bundles.product
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product name="A product with justj" uid="product-with-justj-bundles" version="0.0.1" useFeatures="false" includeLaunchers="true">
+
+   <configIni use="default">
+   </configIni>
+
+   <launcherArgs>
+      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
+      </vmArgsMac>
+   </launcherArgs>
+
+   <plugins>
+      <plugin id="bundle"/>
+      <plugin id="bundle2"/>
+      <plugin id="org.eclipse.justj.openjdk.hotspot.jre.full"/>
+   </plugins>
+
+
+</product>

--- a/tycho-its/projects/justj/bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/justj/bundle/META-INF/MANIFEST.MF
@@ -1,0 +1,9 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: bundle Plug-in
+Bundle-SymbolicName: bundle
+Bundle-Version: 0.0.1.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Export-Package: bundle
+Automatic-Module-Name: bundle
+Require-Bundle: org.eclipse.core.runtime

--- a/tycho-its/projects/justj/bundle/build.properties
+++ b/tycho-its/projects/justj/bundle/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = bin/
+bin.includes = .,\
+               META-INF/
+additional.bundles = org.junit

--- a/tycho-its/projects/justj/bundle/pom.xml
+++ b/tycho-its/projects/justj/bundle/pom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.tycho.tycho-its</groupId>
+    <artifactId>parent-justj</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>bundle</artifactId>
+  <packaging>eclipse-plugin</packaging>
+</project>

--- a/tycho-its/projects/justj/bundle/src/bundle/Something.java
+++ b/tycho-its/projects/justj/bundle/src/bundle/Something.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Sonatype Inc. and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Sonatype Inc. - initial API and implementation
+ *******************************************************************************/
+package bundle;
+
+public class Something {
+
+	public static void sayHello() {
+	}
+	
+}

--- a/tycho-its/projects/justj/bundle2/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/justj/bundle2/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: bundle2
+Bundle-SymbolicName: bundle2;singleton:=true
+Bundle-Version: 0.0.1.qualifier
+Require-Bundle: bundle;bundle-version="0.0.1"
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Automatic-Module-Name: bundle2

--- a/tycho-its/projects/justj/bundle2/build.properties
+++ b/tycho-its/projects/justj/bundle2/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = .,\
+               META-INF/

--- a/tycho-its/projects/justj/bundle2/pom.xml
+++ b/tycho-its/projects/justj/bundle2/pom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.tycho.tycho-its</groupId>
+    <artifactId>parent-justj</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>bundle2</artifactId>
+  <packaging>eclipse-plugin</packaging>
+</project>

--- a/tycho-its/projects/justj/bundle2/src/bundle2/BundleClient.java
+++ b/tycho-its/projects/justj/bundle2/src/bundle2/BundleClient.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Sonatype Inc. and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Sonatype Inc. - initial API and implementation
+ *******************************************************************************/
+package bundle2;
+
+import bundle.Something;
+
+public class BundleClient {
+
+	public void doSomething() {
+		Something.sayHello();
+	}
+	
+}

--- a/tycho-its/projects/justj/feature-product/pom.xml
+++ b/tycho-its/projects/justj/feature-product/pom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.tycho.tycho-its</groupId>
+    <artifactId>parent-justj</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>just-j-product-features</artifactId>
+  <packaging>eclipse-repository</packaging>
+</project>

--- a/tycho-its/projects/justj/feature-product/product-with-features.product
+++ b/tycho-its/projects/justj/feature-product/product-with-features.product
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product name="A product with justj" uid="product-with-justj-features" version="0.0.1" useFeatures="true" includeLaunchers="true">
+
+   <configIni use="default">
+   </configIni>
+
+   <launcherArgs>
+      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
+      </vmArgsMac>
+   </launcherArgs>
+
+   <plugins>
+   </plugins>
+
+   <features>
+      <feature id="feature" installMode="root"/>
+      <feature id="org.eclipse.justj.openjdk.hotspot.jre.full"/>
+   </features>
+
+
+</product>

--- a/tycho-its/projects/justj/feature/build.properties
+++ b/tycho-its/projects/justj/feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/tycho-its/projects/justj/feature/feature.xml
+++ b/tycho-its/projects/justj/feature/feature.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="feature"
+      label="Just-j-itestfeature"
+      version="0.0.1.qualifier">
+
+   <description url="http://www.example.com/description">
+      [Enter Feature Description here.]
+   </description>
+
+   <copyright url="http://www.example.com/copyright">
+      [Enter Copyright Description here.]
+   </copyright>
+
+   <license url="http://www.example.com/license">
+      [Enter License Description here.]
+   </license>
+
+   <plugin
+         id="bundle"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
+   <plugin
+         id="bundle2"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
+</feature>

--- a/tycho-its/projects/justj/feature/pom.xml
+++ b/tycho-its/projects/justj/feature/pom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.tycho.tycho-its</groupId>
+    <artifactId>parent-justj</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>feature</artifactId>
+  <packaging>eclipse-feature</packaging>
+</project>

--- a/tycho-its/projects/justj/pom.xml
+++ b/tycho-its/projects/justj/pom.xml
@@ -6,8 +6,8 @@
 	<version>0.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<properties>
-<!-- 		<tycho-version>2.4.0-SNAPSHOT</tycho-version> -->
-<!-- 		<target-platform>https://download.eclipse.org/releases/2021-03/</target-platform> -->
+ 		<tycho-version>2.4.0-SNAPSHOT</tycho-version>
+ 		<target-platform>https://download.eclipse.org/releases/2021-03/</target-platform>
 	</properties>
 	<modules>
 		<module>bundle</module>
@@ -35,6 +35,14 @@
 				<artifactId>tycho-maven-plugin</artifactId>
 				<version>${tycho-version}</version>
 				<extensions>true</extensions>
+			</plugin>
+				<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<executionEnvironment>none</executionEnvironment>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/tycho-its/projects/justj/pom.xml
+++ b/tycho-its/projects/justj/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.eclipse.tycho.tycho-its</groupId>
+	<artifactId>parent-justj</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	<properties>
+<!-- 		<tycho-version>2.4.0-SNAPSHOT</tycho-version> -->
+<!-- 		<target-platform>https://download.eclipse.org/releases/2021-03/</target-platform> -->
+	</properties>
+	<modules>
+		<module>bundle</module>
+		<module>bundle2</module>
+		<module>feature</module>
+		<module>bundle-product</module>
+		<module>feature-product</module>
+	</modules>
+	<repositories>
+		<repository>
+			<id>platform</id>
+			<url>${target-platform}</url>
+			<layout>p2</layout>
+		</repository>
+		<repository>
+			<id>justj</id>
+			<url>https://download.eclipse.org/justj/jres/11/updates/release/11.0.2</url>
+			<layout>p2</layout>
+		</repository>
+	</repositories>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/product/BuildJustj.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/product/BuildJustj.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.test.product;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.Test;
+
+public class BuildJustj extends AbstractTychoIntegrationTest {
+    @Test
+    public void testJustJ() throws Exception {
+        Verifier verifier = getVerifier("justj", true);
+        verifier.executeGoal("verify");
+        verifier.verifyErrorFreeLog();
+    }
+}


### PR DESCRIPTION
This example fails with 

```
[ERROR] Internal error: java.lang.IllegalStateException: Full specification of custom profile is not (yet) determined -> [Help 1]
org.apache.maven.InternalErrorException: Internal error: java.lang.IllegalStateException: Full specification of custom profile is not (yet) determined
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:120)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: java.lang.IllegalStateException: Full specification of custom profile is not (yet) determined
    at org.eclipse.tycho.core.ee.ExecutionEnvironmentConfigurationImpl.getFullSpecification (ExecutionEnvironmentConfigurationImpl.java:131)
    at org.eclipse.tycho.core.osgitools.OsgiBundleProject.getResolverState (OsgiBundleProject.java:325)
    at org.eclipse.tycho.core.osgitools.OsgiBundleProject.resolveClassPath (OsgiBundleProject.java:196)
    at org.eclipse.tycho.core.resolver.DefaultTychoResolver.resolveProject (DefaultTychoResolver.java:173)
    at org.eclipse.tycho.core.maven.TychoMavenLifecycleParticipant.lambda$resolveProjects$0 (TychoMavenLifecycleParticipant.java:127)
    at java.util.stream.ForEachOps$ForEachOp$OfRef.accept (ForEachOps.java:183)
    at java.util.stream.WhileOps$1$1.accept (WhileOps.java:99)
    at java.util.ArrayList$ArrayListSpliterator.tryAdvance (ArrayList.java:1632)
    at java.util.stream.ReferencePipeline.forEachWithCancel (ReferencePipeline.java:127)
    at java.util.stream.AbstractPipeline.copyIntoWithCancel (AbstractPipeline.java:502)
    at java.util.stream.AbstractPipeline.copyInto (AbstractPipeline.java:488)
    at java.util.stream.AbstractPipeline.wrapAndCopyInto (AbstractPipeline.java:474)
    at java.util.stream.ForEachOps$ForEachOp.evaluateSequential (ForEachOps.java:150)
    at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential (ForEachOps.java:173)
    at java.util.stream.AbstractPipeline.evaluate (AbstractPipeline.java:234)
    at java.util.stream.ReferencePipeline.forEach (ReferencePipeline.java:497)
    at org.eclipse.tycho.core.maven.TychoMavenLifecycleParticipant.resolveProjects (TychoMavenLifecycleParticipant.java:158)
    at org.eclipse.tycho.core.maven.TychoMavenLifecycleParticipant.afterProjectsRead (TychoMavenLifecycleParticipant.java:102)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:264)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)

```