### PR TITLE
Add generic tycho-build core extension

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,33 @@ This page describes the noteworthy improvements provided by each release of Ecli
 
 ## 2.7.0 (under development)
 
+### Tycho-Pomless will become a tycho-core extension
+
+Tycho pomless has started as a small experiment in tycho-extras. Over time it has grown to a fully-fledged solution to build pde-based artifacts with less effort and nearly zero additional configuration.
+
+Neverless, the name "pomless" was always a bit misleading, as actually we have reduced the number required poms to one 'main-pom' it is still not pomless and actually allows poms to be used where suitable.
+Because of this, an to not limit the usage to "pomless" with this version a new core-extension is available name 'tycho-build', that effectively does what tycho-extras-pomless does but in the context of 'core' and is open to further improvements 
+(maybe some time offering an option to not needing a pom at all).
+
+All that needs to be done is replace the old 
+```
+<extension>
+	<groupId>org.eclipse.tycho.extras</groupId>
+	<artifactId>tycho-pomless</artifactId>
+	<version>2.7.0</version>
+</extension>
+```
+
+with
+
+```
+<extension>
+	<groupId>org.eclipse.tycho</groupId>
+	<artifactId>tycho-build</artifactId>
+	<version>2.7.0</version>
+</extension>
+```
+
 ### Mixed reactor build support
 
 previously Tycho has resolved pom considered depdencies as part of the inital maven setup (before the actual build starts). This has lead to the fact that it was not possible to mix projects that e.g. dynamically generate a manifest.

--- a/pom.xml
+++ b/pom.xml
@@ -493,6 +493,7 @@
 
 		<module>tycho-gpg-plugin</module>
 		<module>tycho-extras</module>
+		<module>tycho-build</module>
 	</modules>
 
 	<profiles>
@@ -500,6 +501,7 @@
 			<id>its</id>
 			<modules>
 				<module>tycho-its</module>
+				<module>tycho-extras/tycho-extras-its</module>
 			</modules>
 		</profile>
 		<profile>

