### PR TITLE
Issue #216 Add hint to debugPort parameter for test mojo

### DIFF
--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
@@ -137,7 +137,8 @@ public abstract class AbstractTestMojo extends AbstractMojo {
 
     /**
      * Set this parameter to suspend the test JVM waiting for a client to open a remote debug
-     * session on the specified port.
+     * session on the specified port. If further customization of JVM debug parameters is
+     * required then {@link argLine} can be used instead.
      */
     @Parameter(property = "debugPort")
     private int debugPort;


### PR DESCRIPTION
To help guide the user to argLine which can be used to achieve the same
customization as the maven.surefire.debug property in the Maven Surefire
plugin.