### PR TITLE
Support Maven option --also-make-dependents, and --resume-from for project dependency resolution

### DIFF
--- a/tycho-build/pom.xml
+++ b/tycho-build/pom.xml
@@ -31,6 +31,84 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.eclipse.tycho</groupId>
+			<artifactId>org.eclipse.tycho.core.shared</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.tycho</groupId>
+			<artifactId>org.eclipse.tycho.p2.maven.repository</artifactId>
+			<version>2.7.0-SNAPSHOT</version>
+		</dependency>
+		<!--
+		<dependency>
+			<groupId>org.eclipse.tycho</groupId>
+			<artifactId>tycho-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+-->
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.equinox.p2.core</artifactId>
+			<version>2.6.100</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.osgi</artifactId>
+			<version>3.17.100</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.equinox.p2.publisher</artifactId>
+			<version>1.6.200</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.equinox.p2.director</artifactId>
+			<version>2.5.100</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.equinox.p2.engine</artifactId>
+			<version>2.7.200</version>
+		</dependency>
+
+
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.equinox.p2.metadata</artifactId>
+			<version>2.6.100</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.equinox.p2.repository</artifactId>
+			<version>2.5.300</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.osgi.compatibility.state</artifactId>
+			<version>1.2.500</version>
+		</dependency>
+
+
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.equinox.p2.publisher.eclipse</artifactId>
+			<version>1.4.1</version>
+		</dependency>
+
+
+		<dependency>
+			<groupId>org.eclipse.sisu</groupId>
+			<artifactId>org.eclipse.sisu.plexus</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-model</artifactId>
 			<scope>provided</scope>
@@ -46,5 +124,24 @@
 			<artifactId>maven-core</artifactId>
 			<scope>provided</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.eclipse.tycho</groupId>
+			<artifactId>org.eclipse.tycho.p2.resolver.impl</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.tycho</groupId>
+			<artifactId>org.eclipse.tycho.p2.maven.repository</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.equinox.p2.metadata.repository</artifactId>
+			<version>1.4.0</version>
+		</dependency>
+
+
 	</dependencies>
 </project>

--- a/tycho-build/src/main/java/org/eclipse/tycho/build/MavenLoggerAdapter.java
+++ b/tycho-build/src/main/java/org/eclipse/tycho/build/MavenLoggerAdapter.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2022 SAP AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    SAP AG - initial API and implementation
+ *    Christoph Läubrich - #225 MavenLogger is missing error method that accepts an exception
+ *******************************************************************************/
+package org.eclipse.tycho.build;
+
+import org.codehaus.plexus.logging.Logger;
+import org.eclipse.tycho.core.shared.MavenLogger;
+
+public class MavenLoggerAdapter implements MavenLogger {
+
+	private final Logger logger;
+	private final boolean extendedDebug;
+
+	public MavenLoggerAdapter(Logger logger, boolean extendedDebug) {
+		this.logger = logger;
+		this.extendedDebug = extendedDebug;
+	}
+
+	@Override
+	public void debug(String message) {
+		if (logger.isDebugEnabled()) {
+			logger.debug(message);
+		} else if (isExtendedDebugEnabled()) {
+			logger.info(message);
+		}
+	}
+
+	@Override
+	public void debug(String message, Throwable cause) {
+		if (logger.isDebugEnabled()) {
+			logger.debug(message, cause);
+		} else if (isExtendedDebugEnabled()) {
+			logger.info(message, cause);
+		}
+	}
+
+	@Override
+	public void info(String message) {
+		logger.info(message);
+	}
+
+	@Override
+	public void warn(String message) {
+		warn(message, null);
+	}
+
+	@Override
+	public void warn(String message, Throwable cause) {
+		logger.warn(message, cause);
+	}
+
+	@Override
+	public void error(String message, Throwable cause) {
+		logger.error(message, cause);
+	}
+
+	@Override
+	public void error(String message) {
+		logger.error(message);
+	}
+
+	@Override
+	public boolean isDebugEnabled() {
+		return logger.isDebugEnabled() || isExtendedDebugEnabled();
+	}
+
+	@Override
+	public boolean isExtendedDebugEnabled() {
+		return extendedDebug;
+	}
+
+	private boolean isEmpty(String message) {
+		return message == null || message.isEmpty();
+	}
+}