--- a/tycho-build/pom.xml
+++ b/tycho-build/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.tycho</groupId>
+		<artifactId>tycho</artifactId>
+		<version>2.7.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>tycho-build</artifactId>
+
+	<build>
+
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.plexus</groupId>
+				<artifactId>plexus-component-metadata</artifactId>
+			</plugin>
+
+		</plugins>
+	</build>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.codehaus.plexus</groupId>
+			<artifactId>plexus-utils</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.eclipse.tycho.extras</groupId>
+			<artifactId>tycho-pomless</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-model</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-model-builder</artifactId>
+			<version>${maven-version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-core</artifactId>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/tycho-extras/pom.xml
+++ b/tycho-extras/pom.xml
@@ -193,12 +193,6 @@
 
 	<profiles>
 		<profile>
-			<id>its</id>
-			<modules>
-				<module>tycho-extras-its</module>
-			</modules>
-		</profile>
-		<profile>
     		<id>pack200</id>
     		<activation>
         		<jdk>(,13]</jdk>

--- a/tycho-extras/tycho-extras-its/src/test/resources/testpomless-flat/.mvn/extensions.xml
+++ b/tycho-extras/tycho-extras-its/src/test/resources/testpomless-flat/.mvn/extensions.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extensions>
   <extension>
-    <groupId>org.eclipse.tycho.extras</groupId>
-    <artifactId>tycho-pomless</artifactId>
+    <groupId>org.eclipse.tycho</groupId>
+	<artifactId>tycho-build</artifactId>
     <version>${tycho-version}</version>
   </extension>
 </extensions>

--- a/tycho-extras/tycho-extras-its/src/test/resources/testpomless-structured/.mvn/extensions.xml
+++ b/tycho-extras/tycho-extras-its/src/test/resources/testpomless-structured/.mvn/extensions.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extensions>
   <extension>
-    <groupId>org.eclipse.tycho.extras</groupId>
-    <artifactId>tycho-pomless</artifactId>
+    <groupId>org.eclipse.tycho</groupId>
+	<artifactId>tycho-build</artifactId>
     <version>${tycho-version}</version>
   </extension>
 </extensions>

--- a/tycho-extras/tycho-extras-its/src/test/resources/testpomless/.mvn/extensions.xml
+++ b/tycho-extras/tycho-extras-its/src/test/resources/testpomless/.mvn/extensions.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extensions>
   <extension>
-    <groupId>org.eclipse.tycho.extras</groupId>
-    <artifactId>tycho-pomless</artifactId>
+	<groupId>org.eclipse.tycho</groupId>
+	<artifactId>tycho-build</artifactId>
     <version>${tycho-version}</version>
   </extension>
 </extensions>

--- a/tycho-extras/tycho-extras-its/src/test/resources/testsetversionpomless/.mvn/extensions.xml
+++ b/tycho-extras/tycho-extras-its/src/test/resources/testsetversionpomless/.mvn/extensions.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extensions>
   <extension>
-    <groupId>org.eclipse.tycho.extras</groupId>
-    <artifactId>tycho-pomless</artifactId>
+    <groupId>org.eclipse.tycho</groupId>
+	<artifactId>tycho-build</artifactId>
     <version>${tycho-version}</version>
   </extension>
 </extensions>

--- a/tycho-extras/tycho-pomless/pom.xml
+++ b/tycho-extras/tycho-pomless/pom.xml
@@ -69,6 +69,12 @@
       <artifactId>maven-core</artifactId>
       <scope>provided</scope>
     </dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-embedder</artifactId>
+			<version>${maven-version}</version>
+			<scope>provided</scope>
+		</dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoPomlessLifecycleParticipant.java
+++ b/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoPomlessLifecycleParticipant.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * 
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Christoph Läubrich - initial API and implementation
+ *  
+ *******************************************************************************/
+package org.eclipse.tycho.pomless;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import org.apache.maven.AbstractMavenLifecycleParticipant;
+import org.apache.maven.MavenExecutionException;
+import org.apache.maven.cli.internal.extension.model.CoreExtension;
+import org.apache.maven.cli.internal.extension.model.io.xpp3.CoreExtensionsXpp3Reader;
+import org.apache.maven.execution.MavenSession;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
+@Component(role = AbstractMavenLifecycleParticipant.class, hint = "TychoPomlessLifecycleParticipant")
+public class TychoPomlessLifecycleParticipant extends AbstractMavenLifecycleParticipant {
+
+    @Requirement
+    protected Logger logger;
+
+    @Override
+    public void afterSessionStart(MavenSession session) throws MavenExecutionException {
+        session.getUserProperties().setProperty("tycho.mode", "extension");
+        File moduleProjectDirectory = session.getRequest().getMultiModuleProjectDirectory();
+        if (moduleProjectDirectory != null) {
+            File extensionsFile = new File(moduleProjectDirectory, ".mvn/extensions.xml");
+            CoreExtensionsXpp3Reader parser = new CoreExtensionsXpp3Reader();
+            try (InputStream is = new BufferedInputStream(new FileInputStream(extensionsFile))) {
+                List<CoreExtension> extensions = parser.read(is).getExtensions();
+                for (CoreExtension coreExtension : extensions) {
+                    if ("org.eclipse.tycho.extras".equals(coreExtension.getGroupId())
+                            && "tycho-pomless".equals(coreExtension.getArtifactId())) {
+                        logger.warn(
+                                "org.eclipse.tycho.extras:tycho-pomless build extension will be replaced in a future version of Tycho by the new org.eclipse.tycho:tycho-build extension.");
+                        logger.warn(
+                                "You can simply change your .mvn/extensions.xml to reference the new extension right now:");
+                        logger.warn("<extension>");
+                        logger.warn("   <groupId>org.eclipse.tycho</groupId>");
+                        logger.warn("   <artifactId>tycho-build</artifactId>");
+                        logger.warn("   <version>" + coreExtension.getVersion() + "</version>");
+                        logger.warn("</extension>");
+                        break;
+                    }
+                }
+
+            } catch (IOException | XmlPullParserException e) {
+                // //don't care, we just wan't to inform the user...
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Issue #556 add a tycho-core-extension including pomless
- Issue #148 add a hint to the user to migrate to the generic extension
- Update integration tests to use the new tycho-core-extension

This does not change anything deep inside but prepares the move of tycho-pomless into tycho-core and will allow us to add maven-core extensions (of whatever kind) in a generic way.