### PR TITLE
#37 support M2_REPO Classpath Variable

### DIFF
--- a/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
+++ b/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
@@ -473,13 +473,14 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo
                 classpath.add(location.getAbsolutePath() + toString(cpe.getAccessRules()));
             }
         }
-
-        String basedir = session.getLocalRepository().getBasedir();
-        Collection<ProjectClasspathEntry> classpathEntries = getEclipsePluginProject().getClasspathEntries();
-        for (ProjectClasspathEntry cpe : classpathEntries) {
-            if (cpe instanceof M2ClasspathVariable) {
-                M2ClasspathVariable cpv = (M2ClasspathVariable) cpe;
-                classpath.add(new File(basedir, cpv.getRepositoryPath()).getAbsolutePath());
+        if (session != null) {
+            String basedir = session.getLocalRepository().getBasedir();
+            Collection<ProjectClasspathEntry> classpathEntries = getEclipsePluginProject().getClasspathEntries();
+            for (ProjectClasspathEntry cpe : classpathEntries) {
+                if (cpe instanceof M2ClasspathVariable) {
+                    M2ClasspathVariable cpv = (M2ClasspathVariable) cpe;
+                    classpath.add(new File(basedir, cpv.getRepositoryPath()).getAbsolutePath());
+                }
             }
         }
         return classpath;

--- a/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
+++ b/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
@@ -474,12 +474,15 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo
             }
         }
         if (session != null) {
-            String basedir = session.getLocalRepository().getBasedir();
-            Collection<ProjectClasspathEntry> classpathEntries = getEclipsePluginProject().getClasspathEntries();
-            for (ProjectClasspathEntry cpe : classpathEntries) {
-                if (cpe instanceof M2ClasspathVariable) {
-                    M2ClasspathVariable cpv = (M2ClasspathVariable) cpe;
-                    classpath.add(new File(basedir, cpv.getRepositoryPath()).getAbsolutePath());
+            ArtifactRepository repository = session.getLocalRepository();
+            if (repository != null) {
+                String basedir = repository.getBasedir();
+                Collection<ProjectClasspathEntry> classpathEntries = getEclipsePluginProject().getClasspathEntries();
+                for (ProjectClasspathEntry cpe : classpathEntries) {
+                    if (cpe instanceof M2ClasspathVariable) {
+                        M2ClasspathVariable cpv = (M2ClasspathVariable) cpe;
+                        classpath.add(new File(basedir, cpv.getRepositoryPath()).getAbsolutePath());
+                    }
                 }
             }
         }

--- a/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
+++ b/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
@@ -71,6 +71,7 @@ import org.eclipse.tycho.core.BundleProject;
 import org.eclipse.tycho.core.TychoConstants;
 import org.eclipse.tycho.core.TychoProject;
 import org.eclipse.tycho.core.dotClasspath.JREClasspathEntry;
+import org.eclipse.tycho.core.dotClasspath.M2ClasspathVariable;
 import org.eclipse.tycho.core.dotClasspath.ProjectClasspathEntry;
 import org.eclipse.tycho.core.ee.ExecutionEnvironmentUtils;
 import org.eclipse.tycho.core.ee.StandardExecutionEnvironment;
@@ -470,6 +471,15 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo
         for (ClasspathEntry cpe : getClasspath()) {
             for (File location : cpe.getLocations()) {
                 classpath.add(location.getAbsolutePath() + toString(cpe.getAccessRules()));
+            }
+        }
+
+        String basedir = session.getLocalRepository().getBasedir();
+        Collection<ProjectClasspathEntry> classpathEntries = getEclipsePluginProject().getClasspathEntries();
+        for (ProjectClasspathEntry cpe : classpathEntries) {
+            if (cpe instanceof M2ClasspathVariable) {
+                M2ClasspathVariable cpv = (M2ClasspathVariable) cpe;
+                classpath.add(new File(basedir, cpv.getRepositoryPath()).getAbsolutePath());
             }
         }
         return classpath;

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/dotClasspath/ClasspathParser.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/dotClasspath/ClasspathParser.java
@@ -107,6 +107,12 @@ public class ClasspathParser implements Disposable {
                         } else if ("lib".equals(kind)) {
                             String path = classpathentry.getAttribute("path");
                             list.add(new JDTLibraryClasspathEntry(new File(file.getParentFile(), path), attributes));
+                        } else if ("var".equals(kind)) {
+                            String path = classpathentry.getAttribute("path");
+                            if (path.startsWith(M2ClasspathVariable.M2_REPO_VARIABLE_PREFIX)) {
+                                String repoPath = path.substring(M2ClasspathVariable.M2_REPO_VARIABLE_PREFIX.length());
+                                list.add(new M2E(repoPath, attributes));
+                            }
                         }
                     }
                     entries = Collections.unmodifiableList(list);
@@ -242,6 +248,28 @@ public class ClasspathParser implements Disposable {
         @Override
         public Map<String, String> getAttributes() {
             return attributes;
+        }
+
+    }
+
+    private static final class M2E implements M2ClasspathVariable {
+
+        private final String repoPath;
+        private final Map<String, String> attributes;
+
+        M2E(String repoPath, Map<String, String> attributes) {
+            this.repoPath = repoPath;
+            this.attributes = attributes;
+        }
+
+        @Override
+        public Map<String, String> getAttributes() {
+            return attributes;
+        }
+
+        @Override
+        public String getRepositoryPath() {
+            return repoPath;
         }
 
     }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/dotClasspath/M2ClasspathVariable.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/dotClasspath/M2ClasspathVariable.java
@@ -1,0 +1,9 @@
+package org.eclipse.tycho.core.dotClasspath;
+
+public interface M2ClasspathVariable extends ProjectClasspathEntry {
+
+    static final String M2_REPO_VARIABLE_PREFIX = "M2_REPO/";
+
+    String getRepositoryPath();
+
+}


### PR DESCRIPTION
This adds support for M2_REPO entries for example like this:

`<classpathentry kind="var" path="M2_REPO/org/mockito/mockito-core/3.5.13/mockito-core-3.5.13.jar"/>`

a test case is already provided here https://github.com/eclipse/tycho/pull/206 that fails without and succeeds with this change.