### PR TITLE
Fix #602 - Align pom-generation with flatten plugin

### DIFF
--- a/tycho-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/tycho-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -36,6 +36,9 @@
               <test>
                 org.apache.maven.plugins:maven-surefire-plugin:${surefire-plugin.version}:test
               </test>
+              <prepare-package>
+               org.eclipse.tycho:tycho-packaging-plugin:${project.version}:update-consumer-pom
+              </prepare-package>
               <package>
                 org.eclipse.tycho:tycho-packaging-plugin:${project.version}:package-plugin,
                 org.eclipse.tycho:tycho-p2-plugin:${project.version}:p2-metadata-default
@@ -103,6 +106,9 @@
               <process-test-resources>
                 org.apache.maven.plugins:maven-resources-plugin:${resources-plugin.version}:testResources
               </process-test-resources>
+              <prepare-package>
+               org.eclipse.tycho:tycho-packaging-plugin:${project.version}:update-consumer-pom
+              </prepare-package>
               <package>
                 org.eclipse.tycho:tycho-packaging-plugin:${project.version}:package-plugin,
                 org.eclipse.tycho:tycho-p2-plugin:${project.version}:p2-metadata-default
@@ -161,6 +167,7 @@
               <generate-resources>
               </generate-resources>
               <prepare-package>
+               org.eclipse.tycho:tycho-packaging-plugin:${project.version}:update-consumer-pom
               </prepare-package>
               <package>
                 org.eclipse.tycho:tycho-packaging-plugin:${project.version}:package-feature,
@@ -322,7 +329,7 @@
                 org.eclipse.tycho:tycho-p2-publisher-plugin:${project.version}:publish-products,
                 org.eclipse.tycho:tycho-p2-publisher-plugin:${project.version}:publish-categories,
                 org.eclipse.tycho:tycho-p2-publisher-plugin:${project.version}:attach-artifacts,
-                org.eclipse.tycho:tycho-p2-repository-plugin:${project.version}:assemble-repository,
+                org.eclipse.tycho:tycho-p2-repository-plugin:${project.version}:assemble-repository
               </prepare-package>
               <package>
                 org.eclipse.tycho:tycho-p2-repository-plugin:${project.version}:archive-repository

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackageFeatureMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackageFeatureMojo.java
@@ -156,9 +156,6 @@ public class PackageFeatureMojo extends AbstractTychoPackagingMojo {
                     archive.setAddMavenDescriptor(false);
                 }
 				MavenProject mavenProject = project;
-				if (archive.isAddMavenDescriptor()) {
-					mavenProject = updatePom(finalName);
-				}
 				archiver.createArchive(session, mavenProject, archive);
             } catch (Exception e) {
                 throw new MojoExecutionException("Error creating feature package", e);

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackagePluginMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackagePluginMojo.java
@@ -252,9 +252,6 @@ public class PackagePluginMojo extends AbstractTychoPackagingMojo {
                 getLog().warn("ignoring unsupported archive forced = false parameter.");
                 archive.setForced(true);
             }
-			if (archive.isAddMavenDescriptor()) {
-				mavenProject = updatePom(finalName);
-			}
 			archiver.createArchive(session, mavenProject, archive);
             return pluginFile;
         } catch (IOException | ArchiverException | ManifestException | DependencyResolutionRequiredException e) {

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/UpdateConsumerPomMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/UpdateConsumerPomMojo.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.packaging;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Parent;
+import org.apache.maven.model.io.ModelReader;
+import org.apache.maven.model.io.ModelWriter;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Updates the pom file with the dependencies from the tycho model. If you
+ * further like to customize the pom you should take a look at the <a href=
+ * "https://www.mojohaus.org/flatten-maven-plugin/plugin-info.html">Maven
+ * Flatten Plugin</a>
+ */
+@Mojo(name = "update-consumer-pom", threadSafe = true, defaultPhase = LifecyclePhase.PREPARE_PACKAGE, requiresDependencyResolution = ResolutionScope.TEST)
+public class UpdateConsumerPomMojo extends AbstractMojo {
+
+	private static final String POLYGLOT_POM_TYCHO = ".polyglot.pom.tycho";
+
+	@Parameter(property = "project", readonly = true)
+	protected MavenProject project;
+
+	@Component(role = ModelWriter.class)
+	protected ModelWriter modelWriter;
+
+	@Component(role = ModelReader.class)
+	protected ModelReader modelReader;
+
+	/**
+	 * The directory where the tycho generated POM file will be written to.
+	 */
+	@Parameter(defaultValue = "${project.basedir}", required = true)
+	protected File outputDirectory;
+
+	/**
+	 * The filename of the tycho generated POM file.
+	 */
+	@Parameter(defaultValue = ".tycho-pom.xml", required = true)
+	protected String tychoPomFilename;
+
+	@Parameter(defaultValue = "false")
+	protected boolean skipPomGeneration = false;
+
+	/**
+	 * Indicate if the generated tycho POM should become the new project.
+	 */
+	@Parameter(defaultValue = "true")
+	protected boolean updatePomFile = true;
+
+	@Override
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		if (skipPomGeneration) {
+			return;
+		}
+		if (outputDirectory == null) {
+			outputDirectory = project.getBasedir();
+		}
+		getLog().debug("Generate pom descriptor with updated dependencies...");
+		Model projectModel;
+		try {
+			projectModel = modelReader.read(project.getFile(), null);
+		} catch (IOException e) {
+			throw new MojoExecutionException("reading the model failed!", e);
+		}
+		List<Dependency> dependencies = projectModel.getDependencies();
+		dependencies.clear();
+		List<Dependency> list = Objects.requireNonNullElse(project.getDependencies(), Collections.emptyList());
+		for (Dependency dep : list) {
+			Dependency copy = dep.clone();
+			copy.setSystemPath(null);
+			if (dep.getGroupId().startsWith("p2.eclipse.") && Artifact.SCOPE_SYSTEM.equals(dep.getScope())) {
+				copy.setOptional(true);
+				copy.setScope(Artifact.SCOPE_PROVIDED);
+			}
+			dependencies.add(copy);
+		}
+		Parent parent = projectModel.getParent();
+		if (parent != null) {
+			String relativePath = parent.getRelativePath();
+			if (relativePath != null && relativePath.endsWith(POLYGLOT_POM_TYCHO)) {
+				parent.setRelativePath(
+						relativePath.substring(0, relativePath.length() - POLYGLOT_POM_TYCHO.length()) + "pom.xml");
+			}
+		}
+		File output = new File(outputDirectory, tychoPomFilename);
+		try {
+			modelWriter.write(output, null, projectModel);
+		} catch (IOException e) {
+			throw new MojoExecutionException("writing the model failed!", e);
+		}
+		if (updatePomFile) {
+			project.setFile(output);
+		}
+
+	}
+
+}


### PR DESCRIPTION
This adds a new mojo to the packe plugin that behave similar to the maven [flatten:flatten](https://www.mojohaus.org/flatten-maven-plugin/flatten-mojo.html) goal. it binds to the `prepare-package` phase so it is possible to further adjust/modify the pom (e.g. with the maven-flatten-plugin) before it gets packed into the jar or deployed.