### PR TITLE
Fix #583 - TychoMavenLifecycleParticipant must clone the maven session before spinning new threads

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
@@ -153,7 +153,8 @@ public class TychoMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
                 return;
             }
             try {
-                resolver.resolveProject(session, project, reactorProjects);
+                MavenSession clone = session.clone();
+                resolver.resolveProject(clone, project, reactorProjects);
             } catch (BuildFailureException e) {
                 resolutionErrors.put(project, e);
                 if (failFast) {


### PR DESCRIPTION


Signed-off-by: Christoph Läubrich <laeubi@laeubi-soft.de>