### PR TITLE
#303 M2E-core build fails with Uses-constraint-violations

### DIFF
--- a/tycho-its/projects/resolver.usesConstraintViolations/bundle.test/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/resolver.usesConstraintViolations/bundle.test/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Bundle with w3c depdencies
+Bundle-SymbolicName: bundle.test.w3c
+Bundle-Version: 1.0.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Require-Bundle: org.eclipse.core.runtime,
+ org.apache.batik.dom;bundle-version="1.14.0"

--- a/tycho-its/projects/resolver.usesConstraintViolations/bundle.test/build.properties
+++ b/tycho-its/projects/resolver.usesConstraintViolations/bundle.test/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/resolver.usesConstraintViolations/bundle.test/pom.xml
+++ b/tycho-its/projects/resolver.usesConstraintViolations/bundle.test/pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.tycho.its</groupId>
+		<artifactId>issue303-parent</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>bundle.test.w3c</artifactId>
+	<packaging>eclipse-plugin</packaging>
+
+</project>

--- a/tycho-its/projects/resolver.usesConstraintViolations/bundle.test/src/bundle/test/Dummy.java
+++ b/tycho-its/projects/resolver.usesConstraintViolations/bundle.test/src/bundle/test/Dummy.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich- initial API and implementation
+ *******************************************************************************/
+package bundle.test;
+
+public class Dummy {
+	public static void main(String[] args) {
+	}
+}

--- a/tycho-its/projects/resolver.usesConstraintViolations/pom.xml
+++ b/tycho-its/projects/resolver.usesConstraintViolations/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.eclipse.tycho.its</groupId>
+	<artifactId>issue303-parent</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>pom</packaging>
+
+	<properties>
+		<tycho-version>2.6.0-SNAPSHOT</tycho-version>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<target>
+						<file>../test.target</file>
+					</target>
+					<environments>
+						<environment>
+							<os>linux</os>
+							<ws>gtk</ws>
+							<arch>x86</arch>
+						</environment>
+					</environments>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<modules>
+		<module>bundle.test</module>
+	</modules>
+
+</project>

--- a/tycho-its/projects/resolver.usesConstraintViolations/test.target
+++ b/tycho-its/projects/resolver.usesConstraintViolations/test.target
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="test">
+	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/releases/2021-09/"/>
+			<unit id="org.eclipse.sdk.feature.group" version="4.21.0.v20210906-0842"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2021-09/"/>
+			<unit id="org.w3c.dom.events" version="3.0.0.draft20060413_v201105210656"/>
+			<unit id="org.apache.batik.dom" version="1.14.0.v20210324-0332"/>
+		</location>
+	</locations>
+</target>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/ResolverTests.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/ResolverTests.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.tycho.test.resolver;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.Test;
+
+public class ResolverTests extends AbstractTychoIntegrationTest {
+
+	/**
+	 * This test case tests a combination that at a first glance looks very simple
+	 * but is hard to resolve due to the structure of 'org.eclipse.core.runtime'
+	 * bundle. One can force a failure by running the following commandline
+	 * 
+	 * <pre>
+	 * mvn clean install -Dtycho.equinox.resolver.batch.size=1 -Dtycho.equinox.resolver.uses=true
+	 * </pre>
+	 * 
+	 * what then fails with: Bundle was not resolved because of a uses constraint
+	 * violation, so this test effectively ensures that the defaults are working
+	 * without any special options
+	 * 
+	 * @throws Exception if anything goes wrong
+	 */
+	@Test
+	public void testUsesConstraintViolations() throws Exception {
+
+		Verifier verifier = getVerifier("/usesConstraintViolations");
+		verifier.executeGoal("compile");
+		verifier.verifyErrorFreeLog();
+	}
+
+}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/ResolverTests.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/ResolverTests.java
@@ -33,7 +33,7 @@ public class ResolverTests extends AbstractTychoIntegrationTest {
 	@Test
 	public void testUsesConstraintViolations() throws Exception {
 
-		Verifier verifier = getVerifier("/usesConstraintViolations");
+		Verifier verifier = getVerifier("resolver.usesConstraintViolations");
 		verifier.executeGoal("compile");
 		verifier.verifyErrorFreeLog();
 	}


### PR DESCRIPTION
Let resolver ignore 'uses' constraints to speedup resolving and prevent
failures for complex setups

Signed-off-by: Christoph Läubrich <laeubi@laeubi-soft.de>