### PR TITLE
Move away of deprecated hamcrest dependencies

### DIFF
--- a/sisu-equinox/sisu-equinox-launching/pom.xml
+++ b/sisu-equinox/sisu-equinox-launching/pom.xml
@@ -51,7 +51,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
+			<artifactId>hamcrest</artifactId>
 			<version>2.2</version>
 			<scope>test</scope>
 		</dependency>

--- a/tycho-metadata-model/pom.xml
+++ b/tycho-metadata-model/pom.xml
@@ -40,7 +40,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
+			<artifactId>hamcrest</artifactId>
 			<version>2.2</version>
 			<scope>test</scope>
 		</dependency>

--- a/tycho-testing-harness/pom.xml
+++ b/tycho-testing-harness/pom.xml
@@ -39,7 +39,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-core</artifactId>
+			<artifactId>hamcrest</artifactId>
+			<version>2.2</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
library and core are pom only artifacts for compatibility reasons.