### PR TITLE
[Doc] improve ReadMe and Contributing (Debugging- and Snapshot-section)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,11 +152,19 @@ In order to debug Tycho plugins inside Eclipse:
 
 1. Get the Tycho sources in Eclipse
 2. Create/get a project that highlights the bug
-3. Create a Maven Run-Configuration in your Tycho Eclipse-workspace to build the project, specify goals, profiles and properties as required.
+
+Inside the Eclipse IDE:
+
+3. Create a Maven Run-Configuration in your Tycho Eclipse-workspace to build the project and specify goals, profiles and properties as required
 4. Launch the Maven-configuration from your Eclipse in Debug-mode
 
-Before debugging a build, you should make sure that your local Tycho-sources correspond to the Tycho version used by the project being build.
-Otherwise the debugger may behaves unexpected.
+Or on the command-line interface:
+
+3. Run the project-build using `mvnDebug` (instead of `mvn`) and specify goals, profiles and properties as required
+4. Go into your Eclipse, use `Debug > Remote Java Application`, select `port 8000` to attach the Eclipse Debugger
+
+Before debugging a build, make sure that your local Tycho-sources correspond to the Tycho version used by the project being build.
+Otherwise the debugger might show unexpected behavior.
 
 ## Commits
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,19 @@ Thanks for your interest in this project.
 
 ## Try SNAPSHOTs and report issues
 
-To enable SNAPSHOTs, make sure the following Maven repository is available to your build: https://repo.eclipse.org/content/repositories/tycho-snapshots/ .
+To enable SNAPSHOTs, make sure the following Maven plugin-repository is available to your build: https://repo.eclipse.org/content/repositories/tycho-snapshots/ .
+This can be accomplished by adding the following snippet to your (parent) pom.xml or settings.xml:
+```
+<pluginRepositories>
+    <pluginRepository>
+      <id>tycho-snapshots</id>
+      <url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</url>
+    </pluginRepository>
+</pluginRepositories>
+```
+Make sure you have set the property for the Tycho version (e.g. `tycho-version`) to `<version-under-development>-SNAPSHOT`in the project beeing build.
+
+For documentation of the most recent snapshot build, see the [Snapshot Tycho Site](https://ci.eclipse.org/tycho/job/tycho-sitedocs/lastSuccessfulBuild/artifact/target/staging/index.html).
 
 If you identify an issue, please try to reduce the case to the minimal project and steps to reproduce, and then report the bug with details to reproduce
 and the minimal reproducer project to Tycho's [issue tracker](./issues).
@@ -124,7 +136,15 @@ Tycho has Maven dependencies to Equinox and JDT, so these artifact are used from
 
 ## 🏗️ Build & Test
 
-`mvn clean install -Pits`
+From the root directory of your local Tycho git-repository clone run the following Maven commands...
+* to check if compilation and all tests succeed:
+    * `mvn clean verify -Pits`
+* to install your version of Tycho into your local Maven repository (skips all tests for faster installation):
+    * `mvn clean install -DSkipTests`
+
+In order to test your changes of Tycho locally in a project-build, install your modified Tycho locally as described above
+and use the corresponding Tycho (probably snapshot) version in the project being build.
+You can also debug that build with the steps below (from here you can jump to step 3 immediately).
 
 ## Debugging 
 
@@ -132,9 +152,11 @@ In order to debug Tycho plugins inside Eclipse:
 
 1. Get the Tycho sources in Eclipse
 2. Create/get a project that highlights the bug
-3. Run the project with `mvnDebug clean install`
-4. Go into your Eclipse, use `Debug > Remote Java Application`, select port 8000
+3. Create a Maven Run-Configuration in your Tycho Eclipse-workspace to build the project, specify goals, profiles and properties as required.
+4. Launch the Maven-configuration from your Eclipse in Debug-mode
 
+Before debugging a build, you should make sure that your local Tycho-sources correspond to the Tycho version used by the project being build.
+Otherwise the debugger may behaves unexpected.
 
 ## Commits
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ with Maven.
 
 * 👔 Eclipse project entry: https://projects.eclipse.org/projects/technology.tycho
 * 🗒️ Documentation (some content to be reincorporated into this repository):
-      * https://www.eclipse.org/tycho/sitedocs/
-      * https://wiki.eclipse.org/Tycho/
+     * https://www.eclipse.org/tycho/sitedocs/
+     * https://wiki.eclipse.org/Tycho/
+* 📢 Release notes: [RELEASE_NOTES.md](./RELEASE_NOTES.md)
 * 🪲 Bug Tracker
      * New https://github.com/eclipse/tycho/issues
      * Legacy https://bugs.eclipse.org/bugs/buglist.cgi?product=Tycho
-* ⌨️ How to Contribute: [CONTRIBUTING.md](./CONTRIBUTING.md)
+* ⌨️ How to Contribute and latest snapshots: [CONTRIBUTING.md](./CONTRIBUTING.md)
 * 💬 Community mailing-lists
      * Usage assistance https://dev.eclipse.org/mailman/listinfo/tycho-user
      * Development https://dev.eclipse.org/mailman/listinfo/tycho-dev
-  


### PR DESCRIPTION
With this PR I suggest improvements for Tycho's documentation.
This includes the following changes:
- In README.md
  - fix the formatting of the doc list, on Github the listing was not rendered correctly.
  - add an item to the release notes
  - mention the snapshots as well

- In CONTRIBUTING
  - extend the snapshot section, inspired by the Release-Notes sections from [Tycho's Eclipse wiki](https://wiki.eclipse.org/Tycho/Release_Notes/2.4) so one can simply copy and paste the relevant snippets.
  - extend the build section to distinguish between builds for 'testing' if everything works and builds to install Tycho locally to test changes with a project-build.
  - Change the suggested way to debug Tycho to the (in my opinion) more convenient way of launching Maven from Eclipse in Debug-mode. Do you think the previous way should remain as an alternative?

Please don't hesitate to let me know, if you don't find any of those changes useful.