### PR TITLE
Incorrect requirement version for configuration/plugins in publish-products

### DIFF
--- a/tycho-bundles/org.eclipse.tycho.p2.tools.impl/src/main/java/org/eclipse/tycho/p2/tools/publisher/ProductVersionExpansionRun.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.tools.impl/src/main/java/org/eclipse/tycho/p2/tools/publisher/ProductVersionExpansionRun.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 SAP SE and others.
+ * Copyright (c) 2015, 2021 SAP SE and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *    SAP SE - initial API and implementation
+ *    Christoph Läubrich - Bug 571951 - Incorrect requirement version for configuration/plugins in publish-products migrated to #80
  *******************************************************************************/
 package org.eclipse.tycho.p2.tools.publisher;
 
@@ -36,7 +37,8 @@ class ProductVersionExpansionRun {
         this.productFile = productFile;
     }
 
-    public List<IVersionedId> resolveReferences(String elementName, String artifactType, List<IVersionedId> references) {
+    public List<IVersionedId> resolveReferences(String elementName, String artifactType,
+            List<IVersionedId> references) {
         final List<IVersionedId> result = new ArrayList<>();
         for (IVersionedId reference : references) {
             IInstallableUnit resolvedUnit = resolveReferenceWithErrorHandling(elementName, artifactType, reference);
@@ -79,11 +81,21 @@ class ProductVersionExpansionRun {
         return null;
     }
 
+    public String getErrors() {
+        if (errors == null) {
+            return null;
+        }
+        String str = errors.toString();
+        errors = null;
+        return str;
+    }
+
     public void reportErrors(MavenLogger logger) {
         if (errors != null) {
             logger.error(errors.toString());
-            throw new DependencyResolutionException("Cannot resolve dependencies of product " + productFile.getName()
-                    + ". See log for details.");
+            errors = null;
+            throw new DependencyResolutionException(
+                    "Cannot resolve dependencies of product " + productFile.getName() + ". See log for details.");
         }
     }
 

--- a/tycho-its/projects/product.differentVersions/activemq.target
+++ b/tycho-its/projects/product.differentVersions/activemq.target
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="activemq">
+	<locations>
+		<location includeDependencyScope="compile" includeSource="true" missingManifest="ignore" type="Maven">
+			<groupId>org.apache.activemq</groupId>
+			<artifactId>activemq-core</artifactId>
+			<version>5.7.0</version>
+			<type>jar</type>
+		</location>
+		<location includeDependencyScope="compile" includeSource="true" missingManifest="ignore" type="Maven">
+			<groupId>org.apache.activemq</groupId>
+			<artifactId>activemq-core</artifactId>
+			<version>5.2.0</version>
+			<type>jar</type>
+		</location>
+	</locations>
+</target>

--- a/tycho-its/projects/product.differentVersions/activemq.target
+++ b/tycho-its/projects/product.differentVersions/activemq.target
@@ -8,10 +8,16 @@
 			<version>5.7.0</version>
 			<type>jar</type>
 		</location>
-		<location includeDependencyScope="compile" includeSource="true" missingManifest="ignore" type="Maven">
+		<location includeDependencyScope="compile" missingManifest="ignore" type="Maven">
 			<groupId>org.apache.activemq</groupId>
 			<artifactId>activemq-core</artifactId>
 			<version>5.2.0</version>
+			<type>jar</type>
+		</location>
+		<location missingManifest="ignore" type="Maven">
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-core</artifactId>
+			<version>3.11.0</version>
 			<type>jar</type>
 		</location>
 	</locations>

--- a/tycho-its/projects/product.differentVersions/feature.indirect/build.properties
+++ b/tycho-its/projects/product.differentVersions/feature.indirect/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/tycho-its/projects/product.differentVersions/feature.indirect/feature.xml
+++ b/tycho-its/projects/product.differentVersions/feature.indirect/feature.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="com.test.sample.feature.indirect"
+      version="1.0.0">
+
+   <plugin
+         id="org.apache.camel.camel-core"
+         download-size="0"
+         install-size="0"
+         version="1.5.0"
+         unpack="false"/>
+
+</feature>

--- a/tycho-its/projects/product.differentVersions/feature.indirect/pom.xml
+++ b/tycho-its/projects/product.differentVersions/feature.indirect/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.tycho.its</groupId>
+		<artifactId>issue-80-parent</artifactId>
+		<version>1.0.0</version>
+	</parent>
+
+	<artifactId>com.test.sample.feature.indirect</artifactId>
+	<version>1.0.0</version>
+	<packaging>eclipse-feature</packaging>
+
+</project>

--- a/tycho-its/projects/product.differentVersions/feature.root/build.properties
+++ b/tycho-its/projects/product.differentVersions/feature.root/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/tycho-its/projects/product.differentVersions/feature.root/feature.xml
+++ b/tycho-its/projects/product.differentVersions/feature.root/feature.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="com.test.sample.feature.root"
+      version="1.0.0">
+
+  <plugin
+         id="org.apache.activemq.activemq-jaas"
+         download-size="0"
+         install-size="0"
+         version="5.2.0"
+         unpack="false"/>
+
+</feature>

--- a/tycho-its/projects/product.differentVersions/feature.root/pom.xml
+++ b/tycho-its/projects/product.differentVersions/feature.root/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.tycho.its</groupId>
+		<artifactId>issue-80-parent</artifactId>
+		<version>1.0.0</version>
+	</parent>
+
+	<artifactId>com.test.sample.feature.root</artifactId>
+	<version>1.0.0</version>
+	<packaging>eclipse-feature</packaging>
+
+</project>

--- a/tycho-its/projects/product.differentVersions/feature/build.properties
+++ b/tycho-its/projects/product.differentVersions/feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/tycho-its/projects/product.differentVersions/feature/feature.xml
+++ b/tycho-its/projects/product.differentVersions/feature/feature.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="com.test.sample.feature"
+      version="1.0.0">
+
+   <plugin
+         id="org.apache.activemq.activemq-core"
+         download-size="0"
+         install-size="0"
+         version="5.2.0"
+         unpack="false"/>
+
+</feature>

--- a/tycho-its/projects/product.differentVersions/feature/feature.xml
+++ b/tycho-its/projects/product.differentVersions/feature/feature.xml
@@ -3,6 +3,10 @@
       id="com.test.sample.feature"
       version="1.0.0">
 
+   <includes
+         id="com.test.sample.feature.indirect"
+         version="0.0.0"/>
+
    <plugin
          id="org.apache.activemq.activemq-core"
          download-size="0"

--- a/tycho-its/projects/product.differentVersions/feature/pom.xml
+++ b/tycho-its/projects/product.differentVersions/feature/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.tycho.its</groupId>
+		<artifactId>issue-80-parent</artifactId>
+		<version>1.0.0</version>
+	</parent>
+
+	<artifactId>com.test.sample.feature</artifactId>
+	<version>1.0.0</version>
+	<packaging>eclipse-feature</packaging>
+
+</project>

--- a/tycho-its/projects/product.differentVersions/pom.xml
+++ b/tycho-its/projects/product.differentVersions/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.eclipse.tycho.its</groupId>
+	<artifactId>issue-80-parent</artifactId>
+	<version>1.0.0</version>
+	<packaging>pom</packaging>
+
+	<properties>
+		<tycho-version>2.5.0-SNAPSHOT</tycho-version>
+		<platform-url>https://download.eclipse.org/releases/2021-03/</platform-url>
+	</properties>
+
+	<modules>
+		<module>feature</module>
+		<module>feature.root</module>
+		<module>product</module>
+	</modules>
+
+	<repositories>
+		<repository>
+			<id>platform</id>
+			<layout>p2</layout>
+			<url>${platform-url}</url>
+		</repository>
+	</repositories>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<target>
+						<file>../activemq.target</file>
+					</target>
+					<environments>
+						<environment>
+							<os>linux</os>
+							<ws>gtk</ws>
+							<arch>x86</arch>
+						</environment>
+					</environments>
+				</configuration>
+			</plugin>
+		</plugins>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-p2-repository-plugin</artifactId>
+					<version>${tycho-version}</version>
+					<configuration>
+						<includeAllDependencies>false</includeAllDependencies>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-p2-director-plugin</artifactId>
+					<version>${tycho-version}</version>
+					<executions>
+						<execution>
+							<id>materialize-products</id>
+							<goals>
+								<goal>materialize-products</goal>
+							</goals>
+						</execution>
+						<execution>
+							<id>archive-products</id>
+							<phase>integration-test</phase>
+							<goals>
+								<goal>archive-products</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+
+
+
+</project>
+

--- a/tycho-its/projects/product.differentVersions/pom.xml
+++ b/tycho-its/projects/product.differentVersions/pom.xml
@@ -17,6 +17,7 @@
 	<modules>
 		<module>feature</module>
 		<module>feature.root</module>
+		<module>feature.indirect</module>
 		<module>product</module>
 	</modules>
 

--- a/tycho-its/projects/product.differentVersions/product/pom.xml
+++ b/tycho-its/projects/product.differentVersions/product/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.tycho.its</groupId>
+		<artifactId>issue-80-parent</artifactId>
+		<version>1.0.0</version>
+	</parent>
+
+	<artifactId>product</artifactId>
+	<packaging>eclipse-repository</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-repository-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-director-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/projects/product.differentVersions/product/sample.product
+++ b/tycho-its/projects/product.differentVersions/product/sample.product
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product name="Sample Product" uid="com.test.sample.product" id="com.test.sample.product" application="com.test.sample.application" version="1.0.0.qualifier" useFeatures="true" includeLaunchers="false">
+
+   <plugins>
+   </plugins>
+
+   <features>
+      <feature id="com.test.sample.feature" version="1.0.0"/>
+      <feature id="com.test.sample.feature.root" version="1.0.0" installMode="root"/>
+   </features>
+
+   <configurations>
+      <plugin id="org.apache.activemq.activemq-core" autoStart="true" startLevel="3" />
+      <plugin id="org.apache.activemq.activemq-jaas" autoStart="true" startLevel="3" />
+   </configurations>
+
+</product>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/product/ProductMixedVersionsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/product/ProductMixedVersionsTest.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - [Issue #80] Incorrect requirement version for configuration/plugins in publish-products
+ *******************************************************************************/
+package org.eclipse.tycho.test.product;
+
+import java.util.Arrays;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.eclipse.tycho.test.util.ResourceUtil.P2Repositories;
+import org.junit.Test;
+
+public class ProductMixedVersionsTest extends AbstractTychoIntegrationTest {
+    @Test
+    public void testMixedPluginVersions() throws Exception {
+        Verifier verifier = getVerifier("product.differentVersions", false);
+        verifier.getSystemProperties().setProperty("platform-url", P2Repositories.ECLIPSE_LATEST.toString());
+        verifier.executeGoals(Arrays.asList("clean", "verify"));
+        verifier.verifyErrorFreeLog();
+    }
+}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetPlatformLocationsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetPlatformLocationsTest.java
@@ -32,6 +32,7 @@ public class TargetPlatformLocationsTest extends AbstractTychoIntegrationTest {
         verifier.verifyErrorFreeLog();
     }
 
+    @Test
     public void testDirectoryLocation() throws Exception {
         Verifier verifier = getVerifier("target.directory", false, true);
         verifier.executeGoal("verify");


### PR DESCRIPTION
As a first step, this provides an integrationtest that shows the issue from #80 with a product that contains a root and a non-root feature.

As a second step this includes resolving the bundle versions of a product and setting them to the BundleInfos if the id matches.