### PR TITLE
Fix warning from maven-plugin-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
 			<dependency>
 				<groupId>org.apache.maven</groupId>
 				<artifactId>maven-plugin-api</artifactId>
+				<scope>provided</scope>
 				<version>${maven-version}</version>
 			</dependency>
 			<dependency>
@@ -110,21 +111,31 @@
 			<dependency>
 				<groupId>org.apache.maven</groupId>
 				<artifactId>maven-core</artifactId>
+				<scope>provided</scope>
+				<version>${maven-version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven</groupId>
+				<artifactId>maven-artifact</artifactId>
+				<scope>provided</scope>
 				<version>${maven-version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.maven</groupId>
 				<artifactId>maven-compat</artifactId>
+				<scope>provided</scope>
 				<version>${maven-version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.maven</groupId>
 				<artifactId>maven-model</artifactId>
+				<scope>provided</scope>
 				<version>${maven-version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.maven</groupId>
 				<artifactId>maven-settings</artifactId>
+				<scope>provided</scope>
 				<version>${maven-version}</version>
 			</dependency>
 			<dependency>

--- a/sisu-equinox/sisu-equinox-launching/pom.xml
+++ b/sisu-equinox/sisu-equinox-launching/pom.xml
@@ -25,6 +25,10 @@
 	<description>Support for launching an Equinox runtime as new process</description>
 
 	<dependencies>
+	    <dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-compat</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.eclipse.tycho</groupId>
 			<artifactId>tycho-core</artifactId>

--- a/tycho-compiler-plugin/pom.xml
+++ b/tycho-compiler-plugin/pom.xml
@@ -29,6 +29,10 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-compat</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
 		</dependency>
 		<dependency>

--- a/tycho-core/pom.xml
+++ b/tycho-core/pom.xml
@@ -185,6 +185,11 @@
 			<artifactId>plexus-archiver</artifactId>
 		</dependency>
 		<dependency>
+		    <groupId>org.codehaus.plexus</groupId>
+		    <artifactId>plexus-interpolation</artifactId>
+		    <version>1.26</version>
+		</dependency>
+		<dependency>
 			<groupId>org.codehaus.plexus</groupId>
 			<artifactId>plexus-cipher</artifactId>
 		</dependency>

--- a/tycho-extras/target-platform-validation-plugin/pom.xml
+++ b/tycho-extras/target-platform-validation-plugin/pom.xml
@@ -29,6 +29,14 @@
 			<artifactId>maven-plugin-annotations</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-plugin-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-compat</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.eclipse.tycho</groupId>
 			<artifactId>tycho-p2-facade</artifactId>
 		</dependency>

--- a/tycho-extras/tycho-buildtimestamp-jgit/pom.xml
+++ b/tycho-extras/tycho-buildtimestamp-jgit/pom.xml
@@ -22,6 +22,10 @@
   <name>Tycho JGit Build Timestamp Provider Plugin</name>
 
   <dependencies>
+	<dependency>
+		<groupId>org.apache.maven</groupId>
+		<artifactId>maven-archiver</artifactId>
+	</dependency>
     <dependency>
       <groupId>org.eclipse.tycho</groupId>
       <artifactId>tycho-packaging-plugin</artifactId>

--- a/tycho-extras/tycho-dependency-tools-plugin/pom.xml
+++ b/tycho-extras/tycho-dependency-tools-plugin/pom.xml
@@ -28,6 +28,14 @@
 			<artifactId>maven-plugin-annotations</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-plugin-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-core</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.eclipse.tycho</groupId>
 			<artifactId>tycho-core</artifactId>
 		</dependency>

--- a/tycho-extras/tycho-document-bundle-plugin/pom.xml
+++ b/tycho-extras/tycho-document-bundle-plugin/pom.xml
@@ -31,6 +31,10 @@
 			<artifactId>maven-plugin-annotations</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-compat</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.eclipse.tycho</groupId>
 			<artifactId>tycho-p2-facade</artifactId>
 		</dependency>

--- a/tycho-extras/tycho-eclipserun-plugin/pom.xml
+++ b/tycho-extras/tycho-eclipserun-plugin/pom.xml
@@ -28,8 +28,15 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-plugin-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-compat</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-artifact</artifactId>
-			<version>${maven-version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.tycho</groupId>

--- a/tycho-extras/tycho-p2-extras-plugin/pom.xml
+++ b/tycho-extras/tycho-p2-extras-plugin/pom.xml
@@ -36,7 +36,6 @@
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-artifact</artifactId>
-			<version>${maven-version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.tycho</groupId>

--- a/tycho-extras/tycho-sourceref-jgit/pom.xml
+++ b/tycho-extras/tycho-sourceref-jgit/pom.xml
@@ -24,6 +24,10 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-archiver</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.eclipse.tycho</groupId>
 			<artifactId>tycho-packaging-plugin</artifactId>
 			<version>${tycho-version}</version>

--- a/tycho-extras/tycho-version-bump-plugin/pom.xml
+++ b/tycho-extras/tycho-version-bump-plugin/pom.xml
@@ -31,6 +31,10 @@
 			<artifactId>maven-plugin-annotations</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-compat</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.eclipse.tycho</groupId>
 			<artifactId>tycho-p2-facade</artifactId>
 		</dependency>

--- a/tycho-p2/tycho-p2-facade/pom.xml
+++ b/tycho-p2/tycho-p2-facade/pom.xml
@@ -25,6 +25,10 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-compat</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.codehaus.plexus</groupId>
 			<artifactId>plexus-component-annotations</artifactId>
 		</dependency>

--- a/tycho-p2/tycho-p2-repository-plugin/pom.xml
+++ b/tycho-p2/tycho-p2-repository-plugin/pom.xml
@@ -32,6 +32,10 @@
 			<artifactId>maven-plugin-api</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-compat</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-annotations</artifactId>
 		</dependency>

--- a/tycho-p2/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/MavenP2SiteMojo.java
+++ b/tycho-p2/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/MavenP2SiteMojo.java
@@ -37,8 +37,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.handler.ArtifactHandler;
 import org.apache.maven.artifact.resolver.ArtifactResolutionRequest;
@@ -610,7 +608,7 @@ public class MavenP2SiteMojo extends AbstractMojo {
     protected boolean isSkippedDeploy(MavenProject mavenProject) {
         String property = mavenProject.getProperties().getProperty("maven.deploy.skip");
         if (property != null) {
-            boolean skip = BooleanUtils.toBoolean(property);
+            boolean skip = Boolean.parseBoolean(property);
             getLog().debug("deploy is " + (skip ? "" : "not") + " skipped in MavenProject " + mavenProject.getName()
                     + " because of property 'maven.deploy.skip'");
             return skip;
@@ -618,7 +616,7 @@ public class MavenP2SiteMojo extends AbstractMojo {
         String pluginId = "org.apache.maven.plugins:maven-deploy-plugin";
         property = getPluginParameter(mavenProject, pluginId, "skip");
         if (property != null) {
-            boolean skip = BooleanUtils.toBoolean(property);
+            boolean skip = Boolean.parseBoolean(property);
             getLog().debug("deploy is " + (skip ? "" : "not") + " skipped in MavenProject " + mavenProject.getName()
                     + " because of configuration of the plugin 'org.apache.maven.plugins:maven-deploy-plugin'");
             return skip;
@@ -645,8 +643,8 @@ public class MavenP2SiteMojo extends AbstractMojo {
         Plugin plugin = getPlugin(p, pluginId);
         if (plugin != null) {
             Xpp3Dom xpp3Dom = (Xpp3Dom) plugin.getConfiguration();
-            if (xpp3Dom != null && xpp3Dom.getChild(param) != null
-                    && StringUtils.isNotEmpty(xpp3Dom.getChild(param).getValue())) {
+            if (xpp3Dom != null && xpp3Dom.getChild(param) != null && xpp3Dom.getChild(param).getValue() != null
+                    && !xpp3Dom.getChild(param).getValue().isEmpty()) {
                 return xpp3Dom.getChild(param).getValue();
             }
         }

--- a/tycho-packaging-plugin/pom.xml
+++ b/tycho-packaging-plugin/pom.xml
@@ -51,7 +51,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-core</artifactId>
+			<artifactId>maven-compat</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>

--- a/tycho-pomgenerator-plugin/pom.xml
+++ b/tycho-pomgenerator-plugin/pom.xml
@@ -32,6 +32,10 @@
 			<artifactId>maven-plugin-api</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-compat</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-annotations</artifactId>
 		</dependency>

--- a/tycho-release/tycho-versions-plugin/pom.xml
+++ b/tycho-release/tycho-versions-plugin/pom.xml
@@ -31,6 +31,10 @@
 			<artifactId>maven-plugin-api</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-compat</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-annotations</artifactId>
 		</dependency>

--- a/tycho-source-plugin/pom.xml
+++ b/tycho-source-plugin/pom.xml
@@ -34,7 +34,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-core</artifactId>
+			<artifactId>maven-compat</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>

--- a/tycho-surefire/tycho-surefire-plugin/pom.xml
+++ b/tycho-surefire/tycho-surefire-plugin/pom.xml
@@ -84,6 +84,10 @@
 			<artifactId>maven-plugin-api</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-core</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-annotations</artifactId>
 		</dependency>


### PR DESCRIPTION
It comes as:
'''
[ERROR]
Maven dependencies of Maven Plugins should be in provided scope.
Please make sure that all your dependencies declared in POM whose group
ID is
org.apache.maven have set '<scope>provided</scope>' as well.
In the future this error will break the build.
'''

so just reading the log makes it look like an error which it isn't
(yet!).

There are couple more staying due to maven-surefire-plugin and
maven-gpg-plugin having this bad practice and thus transitively showing
in Tycho build too.