### PR TITLE
Allow absolute path for the target file definition

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReader.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReader.java
@@ -13,6 +13,8 @@
 package org.eclipse.tycho.core.resolver;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Properties;
 
@@ -370,9 +372,10 @@ public class DefaultTargetPlatformConfigurationReader {
         }
         Xpp3Dom[] fileDomArray = targetDom.getChildren("file");
         if (fileDomArray != null && fileDomArray.length > 0) {
+            Path basedir = Paths.get(project.getBasedir().getAbsolutePath());
             for (Xpp3Dom fileDom : fileDomArray) {
                 String file = fileDom.getValue();
-                File target = new File(project.getBasedir(), file);
+                File target = basedir.resolve(file).toFile();
                 if (isTargetFile(target)) {
                     result.addTarget(target);
                     return;

--- a/tycho-its/projects/target.usefileAbsolute/category.xml
+++ b/tycho-its/projects/target.usefileAbsolute/category.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+	<iu id="org.eclipse.jetty.http" version="0.0.0" />
+	<iu id="org.eclipse.jetty.http.source" version="0.0.0" />
+	<iu id="org.eclipse.jetty.io" version="0.0.0" />
+	<iu id="org.eclipse.jetty.io.source" version="0.0.0" />
+	<iu id="org.eclipse.jetty.security" version="0.0.0" />
+	<iu id="org.eclipse.jetty.security.source" version="0.0.0" />
+	<iu id="org.eclipse.jetty.server" version="0.0.0" />
+	<iu id="org.eclipse.jetty.server.source" version="0.0.0" />
+	<iu id="org.eclipse.jetty.servlet" version="0.0.0" />
+	<iu id="org.eclipse.jetty.servlet.source" version="0.0.0" />
+	<iu id="org.eclipse.jetty.util" version="0.0.0" />
+	<iu id="org.eclipse.jetty.util.source" version="0.0.0" />
+	<iu id="org.eclipse.jetty.util.ajax" version="0.0.0" />
+	<iu id="org.eclipse.jetty.util.ajax.source" version="0.0.0" />
+</site>

--- a/tycho-its/projects/target.usefileAbsolute/jetty.target
+++ b/tycho-its/projects/target.usefileAbsolute/jetty.target
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target>
+	<locations>
+		<location includeDependencyScope="compile" includeSource="true" missingManifest="ignore" type="Maven">
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-servlet</artifactId>
+			<version>10.0.1</version>
+			<type>jar</type>
+		</location>
+	</locations>
+</target>

--- a/tycho-its/projects/target.usefileAbsolute/pom.xml
+++ b/tycho-its/projects/target.usefileAbsolute/pom.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (c) 2008 Sonatype, Inc. All rights reserved. This program 
+	and the accompanying materials are made available under the terms of the 
+	Eclipse Public License 2.0 which accompanies this distribution, and is available 
+	at https://www.eclipse.org/legal/epl-2.0/ SPDX-License-Identifier: EPL-2.0 -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.eclipse.plaform.releng.buildtools</groupId>
+	<artifactId>org.eclipse.platform.jetty.repository</artifactId>
+	<version>10.0.1</version>
+	<packaging>eclipse-repository</packaging>
+
+	<name>Jetty p2 Update Site for Platform build neeeds</name>
+
+	<properties>
+		<tycho-version>2.5.0-SNAPSHOT</tycho-version>
+	</properties>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>tycho-snapshots</id>
+			<url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<target>
+						<file>${project.basedir}/jetty.target</file>
+					</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-repository-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<includeAllDependencies>true</includeAllDependencies>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<profiles>
+		<!-- Eclipse SimRel requires all artifacts to be jar-signed. So we sign 
+			the (non eclipse) artifacts and update the p2 metadata accordingly -->
+		<profile>
+			<id>eclipse-sign</id>
+			<pluginRepositories>
+				<pluginRepository>
+					<id>cbi-snapshots</id>
+					<url>https://repo.eclipse.org/content/repositories/cbi-snapshots/</url>
+				</pluginRepository>
+			</pluginRepositories>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.cbi.maven.plugins</groupId>
+						<artifactId>eclipse-jarsigner-plugin</artifactId>
+						<version>1.3.0-SNAPSHOT</version>
+						<executions>
+							<execution>
+								<id>sign</id>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+								<phase>prepare-package</phase>
+							</execution>
+						</executions>
+						<configuration>
+							<excludeInnerJars>true</excludeInnerJars>
+							<resigningStrategy>DO_NOT_RESIGN</resigningStrategy>
+							<archiveDirectory>${project.build.directory}/repository/plugins/</archiveDirectory>
+							<processMainArtifact>false</processMainArtifact>
+							<processAttachedArtifacts>false</processAttachedArtifacts>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-p2-repository-plugin</artifactId>
+						<version>${tycho-version}</version>
+						<executions>
+							<execution>
+								<id>update</id>
+								<goals>
+									<goal>fix-artifacts-metadata</goal>
+								</goals>
+								<phase>prepare-package</phase>
+							</execution>
+							<execution>
+								<id>verify</id>
+								<goals>
+									<goal>verify-repository</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+</project>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetRestrictionThroughTargetFilesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetRestrictionThroughTargetFilesTest.java
@@ -35,6 +35,13 @@ public class TargetRestrictionThroughTargetFilesTest extends AbstractTychoIntegr
     }
 
     @Test
+    public void testWithFileAbsolute() throws Exception {
+        verifier = getVerifier("target.usefileAbsolute", false);
+        verifier.executeGoal("package");
+        verifier.verifyErrorFreeLog();
+    }
+
+    @Test
     public void testVersionRestrictionWithPlanner() throws Exception {
         verifier = getVerifier("target.restriction.targetFile/testProject", false);
         TargetDefinitionUtil.makeURLsAbsolute(new File(getTargetsProject(), "planner.target"),


### PR DESCRIPTION
Fixes #263

As discussed in the issue, using a `<file>` value starting with`${project.basedir}` isn't real one, since if you omit this, the file is already a relative file from this base directory. It is convenient to create a test with a value starting with `/`.

A more real usage would be a real absolute file:

* `/my/target/location/file.target`
* `${targetDefs}/version1.target` (where `targetDefs` is an absolute path to some folder)
