### PR TITLE
Suppress progress output in maven

### DIFF
--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -34,4 +34,4 @@ jobs:
           ${{ runner.os }}-maven-
     - name: License check
       run: | 
-        mvn -U -V -e org.eclipse.dash:license-tool-plugin:license-check --file pom.xml
+        mvn -U -V -e -B -ntp org.eclipse.dash:license-tool-plugin:license-check --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -40,9 +40,9 @@ jobs:
     - name: Build Tycho
       run: | 
         cp toolchains-gh.xml ~/.m2/toolchains.xml
-        mvn -U -V -e clean install --file pom.xml
+        mvn -U -V -e -B -ntp clean install --file pom.xml
     - name: Run Integration Tests
-      run: mvn -U -V -e -Pits -Dmaven.test.failure.ignore=true clean install --file tycho-its/pom.xml
+      run: mvn -U -V -e -B -ntp -Pits -Dmaven.test.failure.ignore=true clean install --file tycho-its/pom.xml
     - name: Upload Test Results
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
Enable batch mode and explicitly suppress transfer progress to get rid
of unwanted log lines.