### PR TITLE
Avoid Maven info about missing resource encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -386,6 +386,9 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-resources-plugin</artifactId>
 					<version>3.2.0</version>
+					<configuration>
+						<propertiesEncoding>UTF-8</propertiesEncoding>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Without that setting the build has 3 occurrences of the following info.

[INFO] The encoding used to copy filtered properties files have not been
set. This means that the same encoding will be used to copy filtered
properties files as when copying other filtered resources. This might
not be what you want! Run your build with --debug to see which files
might be affected. Read more at
https://maven.apache.org/plugins/maven-resources-plugin/examples/filtering-properties-files.html