### PR TITLE
Add commons-lang3 dep to tycho-p2-plugin

### DIFF
--- a/tycho-p2/tycho-p2-plugin/pom.xml
+++ b/tycho-p2/tycho-p2-plugin/pom.xml
@@ -53,7 +53,11 @@
             <artifactId>tycho-artifactcomparator</artifactId>
             <version>${project.version}</version>
         </dependency>
-
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-lang3</artifactId>
+		    <version>3.12.0</version>
+		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>


### PR DESCRIPTION
Fixes https://bugs.eclipse.org/bugs/show_bug.cgi?id=578172 where build
fails with:
19:58:06  [ERROR] Failed to execute goal
org.eclipse.tycho:tycho-p2-plugin:2.7.0-SNAPSHOT:p2-metadata
(p2-metadata) on project org.eclipse.test.performance: Execution
p2-metadata of goal
org.eclipse.tycho:tycho-p2-plugin:2.7.0-SNAPSHOT:p2-metadata failed: A
required class was missing while executing
org.eclipse.tycho:tycho-p2-plugin:2.7.0-SNAPSHOT:p2-metadata:
org/apache/commons/lang3/reflect/MethodUtils

Caused by commons-lang3 being there at compile time as it's transitive
dep of maven bits which insist to be in provided scope so to decouple
what maven uses from leaking into dependencies as in this case.