### PR TITLE
Issue #183 - avoid parallel execution of compiler

### DIFF
--- a/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
+++ b/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
@@ -106,6 +106,8 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo
      */
     public static final String RULE_EXCLUDE_ALL = "?**/*";
 
+    private static final Object LOCK = new Object();
+
     private static final Set<String> MATCH_ALL = Collections.singleton("**/*");
 
     private static final String PREFS_FILE_PATH = ".settings" + File.separator + "org.eclipse.jdt.core.prefs";
@@ -330,7 +332,11 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo
 
         checkTargetLevelCompatibleWithManifestBREEs(effectiveTargetLevel, manifestBREEs);
 
-        doCompile();
+        synchronized (LOCK) {
+            // sync to workaround https://bugs.eclipse.org/bugs/show_bug.cgi?id=574450
+            // TODO remove it when default ECJ has fix
+            doCompile();
+        }
         doFinish();
     }
 


### PR DESCRIPTION
Compiler cannot use parallel execution until related bugs is fixed in
the version used and provided by default in Tycho.