--- a/tycho-build/src/main/java/org/eclipse/tycho/build/PlexusBundleContext.java
+++ b/tycho-build/src/main/java/org/eclipse/tycho/build/PlexusBundleContext.java
@@ -1,0 +1,181 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.build;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Dictionary;
+
+import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.osgi.internal.framework.FilterImpl;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.BundleListener;
+import org.osgi.framework.Filter;
+import org.osgi.framework.FrameworkListener;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceFactory;
+import org.osgi.framework.ServiceListener;
+import org.osgi.framework.ServiceObjects;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
+
+//FIXME this should not be necessary at all see https://bugs.eclipse.org/bugs/show_bug.cgi?id=578387
+@Component(role = BundleContext.class, hint = "plexus")
+public class PlexusBundleContext implements BundleContext {
+
+	@Override
+	public String getProperty(String key) {
+		return System.getProperty(key);
+	}
+
+	@Override
+	public Bundle getBundle() {
+		throw new IllegalStateException("this is not OSGi!");
+	}
+
+	@Override
+	public Bundle installBundle(String location, InputStream input) throws BundleException {
+		throw new BundleException("this context does not support installations");
+	}
+
+	@Override
+	public Bundle installBundle(String location) throws BundleException {
+		throw new BundleException("this context does not support installations");
+	}
+
+	@Override
+	public Bundle getBundle(long id) {
+		return getBundle();
+	}
+
+	@Override
+	public Bundle[] getBundles() {
+		return new Bundle[0];
+	}
+
+	@Override
+	public void addServiceListener(ServiceListener listener, String filter) throws InvalidSyntaxException {
+
+	}
+
+	@Override
+	public void addServiceListener(ServiceListener listener) {
+
+	}
+
+	@Override
+	public void removeServiceListener(ServiceListener listener) {
+
+	}
+
+	@Override
+	public void addBundleListener(BundleListener listener) {
+
+	}
+
+	@Override
+	public void removeBundleListener(BundleListener listener) {
+
+	}
+
+	@Override
+	public void addFrameworkListener(FrameworkListener listener) {
+
+	}
+
+	@Override
+	public void removeFrameworkListener(FrameworkListener listener) {
+
+	}
+
+	@Override
+	public ServiceRegistration<?> registerService(String[] clazzes, Object service, Dictionary<String, ?> properties) {
+		throw new IllegalStateException("this is not OSGi!");
+	}
+
+	@Override
+	public ServiceRegistration<?> registerService(String clazz, Object service, Dictionary<String, ?> properties) {
+		throw new IllegalStateException("this is not OSGi!");
+	}
+
+	@Override
+	public <S> ServiceRegistration<S> registerService(Class<S> clazz, S service, Dictionary<String, ?> properties) {
+		throw new IllegalStateException("this is not OSGi!");
+	}
+
+	@Override
+	public <S> ServiceRegistration<S> registerService(Class<S> clazz, ServiceFactory<S> factory,
+			Dictionary<String, ?> properties) {
+		throw new IllegalStateException("this is not OSGi!");
+	}
+
+	@Override
+	public ServiceReference<?>[] getServiceReferences(String clazz, String filter) throws InvalidSyntaxException {
+		throw new IllegalStateException("this is not OSGi!");
+	}
+
+	@Override
+	public ServiceReference<?>[] getAllServiceReferences(String clazz, String filter) throws InvalidSyntaxException {
+		throw new IllegalStateException("this is not OSGi!");
+	}
+
+	@Override
+	public ServiceReference<?> getServiceReference(String clazz) {
+		throw new IllegalStateException("this is not OSGi!");
+	}
+
+	@Override
+	public <S> ServiceReference<S> getServiceReference(Class<S> clazz) {
+		throw new IllegalStateException("this is not OSGi!");
+	}
+
+	@Override
+	public <S> Collection<ServiceReference<S>> getServiceReferences(Class<S> clazz, String filter)
+			throws InvalidSyntaxException {
+		throw new IllegalStateException("this is not OSGi!");
+	}
+
+	@Override
+	public <S> S getService(ServiceReference<S> reference) {
+		throw new IllegalStateException("this is not OSGi!");
+	}
+
+	@Override
+	public boolean ungetService(ServiceReference<?> reference) {
+		return true;
+	}
+
+	@Override
+	public <S> ServiceObjects<S> getServiceObjects(ServiceReference<S> reference) {
+		throw new IllegalStateException("this is not OSGi!");
+	}
+
+	@Override
+	public File getDataFile(String filename) {
+		return null;
+	}
+
+	@Override
+	public Filter createFilter(String filter) throws InvalidSyntaxException {
+		return FilterImpl.newInstance(filter);
+	}
+
+	@Override
+	public Bundle getBundle(String location) {
+		return getBundle();
+	}
+
+}

