### PR TITLE
#179 Fix false detection of 'clean-only' builds (regression from #166)

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
@@ -240,7 +240,8 @@ public class TychoMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
         // command line property to disable Tycho lifecycle participant
         return "maven".equals(session.getUserProperties().get("tycho.mode"))
                 || session.getUserProperties().containsKey("m2e.version")
-                || CLEAN_PHASES.containsAll(session.getGoals());
+                // disable for 'clean-only' builds. Consider that Maven can be invoked without explicit goals, if default goals are specified
+                || (!session.getGoals().isEmpty() && CLEAN_PHASES.containsAll(session.getGoals()));
     }
 
     private void configureComponents(MavenSession session) {


### PR DESCRIPTION
This PR fixes issue #179.
If default goals are used Maven can be invoked without specifying goals explicitly in the command, so the List of goals is empty.

This had the consequence, that the AbstractMavenLifecycleParticipant false detected a clean-only build and skipped dependency/target-platform resolution, which lead to follow up errors.

The logic to detect 'clean-only' builds is improved to consider the described case.