### PR TITLE
Create a github action as pre-validation check

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,32 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Build Tycho
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+    - name: Cache local Maven repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+    - name: Build with Maven
+      run: mvn -U -V -e clean install --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,3 +30,4 @@ jobs:
           ${{ runner.os }}-maven-
     - name: Build with Maven
       run: mvn -U -V -e clean install --file pom.xml
+# currently I-Test are disabled (-Pits parameter in run command) because JdtBreeJava8Test requires a JDK8 in toolchain what currently is not directly supported by the setup-java action


### PR DESCRIPTION
Even though eclipse-infra is back online, I think it is good to get some experience with github actions.
Currently the itest are not run (due to special requirements for java8) but this might be still good as a first pre-validation, and the eclipse-ci can then run the full build+integration suite.