--- a/tycho-build/src/main/java/org/eclipse/tycho/build/TychoGraphBuilder.java
+++ b/tycho-build/src/main/java/org/eclipse/tycho/build/TychoGraphBuilder.java
@@ -1,0 +1,366 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Christoph Läubrich and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation based on 
+ *    		org.eclipse.tycho.p2.util.resolution.AbstractSlicerResolutionStrategy
+ *    		org.eclipse.tycho.p2.util.resolution.ProjectorResolutionStrategy
+ *******************************************************************************/
+package org.eclipse.tycho.build;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Future;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.execution.ProjectDependencyGraph;
+import org.apache.maven.graph.DefaultGraphBuilder;
+import org.apache.maven.graph.DefaultProjectDependencyGraph;
+import org.apache.maven.graph.GraphBuilder;
+import org.apache.maven.model.building.DefaultModelProblem;
+import org.apache.maven.model.building.ModelProblem;
+import org.apache.maven.model.building.ModelProblem.Severity;
+import org.apache.maven.model.building.Result;
+import org.apache.maven.project.DuplicateProjectException;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.util.dag.CycleDetectedException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.equinox.internal.p2.director.DirectorActivator;
+import org.eclipse.equinox.internal.p2.publisher.eclipse.FeatureParser;
+import org.eclipse.equinox.p2.metadata.IArtifactKey;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.publisher.IPublisherInfo;
+import org.eclipse.equinox.p2.publisher.PublisherInfo;
+import org.eclipse.equinox.p2.publisher.PublisherResult;
+import org.eclipse.equinox.p2.publisher.eclipse.BundlesAction;
+import org.eclipse.equinox.p2.publisher.eclipse.Feature;
+import org.eclipse.equinox.p2.publisher.eclipse.FeaturesAction;
+import org.eclipse.equinox.p2.query.QueryUtil;
+import org.eclipse.osgi.service.resolver.BundleDescription;
+import org.eclipse.tycho.core.shared.MavenLogger;
+import org.eclipse.tycho.p2.target.ee.NoExecutionEnvironmentResolutionHints;
+import org.eclipse.tycho.p2.util.resolution.ProjectorResolutionStrategy;
+import org.eclipse.tycho.p2.util.resolution.ResolutionDataImpl;
+import org.eclipse.tycho.p2.util.resolution.ResolverException;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
+
+@Component(role = GraphBuilder.class, hint = GraphBuilder.HINT)
+public class TychoGraphBuilder extends DefaultGraphBuilder {
+
+	public static final String TYPE_ECLIPSE_PLUGIN = "eclipse-plugin";
+	public static final String TYPE_ECLIPSE_TEST_PLUGIN = "eclipse-test-plugin";
+	public static final String TYPE_ECLIPSE_FEATURE = "eclipse-feature";
+	public static final String TYPE_ECLIPSE_REPOSITORY = "eclipse-repository";
+	public static final String TYPE_ECLIPSE_TARGET_DEFINITION = "eclipse-target-definition";
+
+	@Requirement
+	private Logger log;
+
+	@Requirement(hint = "plexus")
+	private BundleContext bundleContext;
+
+	@Override
+	public Result<ProjectDependencyGraph> build(MavenSession session) {
+		MavenExecutionRequest request = session.getRequest();
+		ProjectDependencyGraph dependencyGraph = session.getProjectDependencyGraph();
+		Result<ProjectDependencyGraph> graphResult = super.build(session);
+		if (dependencyGraph != null || graphResult.hasErrors()) {
+			// on second pass nothing to do for tycho, or already error ...
+			return graphResult;
+		}
+		session.getUserProperties().put("tycho.mode", "extension");
+		MavenLogger loggerAdapter = new MavenLoggerAdapter(log,
+				Boolean.valueOf(session.getUserProperties().getProperty("tycho.debug.resolver")));
+		String makeBehavior = request.getMakeBehavior();
+		if (loggerAdapter.isExtendedDebugEnabled()) {
+			loggerAdapter.debug("TychoGraphBuilder:");
+			loggerAdapter.debug("  - SelectedProjects: " + request.getSelectedProjects());
+			loggerAdapter.debug("  - ExcludedProjects: " + request.getExcludedProjects());
+			loggerAdapter.debug("  - MakeBehavior:     " + makeBehavior);
+		}
+		boolean makeUpstream = MavenExecutionRequest.REACTOR_MAKE_UPSTREAM.equals(makeBehavior)
+				|| MavenExecutionRequest.REACTOR_MAKE_BOTH.equals(makeBehavior);
+		boolean makeDownstream = MavenExecutionRequest.REACTOR_MAKE_DOWNSTREAM.equals(makeBehavior)
+				|| MavenExecutionRequest.REACTOR_MAKE_BOTH.equals(makeBehavior);
+		if (!makeDownstream && !makeUpstream) {
+			// just like default...
+			return graphResult;
+		}
+		if (DirectorActivator.context == null) {
+			DirectorActivator.context = bundleContext;
+		}
+		ProjectDependencyGraph graph = graphResult.get();
+		List<MavenProject> projects = graph.getAllProjects();
+		List<ModelProblem> problems = new CopyOnWriteArrayList<>();
+		int degreeOfConcurrency = request.getDegreeOfConcurrency();
+		boolean failFast = MavenExecutionRequest.REACTOR_FAIL_FAST.equals(request.getReactorFailureBehavior());
+		Optional<ExecutorService> executor;
+		if (degreeOfConcurrency > 1) {
+			executor = Optional.of(new ForkJoinPool(degreeOfConcurrency));
+		} else {
+			executor = Optional.empty();
+		}
+		BooleanSupplier hasFailures = () -> failFast && !problems.isEmpty();
+		Set<MavenProject> selectedProjects = ConcurrentHashMap.newKeySet();
+		try {
+			Map<MavenProject, Collection<IInstallableUnit>> projectIUMap = new ConcurrentHashMap<>();
+			try {
+				var projectUnits = computeProjectUnits(problems);
+				runStream(projects.stream(), p -> projectIUMap.put(p, projectUnits.apply(p)), hasFailures, executor);
+			} catch (ExecutionException e) {
+				log.error("Can't read projects", e);
+				return Result.error(graph);
+			}
+			Map<MavenProject, Collection<IInstallableUnit>> projectDependenciesMap = new ConcurrentHashMap<MavenProject, Collection<IInstallableUnit>>();
+			try {
+				Collection<IInstallableUnit> availableIUs = projectIUMap.values().stream().flatMap(Collection::stream)
+						.collect(Collectors.toSet());
+				var projectDependencies = computeProjectDependencies(availableIUs, problems, loggerAdapter);
+				runStream(projectIUMap.entrySet().stream(),
+						entry -> projectDependenciesMap.put(entry.getKey(), projectDependencies.apply(entry)),
+						hasFailures, executor);
+			} catch (ExecutionException e) {
+				log.error("Can't resolve projects", e);
+				return Result.error(graph);
+			}
+			if (hasFailures.getAsBoolean()) {
+				if (loggerAdapter.isExtendedDebugEnabled()) {
+					for (ModelProblem modelProblem : problems) {
+						loggerAdapter.error(modelProblem.getMessage(), modelProblem.getException());
+					}
+				}
+				return Result.error(graph, problems);
+			}
+			Map<IInstallableUnit, MavenProject> iuProjectMap = new HashMap<IInstallableUnit, MavenProject>();
+			for (var entry : projectIUMap.entrySet()) {
+				MavenProject mavenProject = entry.getKey();
+				for (IInstallableUnit iu : entry.getValue()) {
+					iuProjectMap.put(iu, mavenProject);
+				}
+			}
+			if (loggerAdapter.isExtendedDebugEnabled()) {
+				for (Entry<MavenProject, Collection<IInstallableUnit>> entry : projectDependenciesMap.entrySet()) {
+					MavenProject project = entry.getKey();
+					Collection<IInstallableUnit> depends = entry.getValue();
+					if (depends.isEmpty()) {
+						continue;
+					}
+					loggerAdapter.debug("[[ project " + project.getName() + " depends on: ]]");
+					for (IInstallableUnit dependency : depends) {
+						MavenProject mavenProject = iuProjectMap.get(dependency);
+						if (mavenProject == null) {
+							loggerAdapter.debug(" IU: " + dependency);
+						} else {
+							loggerAdapter.debug(" IU: " + dependency + " [of project " + mavenProject.getName() + "]");
+						}
+					}
+				}
+			}
+			Queue<ProjectRequest> queue = new ConcurrentLinkedQueue<>(graph.getSortedProjects().stream()
+					.map(p -> new ProjectRequest(p, makeDownstream, makeUpstream, null)).collect(Collectors.toList()));
+			loggerAdapter.debug("Computing additional " + makeBehavior
+					+ " dependencies based on initial project set of " + queue.stream().map(r -> r.mavenProject)
+							.map(MavenProject::getName).collect(Collectors.joining(", ")));
+			while (!queue.isEmpty()) {
+				ProjectRequest projectRequest = queue.poll();
+				if (selectedProjects.add(projectRequest.mavenProject)) {
+					if (projectRequest.requestDownstream) {
+						Collection<IInstallableUnit> depends = projectDependenciesMap
+								.getOrDefault(projectRequest.mavenProject, Collections.emptyList());
+						depends.stream()//
+								.map(iuProjectMap::get)//
+								.filter(Objects::nonNull)//
+								.distinct()//
+								.peek(project -> loggerAdapter.debug(" + add downstream project '" + project.getName()
+										+ "' of project '" + projectRequest.mavenProject.getName() + "'..."))//
+								.forEach(
+										project -> queue.add(new ProjectRequest(project, true, false, projectRequest)));
+					}
+					if (projectRequest.requestUpstream) {
+						projectDependenciesMap.entrySet().stream()//
+								.filter(entry -> {
+									return entry.getValue().stream()//
+											.map(iuProjectMap::get)//
+											.filter(Objects::nonNull)//
+											.anyMatch(projectRequest::matches);
+								})//
+								.map(Entry::getKey)//
+								.distinct()//
+								.peek(project -> loggerAdapter.debug(" + add upstream project '" + project.getName()
+										+ "' of project '" + projectRequest.mavenProject.getName() + "'..."))//
+								.forEach(
+										project -> queue.add(new ProjectRequest(project, true, false, projectRequest)));
+					}
+				}
+			}
+			// add target projects always, they don't really add to the build times but are
+			// needed if referenced inside projects we might be more selective and choose
+			// target projects depending on project configuration
+			for (MavenProject mavenProject : projects) {
+				if (TYPE_ECLIPSE_TARGET_DEFINITION.equals(mavenProject.getPackaging())) {
+					selectedProjects.add(mavenProject);
+				}
+
+			}
+		} finally {
+			executor.ifPresent(ExecutorService::shutdownNow);
+		}
+
+		try {
+			return Result.success(new DefaultProjectDependencyGraph(projects, selectedProjects));
+		} catch (DuplicateProjectException | CycleDetectedException e) {
+			log.error("Can't compute project dependency graph", e);
+			return Result.error(graph);
+		}
+	}
+
+	private Function<MavenProject, Collection<IInstallableUnit>> computeProjectUnits(List<ModelProblem> problems) {
+		return project -> {
+			PublisherInfo publisherInfo = new PublisherInfo();
+			publisherInfo.setArtifactOptions(IPublisherInfo.A_INDEX);
+			if (TYPE_ECLIPSE_PLUGIN.equals(project.getPackaging())
+					|| TYPE_ECLIPSE_TEST_PLUGIN.equals(project.getPackaging())) {
+				try {
+					BundleDescription bundleDescription = BundlesAction.createBundleDescription(project.getBasedir());
+					IArtifactKey descriptor = BundlesAction.createBundleArtifactKey(bundleDescription.getSymbolicName(),
+							bundleDescription.getVersion().toString());
+					IInstallableUnit iu = BundlesAction.createBundleIU(bundleDescription, descriptor, publisherInfo);
+					return Collections.singletonList(iu);
+				} catch (IOException | BundleException e) {
+					problems.add(new DefaultModelProblem(
+							"can't read " + project.getPackaging() + " project @ " + project.getBasedir(),
+							Severity.ERROR, null, null, 0, 0, e));
+				}
+			} else if (TYPE_ECLIPSE_FEATURE.equals(project.getPackaging())) {
+				FeatureParser parser = new FeatureParser();
+				File basedir = project.getBasedir();
+				Feature feature = parser.parse(basedir);
+				Map<IInstallableUnit, Feature> featureMap = new HashMap<>();
+				FeaturesAction action = new FeaturesAction(new Feature[] { feature }) {
+					@Override
+					protected void publishFeatureArtifacts(Feature feature, IInstallableUnit featureIU,
+							IPublisherInfo publisherInfo) {
+						// so not call super as we don't wan't to copy anything --> Bug in P2 with
+						// IPublisherInfo.A_INDEX option
+						// see https://bugs.eclipse.org/bugs/show_bug.cgi?id=578380
+					}
+
+					@Override
+					protected IInstallableUnit generateFeatureJarIU(Feature feature, IPublisherInfo publisherInfo) {
+						IInstallableUnit iu = super.generateFeatureJarIU(feature, publisherInfo);
+						featureMap.put(iu, feature);
+						return iu;
+					}
+				};
+				PublisherResult results = new PublisherResult();
+				action.perform(publisherInfo, results, null);
+				Set<IInstallableUnit> result = results.query(QueryUtil.ALL_UNITS, null).toSet();
+				return result;
+
+			}
+			return Collections.emptyList();
+		};
+	}
+
+	private Function<Entry<MavenProject, Collection<IInstallableUnit>>, Collection<IInstallableUnit>> computeProjectDependencies(
+			Collection<IInstallableUnit> availableIUs, List<ModelProblem> problems, MavenLogger logger) {
+		return entry -> {
+			Collection<IInstallableUnit> projectUnits = entry.getValue();
+			if (!projectUnits.isEmpty()) {
+				MavenProject project = entry.getKey();
+				logger.debug("Resolve dependencies for project " + project.getName() + "...");
+				try {
+					ProjectorResolutionStrategy resolutionStrategy = new ProjectorResolutionStrategy(logger);
+					ResolutionDataImpl data = new ResolutionDataImpl(NoExecutionEnvironmentResolutionHints.INSTANCE);
+					data.setFailOnMissing(false);
+					data.setAvailableIUs(Collections.unmodifiableCollection(availableIUs));
+					data.setRootIUs(Collections.unmodifiableCollection(projectUnits));
+					data.setSlicerPredicate(always -> true);
+					resolutionStrategy.setData(data);
+					Collection<IInstallableUnit> resolve = resolutionStrategy.resolve(new HashMap<String, String>(),
+							new NullProgressMonitor());
+					resolve.removeAll(projectUnits);
+					return resolve;
+				} catch (ResolverException e) {
+					problems.add(new DefaultModelProblem(
+							"can't resolve " + project.getPackaging() + " project @ " + project.getBasedir(),
+							Severity.ERROR, null, null, 0, 0, e));
+				}
+			}
+			return Collections.emptyList();
+		};
+	}
+
+	private static <T> void runStream(Stream<T> stream, Consumer<? super T> consumer, BooleanSupplier hasFailures,
+			Optional<ExecutorService> service) throws ExecutionException {
+		if (hasFailures.getAsBoolean()) {
+			// short-cut
+			return;
+		}
+		Predicate<T> takeWhile = nil -> !hasFailures.getAsBoolean();
+		if (service.isEmpty()) {
+			stream.unordered().takeWhile(takeWhile).forEach(consumer);
+		} else {
+			Future<?> future = service.get().submit(() -> {
+				stream.unordered().parallel().takeWhile(takeWhile).forEach(consumer);
+			});
+			try {
+				future.get();
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		}
+	}
+
+	private static final class ProjectRequest {
+
+		final MavenProject mavenProject;
+		final ProjectRequest parent;
+		final boolean requestDownstream;
+		final boolean requestUpstream;
+
+		ProjectRequest(MavenProject mavenProject, boolean requestDownstream, boolean requestUpstream,
+				ProjectRequest parent) {
+			this.requestDownstream = requestDownstream;
+			this.requestUpstream = requestUpstream;
+			this.parent = parent;
+			this.mavenProject = mavenProject;
+		}
+
+		boolean matches(MavenProject mavenproject) {
+			return this.mavenProject == mavenproject;
+		}
+	}
+
+}

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/util/resolution/ProjectorResolutionStrategy.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/util/resolution/ProjectorResolutionStrategy.java
@@ -46,7 +46,7 @@ public class ProjectorResolutionStrategy extends AbstractSlicerResolutionStrateg
      * incomplete solution
      */
     private static final int MAX_ITERATIONS = Integer
-            .getInteger("tycho.internal.ProjectorResolutionStrategy.maxIterations", 100);
+            .getInteger("tycho.internal.ProjectorResolutionStrategy.maxIterations", 1000);
 
     public ProjectorResolutionStrategy(MavenLogger logger) {
         super(logger);


### PR DESCRIPTION
This is a basic prototype for https://github.com/eclipse/tycho/issues/48 and https://github.com/eclipse/tycho/issues/551 and also a showcase that Tycho could use P2 without the need of running it inside an OSGi-Framework (FYI @merks).

With this change (and enabling the [tycho-build extension](https://github.com/eclipse/tycho/blob/master/RELEASE_NOTES.md#tycho-pomless-will-become-a-tycho-core-extension)) the test cases from https://github.com/eclipse/tycho/pull/564 succeed.

As there where some discussion why we don't _"just fix this after such a long time"_, I'd like to give some insights about the efforts put into this prototype up to now (and its not complete but should work for common cases):

Beside the discussions and analysis in https://github.com/eclipse/tycho/issues/48 with the useful hint/example code in https://github.com/eclipse/tycho/issues/551 (thanks @sratz) and the provided test-cases in https://github.com/eclipse/tycho/pull/564 (thanks @joeshannon) the following changes and refactoring where a perquisite:

- https://github.com/eclipse/tycho/commit/e2cecb599d30ae8f110da92e92909ff50d0d79aa (271 changed LOCs)
- https://github.com/eclipse/tycho/commit/53ac9ec27529ec5e6f1353b3c622407cf38200b0 (177 changed LOCs)
- https://github.com/eclipse/tycho/commit/f22018598a4c6b2986d120b03a0102abd8bdf692 (308 changed LOCs)

To make this sustainable in the future the following changes in external projects where triggered and PRs provided:

- https://github.com/apache/maven/pull/665
- https://bugs.eclipse.org/bugs/show_bug.cgi?id=578380
- https://bugs.eclipse.org/bugs/show_bug.cgi?id=578394
- https://bugs.eclipse.org/bugs/show_bug.cgi?id=578365

**Altogether I approximately spend 20 hrs of development time with coding, writing issues, reviewing, analysis and test.**

And as mentioned this is a prototype and it is not complete, there is more work to do to make this complete and more useful (e.g. at the moment project dependencies are resolved twice once for graph building and once in the regular build).

Lust but not least I think we can integrate this at the current state in Tycho if there are no concern ( @mickaelistria @akurtakov ).

If this is crucial to someones business/workflow and likes to push the development forward in that area a [sponsoring](https://github.com/sponsors/laeubi?frequency=one-time) would allow me to assign more time-slots on these particular issue. Of course one can always contact me directly or contribute upon this initial prototype.