### PR TITLE
[ENHANCEMENT] Upgrade default JavaSE to latest LTS JDK

### DIFF
--- a/target-platform-configuration/src/main/java/org/eclipse/tycho/target/TargetPlatformConfigurationMojo.java
+++ b/target-platform-configuration/src/main/java/org/eclipse/tycho/target/TargetPlatformConfigurationMojo.java
@@ -74,8 +74,8 @@ public class TargetPlatformConfigurationMojo extends AbstractMojo {
     private boolean allowConflictingDependences;
 
     /**
-     * Force an execution environment for dependency resolution. If unset, the first
-     * <code>targetJRE</code> available in {@link #target} is used.
+     * Force an execution environment for dependency resolution. If unset, use the default JRE 
+     * of your computer.
      * <p>
      * Set to <code>none</code> to force the resolution to happen <b>without</b> any execution
      * environment, typically when the module is supposed to use system packages coming from some

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/ee/ExecutionEnvironmentConfigurationImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/ee/ExecutionEnvironmentConfigurationImpl.java
@@ -24,7 +24,7 @@ import org.eclipse.tycho.core.shared.BuildFailureException;
 
 public class ExecutionEnvironmentConfigurationImpl implements ExecutionEnvironmentConfiguration {
     // Most likely best to always be the latest known supported EE
-    private static final String DEFAULT_EXECUTION_ENVIRONMENT = "JavaSE-11";
+    private static final String DEFAULT_EXECUTION_ENVIRONMENT = "JavaSE-17";
 
     private static final int PRIMARY = 0;
     private static final int SECONDARY = 1;

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/ee/ExecutionEnvironmentConfigurationImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/ee/ExecutionEnvironmentConfigurationImpl.java
@@ -24,7 +24,7 @@ import org.eclipse.tycho.core.shared.BuildFailureException;
 
 public class ExecutionEnvironmentConfigurationImpl implements ExecutionEnvironmentConfiguration {
     // Most likely best to always be the latest known supported EE
-    private static final String DEFAULT_EXECUTION_ENVIRONMENT = "JavaSE" + Integer.toString(Runtime.version().feature());
+    private static final String DEFAULT_EXECUTION_ENVIRONMENT = "JavaSE-" + Integer.toString(Runtime.version().feature());
 
     private static final int PRIMARY = 0;
     private static final int SECONDARY = 1;

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/ee/ExecutionEnvironmentConfigurationImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/ee/ExecutionEnvironmentConfigurationImpl.java
@@ -24,7 +24,7 @@ import org.eclipse.tycho.core.shared.BuildFailureException;
 
 public class ExecutionEnvironmentConfigurationImpl implements ExecutionEnvironmentConfiguration {
     // Most likely best to always be the latest known supported EE
-    private static final String DEFAULT_EXECUTION_ENVIRONMENT = "JavaSE-17";
+    private static final String DEFAULT_EXECUTION_ENVIRONMENT = "JavaSE" + Integer.toString(Runtime.version().feature());
 
     private static final int PRIMARY = 0;
     private static final int SECONDARY = 1;


### PR DESCRIPTION
Switching from JavaSE-11 to new JavaSE-17 which is the latest LTS (from September 2021)