### PR TITLE
Throw exception instead of warning for tycho.targetPlatform

### DIFF
--- a/tycho-compiler-plugin/src/test/java/org/eclipse/tycho/osgicompiler/test/OsgiCompilerTest.java
+++ b/tycho-compiler-plugin/src/test/java/org/eclipse/tycho/osgicompiler/test/OsgiCompilerTest.java
@@ -67,7 +67,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void testAccessRestrictionCompilationError() throws Exception {
         File basedir = getBasedir("projects/accessrules");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
 
         try {
             for (MavenProject project : projects) {
@@ -83,7 +83,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void testAccessRulesClasspath() throws Exception {
         File basedir = getBasedir("projects/accessrules");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
 
         getMojo(projects, projects.get(1)).execute();
         getMojo(projects, projects.get(2)).execute();
@@ -157,7 +157,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void test_multisourceP001_viaMojoConfiguration() throws Exception {
         File basedir = getBasedir("projects/multisource/p001");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
 
         MavenProject project = projects.get(0);
         getMojo(projects, project).execute();
@@ -168,7 +168,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void test_multisourceP002_viaBuildProperties() throws Exception {
         File basedir = getBasedir("projects/multisource/p002");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
 
         MavenProject project = projects.get(0);
         getMojo(projects, project).execute();
@@ -179,7 +179,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void test_multipleOutputJars() throws Exception {
         File basedir = getBasedir("projects/multijar");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
 
         MavenProject project = projects.get(0);
         getMojo(projects, project).execute();
@@ -193,7 +193,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void test_multipleOutputJars_getSourcepath() throws Exception {
         File basedir = getBasedir("projects/multijar");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
 
         MavenProject project = projects.get(0);
 
@@ -212,7 +212,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void testCopyResources() throws Exception {
         File basedir = getBasedir("projects/resources/p001");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject project = projects.get(0);
         getMojo(projects, project).execute();
         assertTrue(new File(project.getBasedir(), "target/classes/testresources/Test.class").canRead());
@@ -221,7 +221,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void testCopyResourcesWithNestedJar() throws Exception {
         File basedir = getBasedir("projects/resources/p004");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject project = projects.get(0);
         getMojo(projects, project).execute();
         assertTrue(new File(project.getBasedir(), "target/classes/testresources/Test.class").canRead());
@@ -230,7 +230,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void testExcludeCopyResources() throws Exception {
         File basedir = getBasedir("projects/resources/p002");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject project = projects.get(0);
         getMojo(projects, project).execute();
         assertTrue(new File(project.getBasedir(), "target/classes/testresources/Test.class").canRead());
@@ -239,7 +239,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void testCopyResourcesWithResourceCopyingSetToOff() throws Exception {
         File basedir = getBasedir("projects/resources/p003");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject project = projects.get(0);
         getMojo(projects, project).execute();
         assertTrue(new File(project.getBasedir(), "target/classes/testresources/Test.class").exists());
@@ -248,7 +248,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void testSourceCompileLevel() throws Exception {
         File basedir = getBasedir("projects/executionEnvironment");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject project;
         // project with neither POM nor MANIFEST configuration => must fallback to 
         // source/target level == 11
@@ -293,7 +293,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void testNewerEEthanBREE() throws Exception {
         File basedir = getBasedir("projects/executionEnvironment/p006-newerEEthanBREE");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject project = projects.get(0);
         AbstractOsgiCompilerMojo mojo = getMojo(projects, project);
         mojo.execute();
@@ -306,7 +306,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void testNoBREEButEERequirement() throws Exception {
         File basedir = getBasedir("projects/executionEnvironment/eeAsRequirement");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject project = projects.get(0);
         AbstractOsgiCompilerMojo mojo = getMojo(projects, project);
         StandardExecutionEnvironment[] ees = mojo.getBREE();
@@ -317,7 +317,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
     public void testAutomaticReleaseCompilerArgumentDeterminationDisabled() throws Exception {
         File basedir = getBasedir(
                 "projects/executionEnvironment/p007-automaticReleaseCommpilerArgumentDeterminationDisabled");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject project = projects.get(0);
         AbstractOsgiCompilerMojo mojo = getMojo(projects, project);
         mojo.execute();
@@ -336,7 +336,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void test_TYCHO0400indirectDependencies() throws Exception {
         File basedir = getBasedir("projects/indirectDependencies");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
 
         assertEquals("C", projects.get(1).getArtifactId());
         getMojo(projects, projects.get(1)).execute();
@@ -355,7 +355,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void test_embeddedNonClasspath() throws Exception {
         File basedir = getBasedir("projects/embedednonclasspath");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
 
         MavenProject project = projects.get(0);
         getMojo(projects, project).execute();
@@ -369,7 +369,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void test_bootclasspathAccessRules() throws Exception {
         File basedir = getBasedir("projects/bootclasspath-accessrules");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
 
         MavenProject project = projects.get(0);
         getMojo(projects, project).execute();
@@ -377,7 +377,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void testWarningAndErrorMessages() throws Exception {
         File basedir = getBasedir("projects/compilermessages");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject project = projects.get(0);
         AbstractOsgiCompilerMojo mojo = getMojo(projects, project);
         final List<CharSequence> warnings = new ArrayList<>();
@@ -412,7 +412,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void testCompilerArgs() throws Exception {
         File basedir = getBasedir("projects/compiler-args");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject project = projects.get(0);
         AbstractOsgiCompilerMojo mojo = getMojo(projects, project);
 
@@ -444,7 +444,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
         // the code in the project does use boxing and the settings file 
         // turns on warning for auto boxing so we expect here a warning
         File basedir = getBasedir("projects/projectSettings/p001");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject project = projects.get(0);
         AbstractOsgiCompilerMojo mojo = getMojo(projects, project);
         setVariableValueToObject(mojo, "useProjectSettings", Boolean.TRUE);
@@ -464,7 +464,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void testUseProjectSettingsSetToFalse() throws Exception {
         File basedir = getBasedir("projects/projectSettings/p001");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject project = projects.get(0);
         AbstractOsgiCompilerMojo mojo = getMojo(projects, project);
         setVariableValueToObject(mojo, "useProjectSettings", Boolean.FALSE);
@@ -483,7 +483,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void testUseProjectSettingsSetToTrueWithMissingPrefsFile() throws Exception {
         File basedir = getBasedir("projects/projectSettings/p002");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject project = projects.get(0);
         AbstractOsgiCompilerMojo mojo = getMojo(projects, project);
         setVariableValueToObject(mojo, "useProjectSettings", Boolean.TRUE);
@@ -516,7 +516,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void testBreeCompilerTargetCompatibilityIsChecked() throws Exception {
         File basedir = getBasedir("projects/bree-target-compatibility");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
 
         MavenProject project = projects.get(0);
         try {
@@ -535,7 +535,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void test386210_compilerConfigurationCrosstalk() throws Exception {
         File basedir = getBasedir("projects/crosstalk");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
 
         getMojo(projects, projects.get(1)).execute();
         getMojo(projects, projects.get(2)).execute();
@@ -543,7 +543,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void testCompilerLogWithMultiJarInSingleDirectory() throws Exception {
         File basedir = getBasedir("projects/logs/multiJarSingleDir");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject project = projects.get(0);
         lookupConfiguredMojo(project, "compile").execute();
         assertTrue(new File(basedir, "target/log-dir/@dot.log").canRead());
@@ -552,7 +552,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void testCompilerLogWithMultiJarInSubDirectory() throws Exception {
         File basedir = getBasedir("projects/logs/multiJarMultiDir");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject project = projects.get(0);
         lookupConfiguredMojo(project, "compile").execute();
         assertTrue(new File(basedir, "target/log-dir/@dot.log").canRead());
@@ -561,7 +561,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void testCompilerLogWithSingleJar() throws Exception {
         File basedir = getBasedir("projects/logs/singleJar");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject project = projects.get(0);
         lookupConfiguredMojo(project, "compile").execute();
         assertTrue(new File(basedir, "target/log-dir/@dot.xml").canRead());
@@ -569,7 +569,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void testCompilerLogWithCustomComilerArgs() throws Exception {
         File basedir = getBasedir("projects/logs/customCompilerArgs");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject project = projects.get(0);
         lookupConfiguredMojo(project, "compile").execute();
         assertTrue(new File(basedir, "target/@dot.xml").canRead());
@@ -577,7 +577,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void testCompilerLogWithCustomComilerArgsAndLog() throws Exception {
         File basedir = getBasedir("projects/logs/customCompilerArgsAndLog");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject project = projects.get(0);
         try {
             lookupConfiguredMojo(project, "compile").execute();
@@ -590,7 +590,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void testJreCompilationProfile() throws Exception {
         File basedir = getBasedir("projects/jreCompilationProfile");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject project = projects.get(0);
         AbstractOsgiCompilerMojo mojo = getMojo(Collections.singletonList(project), project);
         mojo.execute();
@@ -601,7 +601,7 @@ public class OsgiCompilerTest extends AbstractTychoMojoTestCase {
 
     public void testUseJDKBREE() throws Exception {
         File basedir = getBasedir("projects/useJDKBREE");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject project = projects.get(0);
         AbstractOsgiCompilerMojo mojo = getMojo(Collections.singletonList(project), project);
         try {

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/AbstractArtifactBasedProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/AbstractArtifactBasedProject.java
@@ -11,11 +11,8 @@
 package org.eclipse.tycho.core.osgitools;
 
 import org.eclipse.tycho.ReactorProject;
-import org.eclipse.tycho.core.ArtifactDependencyVisitor;
 import org.eclipse.tycho.core.ArtifactDependencyWalker;
-import org.eclipse.tycho.core.TargetPlatformConfiguration;
 import org.eclipse.tycho.core.shared.TargetEnvironment;
-import org.eclipse.tycho.core.utils.TychoProjectUtils;
 
 public abstract class AbstractArtifactBasedProject extends AbstractTychoProject {
     // this is stricter than Artifact.SNAPSHOT_VERSION
@@ -32,16 +29,8 @@ public abstract class AbstractArtifactBasedProject extends AbstractTychoProject 
         return newDependencyWalker(project, environment);
     }
 
-    protected abstract ArtifactDependencyWalker newDependencyWalker(ReactorProject project, TargetEnvironment environment);
-
-    @Override
-    public void checkForMissingDependencies(ReactorProject project) {
-        TargetPlatformConfiguration configuration = TychoProjectUtils.getTargetPlatformConfiguration(project);
-
-        // this throws exceptions when dependencies are missing
-        getDependencyWalker(project).walk(new ArtifactDependencyVisitor() {
-        });
-    }
+    protected abstract ArtifactDependencyWalker newDependencyWalker(ReactorProject project,
+            TargetEnvironment environment);
 
     protected String getOsgiVersion(ReactorProject project) {
         String version = project.getVersion();

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/AbstractTychoProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/AbstractTychoProject.java
@@ -23,7 +23,6 @@ import org.eclipse.tycho.core.TargetPlatformConfiguration;
 import org.eclipse.tycho.core.TychoConstants;
 import org.eclipse.tycho.core.TychoProject;
 import org.eclipse.tycho.core.ee.shared.ExecutionEnvironmentConfiguration;
-import org.eclipse.tycho.core.osgitools.targetplatform.LocalDependencyResolver;
 import org.eclipse.tycho.core.osgitools.targetplatform.MultiEnvironmentDependencyArtifacts;
 import org.eclipse.tycho.core.shared.TargetEnvironment;
 import org.eclipse.tycho.core.utils.TychoProjectUtils;
@@ -64,14 +63,6 @@ public abstract class AbstractTychoProject extends AbstractLogEnabled implements
 
     public void setupProject(MavenSession session, MavenProject project) {
         // do nothing by default
-    }
-
-    /**
-     * @deprecated Only needed for {@link LocalDependencyResolver}; p2 resolver checks consistency
-     *             itself
-     */
-    @Deprecated
-    public void checkForMissingDependencies(ReactorProject project) {
     }
 
     protected TargetEnvironment[] getEnvironments(ReactorProject project, TargetEnvironment environment) {

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/targetplatform/EclipseInstallationLayout.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/targetplatform/EclipseInstallationLayout.java
@@ -39,10 +39,11 @@ import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
  * http://mea-bloga.blogspot.com/2008/04/new-target-platform-preference.html
  * 
  * @author igor
- * 
+ * @deprecated only required for {@link LocalDependencyResolver}
  */
 
 @Component(role = EclipseInstallationLayout.class, instantiationStrategy = "per-lookup")
+@Deprecated
 public class EclipseInstallationLayout extends AbstractLogEnabled {
 
     private static final class FEATURE_FILTER implements FileFilter {

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/osgitools/EquinoxResolverTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/osgitools/EquinoxResolverTest.java
@@ -125,7 +125,7 @@ public class EquinoxResolverTest extends AbstractTychoMojoTestCase {
         Properties properties = new Properties();
         properties.put("tycho-version", TychoVersion.getTychoVersion());
 
-        List<MavenProject> projects = getSortedProjects(basedir, properties, null);
+        List<MavenProject> projects = getSortedProjects(basedir, properties);
         assertEquals(1, projects.size());
 
         return projects.get(0);

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/test/DependencyComputerTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/test/DependencyComputerTest.java
@@ -73,7 +73,7 @@ public class DependencyComputerTest extends AbstractTychoMojoTestCase {
     public void testExportPackage() throws Exception {
         File basedir = getBasedir("projects/exportpackage");
 
-        Map<File, MavenProject> basedirMap = MavenSessionUtils.getBasedirMap(getSortedProjects(basedir, null));
+        Map<File, MavenProject> basedirMap = MavenSessionUtils.getBasedirMap(getSortedProjects(basedir));
 
         MavenProject project = basedirMap.get(new File(basedir, "bundle"));
         ReactorProject reactorProject = DefaultReactorProject.adapt(project);
@@ -109,7 +109,7 @@ public class DependencyComputerTest extends AbstractTychoMojoTestCase {
     public void testWiringToPackageFromCustomProfile() throws Exception {
         File basedir = getBasedir("projects/customProfile");
 
-        Map<File, MavenProject> basedirMap = MavenSessionUtils.getBasedirMap(getSortedProjects(basedir, null));
+        Map<File, MavenProject> basedirMap = MavenSessionUtils.getBasedirMap(getSortedProjects(basedir));
 
         MavenProject project = basedirMap.get(new File(basedir, "bundle"));
         ReactorProject reactorProject = DefaultReactorProject.adapt(project);
@@ -179,7 +179,7 @@ public class DependencyComputerTest extends AbstractTychoMojoTestCase {
     @Test
     public void testAccessRules() throws Exception {
         File basedir = getBasedir("projects/accessrules");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject project = projects.get(4);
         assertEquals("p002", project.getName());
         List<DependencyEntry> dependencies = computeDependencies(project);
@@ -192,7 +192,7 @@ public class DependencyComputerTest extends AbstractTychoMojoTestCase {
     @Test
     public void testReexportAccessRules() throws Exception {
         File basedir = getBasedir("projects/reexport");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject project = projects.get(4);
         assertEquals("p002", project.getName());
         List<DependencyEntry> dependencies = computeDependencies(project);
@@ -206,7 +206,7 @@ public class DependencyComputerTest extends AbstractTychoMojoTestCase {
     @Test
     public void testFragments() throws Exception {
         File basedir = getBasedir("projects/eeProfile.resolution.fragments");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject jface = projects.get(3);
         assertEquals("org.eclipse.jface.databinding", jface.getArtifactId());
         Collection<DependencyEntry> deps = computeDependenciesIgnoringEE(jface);
@@ -221,7 +221,7 @@ public class DependencyComputerTest extends AbstractTychoMojoTestCase {
     @Test
     public void testFragmentsImportClassProvidedByFragmentFromPackageExportedByHost() throws Exception {
         File basedir = getBasedir("projects/fragment-import-class-provided-by-fragment-from-package-exported-by-host");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject bundle2 = projects.get(2);
         assertEquals("bundle2", bundle2.getArtifactId());
         Collection<DependencyEntry> deps = computeDependenciesIgnoringEE(bundle2);
@@ -235,7 +235,7 @@ public class DependencyComputerTest extends AbstractTychoMojoTestCase {
     @Test
     public void testFragmentSplitPackage() throws Exception {
         File basedir = getBasedir("projects/fragment-split-package");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject bundleTest = projects.get(3);
         assertEquals("bundle.tests", bundleTest.getArtifactId());
         Collection<DependencyEntry> deps = computeDependencies(bundleTest);
@@ -256,7 +256,7 @@ public class DependencyComputerTest extends AbstractTychoMojoTestCase {
     @Test
     public void testFragmentSplitPackageMandatory() throws Exception {
         File basedir = getBasedir("projects/fragment-split-mandatory");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject bundleTest = projects.get(3);
         assertEquals("bundle.tests", bundleTest.getArtifactId());
         Collection<DependencyEntry> deps = computeDependencies(bundleTest);
@@ -277,7 +277,7 @@ public class DependencyComputerTest extends AbstractTychoMojoTestCase {
     @Test
     public void testImportVsRequire() throws Exception {
         File basedir = getBasedir("projects/importVsRequire");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject bundleTest = projects.get(2);
         assertEquals("A", bundleTest.getArtifactId());
         Collection<DependencyEntry> deps = computeDependencies(bundleTest);
@@ -293,7 +293,7 @@ public class DependencyComputerTest extends AbstractTychoMojoTestCase {
     @Test
     public void testDeepReexportBundle() throws Exception {
         File basedir = getBasedir("projects/deepReexport");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject bundleTest = projects.get(4);
         assertEquals("D", bundleTest.getArtifactId());
         Collection<DependencyEntry> deps = computeDependencies(bundleTest);

--- a/tycho-extras/tycho-p2-extras-plugin/src/test/java/org/eclipse/tycho/plugins/p2/extras/MirrorMojoTest.java
+++ b/tycho-extras/tycho-p2-extras-plugin/src/test/java/org/eclipse/tycho/plugins/p2/extras/MirrorMojoTest.java
@@ -42,7 +42,7 @@ public class MirrorMojoTest extends AbstractTychoMojoTestCase {
     protected void setUp() throws Exception {
         super.setUp();
         File basedir = getBasedir("mirroring/testProject");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject project = projects.get(0);
         initLegacySupport(projects, project);
         mirrorDestinationDir = new File(project.getFile().getParent(), "target/repository").getCanonicalFile();

--- a/tycho-extras/tycho-p2-extras-plugin/src/test/java/org/eclipse/tycho/plugins/p2/extras/PublishFeaturesAndBundlesMojoTest.java
+++ b/tycho-extras/tycho-p2-extras-plugin/src/test/java/org/eclipse/tycho/plugins/p2/extras/PublishFeaturesAndBundlesMojoTest.java
@@ -41,7 +41,7 @@ public class PublishFeaturesAndBundlesMojoTest extends AbstractTychoMojoTestCase
 
     public void testPublisher() throws Exception {
         File basedir = getBasedir("publisher/testProject");
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+        List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject project = projects.get(0);
 
         initLegacySupport(projects, project);

--- a/tycho-its/projects/TYCHO418pomDependencyConsider/pom.xml
+++ b/tycho-its/projects/TYCHO418pomDependencyConsider/pom.xml
@@ -7,7 +7,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho.targetPlatform>${java.io.tmpdir}</tycho.targetPlatform>
+		<tycho.version>2.7.0-SNAPSHOT</tycho.version>
 	</properties>
 
 	<modules>
@@ -38,7 +38,6 @@
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
-					<resolver>local</resolver>
 					<pomDependencies>consider</pomDependencies>
 				</configuration>
 			</plugin>

--- a/tycho-packaging-plugin/src/test/java/org/eclipse/tycho/buildnumber/test/PackagePluginMojoTest.java
+++ b/tycho-packaging-plugin/src/test/java/org/eclipse/tycho/buildnumber/test/PackagePluginMojoTest.java
@@ -127,7 +127,7 @@ public class PackagePluginMojoTest extends AbstractTychoMojoTestCase {
     }
 
     private PackagePluginMojo execMaven(File basedir) throws Exception {
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+		List<MavenProject> projects = getSortedProjects(basedir);
         MavenProject project = projects.get(0);
         MavenSession session = newMavenSession(project, projects);
 

--- a/tycho-packaging-plugin/src/test/java/org/eclipse/tycho/buildversion/BuildQualifierTest.java
+++ b/tycho-packaging-plugin/src/test/java/org/eclipse/tycho/buildversion/BuildQualifierTest.java
@@ -150,7 +150,7 @@ public class BuildQualifierTest extends AbstractTychoMojoTestCase {
     public void testStableQualifier() throws Exception {
         File basedir = getBasedir("projects/stablebuildqualifier/basic");
 
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+		List<MavenProject> projects = getSortedProjects(basedir);
         MavenSession session = newMavenSession(projects.get(0), projects);
 
         executeMojo(session, getProject(projects, "bundle01"));
@@ -174,7 +174,7 @@ public class BuildQualifierTest extends AbstractTychoMojoTestCase {
     public void testUnparsableIncludedArtifactQualifier() throws Exception {
         File basedir = getBasedir("projects/stablebuildqualifier/unpasablequalifier");
 
-        List<MavenProject> projects = getSortedProjects(basedir, null);
+		List<MavenProject> projects = getSortedProjects(basedir);
         MavenSession session = newMavenSession(projects.get(0), projects);
 
         executeMojo(session, getProject(projects, "bundle"));

--- a/tycho-testing-harness/src/main/java/org/eclipse/tycho/testing/AbstractTychoMojoTestCase.java
+++ b/tycho-testing-harness/src/main/java/org/eclipse/tycho/testing/AbstractTychoMojoTestCase.java
@@ -118,13 +118,19 @@ public class AbstractTychoMojoTestCase extends AbstractMojoTestCase {
     }
 
     protected List<MavenProject> getSortedProjects(File basedir) throws Exception {
-        return getSortedProjects(basedir, null);
+        return getSortedProjects(basedir, null, null);
     }
 
+    @Deprecated
     protected List<MavenProject> getSortedProjects(File basedir, File platform) throws Exception {
         return getSortedProjects(basedir, null, platform);
     }
 
+    protected List<MavenProject> getSortedProjects(File basedir, Properties userProperties) throws Exception {
+        return getSortedProjects(basedir, userProperties, null);
+    }
+
+    @Deprecated
     protected List<MavenProject> getSortedProjects(File basedir, Properties userProperties, File platform)
             throws Exception {
         File pom = new File(basedir, "pom.xml");
@@ -132,7 +138,7 @@ public class AbstractTychoMojoTestCase extends AbstractMojoTestCase {
         request.getProjectBuildingRequest().setProcessPlugins(false);
         request.setLocalRepository(getLocalRepository());
         if (platform != null) {
-            request.getUserProperties().put("tycho.targetPlatform", platform.getAbsolutePath());
+            request.getUserProperties().put("tycho.test.targetPlatform", platform.getAbsolutePath());
         }
         if (userProperties != null) {
             request.getUserProperties().putAll(userProperties);


### PR DESCRIPTION
This throws an error instead of print a warning and shows that some tests in Tycho still depend on the deprecated property.

I tried to move the stuff to test see https://github.com/laeubi/tycho/tree/486_move_to_test and poked around a bit with the test but can't get it to work. If you have an idea how to fix certain tests that would be appreciated.

Just keep in mind that `MavenDependencyCollector` and `EclipseInstallationLayout` also are eligible for removal as they are only required by the Local resolver, so any tests that fail for that classes could safely be ignored...