### PR TITLE
#443 - reuse information from p2 iu

### DIFF
--- a/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/MavenDependencyDescriptor.java
+++ b/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/MavenDependencyDescriptor.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho;
+
+/**
+ * describes a dependency as with the maven Dependency class
+ */
+public interface MavenDependencyDescriptor {
+
+    /**
+     * @return the unique id for an artifact
+     */
+    String getArtifactId();
+
+    /**
+     * @return the classifier of the dependency
+     */
+    String getClassifier();
+
+    /**
+     * 
+     * @return group that produced the dependency
+     */
+    String getGroupId();
+
+    /**
+     * @return the type of dependency
+     */
+    String getType();
+
+    /**
+     * @return the version of the dependency
+     */
+    String getVersion();
+}

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TestResolverFactory.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TestResolverFactory.java
@@ -24,6 +24,8 @@ import java.util.Properties;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.equinox.p2.core.ProvisionException;
+import org.eclipse.tycho.ArtifactDescriptor;
+import org.eclipse.tycho.MavenDependencyDescriptor;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.core.shared.DependencyResolutionException;
 import org.eclipse.tycho.core.shared.MavenArtifactRepositoryReference;
@@ -150,5 +152,10 @@ public class TestResolverFactory implements P2ResolverFactory {
     @Override
     public P2Resolver createResolver(MavenLogger logger) {
         return new P2ResolverImpl(getTargetPlatformFactoryImpl(), mavenContext.getLogger());
+    }
+
+    @Override
+    public MavenDependencyDescriptor resolveDependencyDescriptor(ArtifactDescriptor artifactDescriptor) {
+        return null;
     }
 }

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.shared/src/main/java/org/eclipse/tycho/p2/resolver/facade/P2ResolverFactory.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.shared/src/main/java/org/eclipse/tycho/p2/resolver/facade/P2ResolverFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 Sonatype Inc. and others.
+ * Copyright (c) 2008, 2022 Sonatype Inc. and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,9 +10,12 @@
  * Contributors:
  *    Sonatype Inc. - initial API and implementation
  *    Christoph Läubrich - Bug 567098 - pomDependencies=consider should wrap non-osgi jars
+ *                       - Issue #443 - Use regular Maven coordinates -when possible- for dependencies
  *******************************************************************************/
 package org.eclipse.tycho.p2.resolver.facade;
 
+import org.eclipse.tycho.ArtifactDescriptor;
+import org.eclipse.tycho.MavenDependencyDescriptor;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.core.shared.MavenLogger;
 import org.eclipse.tycho.p2.target.facade.PomDependencyCollector;
@@ -30,4 +33,14 @@ public interface P2ResolverFactory {
     public TargetPlatformFactory getTargetPlatformFactory();
 
     public P2Resolver createResolver(MavenLogger logger);
+
+    /**
+     * tries to resolve a {@link MavenDependencyDescriptor} from the given
+     * {@link ArtifactDescriptor}. If the {@link ArtifactDescriptor} does not contain any
+     * information about the maven origin <code>null</code> is returned.
+     * 
+     * @param artifactDescriptor
+     * @return the resolved maven origin or <code>null</code> if none could be found in the metadata
+     */
+    MavenDependencyDescriptor resolveDependencyDescriptor(ArtifactDescriptor artifactDescriptor);
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/MavenDependencyCollector.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/MavenDependencyCollector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2011 Sonatype Inc. and others.
+ * Copyright (c) 2008, 2022 Sonatype Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,7 +35,7 @@ public class MavenDependencyCollector extends ArtifactDependencyVisitor {
     private final Logger logger;
 
     public MavenDependencyCollector(MavenProject project, BundleReader bundleReader, Logger logger) {
-        this.injector = new MavenDependencyInjector(project, bundleReader, logger);
+        this.injector = new MavenDependencyInjector(project, bundleReader, null, logger);
         this.logger = logger;
     }
 

--- a/tycho-p2/tycho-p2-facade/src/main/java/org/eclipse/tycho/p2/resolver/P2DependencyResolver.java
+++ b/tycho-p2/tycho-p2-facade/src/main/java/org/eclipse/tycho/p2/resolver/P2DependencyResolver.java
@@ -458,6 +458,6 @@ public class P2DependencyResolver extends AbstractLogEnabled implements Dependen
     public void injectDependenciesIntoMavenModel(MavenProject project, AbstractTychoProject projectType,
             DependencyArtifacts dependencyArtifacts, DependencyArtifacts testDependencyArtifacts, Logger logger) {
         MavenDependencyInjector.injectMavenDependencies(project, dependencyArtifacts, testDependencyArtifacts,
-                bundleReader, logger);
+                bundleReader, resolverFactory::resolveDependencyDescriptor, logger);
     }
 }


### PR DESCRIPTION
This restores maven-dependency information from the IU properties if available.

Example output (**note last item in the output**):
```
[INFO] ----------------< org.eclipse.tycho.itests:test.bundle >----------------
[INFO] Building test.bundle 0.0.1-SNAPSHOT
[INFO] ---------------------------[ eclipse-plugin ]---------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:2.8:list (default-cli) @ test.bundle ---
[INFO] 
[INFO] The following files have been resolved:
[INFO]    p2.eclipse-plugin:wrapped.oro.oro:jar:2.0.8:system
[INFO]    p2.eclipse-plugin:custom.name.test:jar:3.141.59:system
[INFO]    commons-lang:commons-lang:jar:2.4:system
```

@mickaelistria to make this work for maven-target-location items https://github.com/eclipse/tycho/pull/485 is a perquisite.