### PR TITLE
Add a property to define the fork-count for the integrationtests

### DIFF
--- a/tycho-its/pom.xml
+++ b/tycho-its/pom.xml
@@ -27,7 +27,7 @@
 		<tycho-build-version>${project.version}</tycho-build-version>
 		<its-maven-version>3.8.3</its-maven-version>
 		<maven-dir>${project.build.directory}/apache-maven-${its-maven-version}</maven-dir>
-
+		<itest-forkcount>1</itest-forkcount>
 	</properties>
 
 	<build>
@@ -96,6 +96,7 @@
 					<systemPropertyVariables>
 						<it.cliOptions>${it.cliOptions}</it.cliOptions>
 					</systemPropertyVariables>
+					<forkCount>${itest-forkcount}</forkCount>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
It seems there is no standard property to define the [forkCount](https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#forkCount).
This adds a property for the [forkCount](https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#forkCount) so we can specify it on the commandline.