### PR TITLE
TychoGraphBuilder: -amd should pick up dependencies of dependants

### DIFF
--- a/tycho-build/src/main/java/org/eclipse/tycho/build/TychoGraphBuilder.java
+++ b/tycho-build/src/main/java/org/eclipse/tycho/build/TychoGraphBuilder.java
@@ -220,9 +220,9 @@ public class TychoGraphBuilder extends DefaultGraphBuilder {
 								.distinct()//
 								.peek(project -> loggerAdapter.debug(" + add downstream project '" + project.getName()
 										+ "' of project '" + projectRequest.mavenProject.getName() + "'..."))//
-								// make behaviors are both false here as projectDependenciesMap includes transitive already
+								// request dependencies of dependants, otherwise, -amd would not be able to produce a satisfiable build graph
 								.forEach(
-										project -> queue.add(new ProjectRequest(project, false, false, projectRequest)));
+										project -> queue.add(new ProjectRequest(project, false, true, projectRequest)));
 					}
 				}
 			}

--- a/tycho-its/projects/reactor.makeBehaviour/bundle1a/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/reactor.makeBehaviour/bundle1a/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Bundle 1a
+Bundle-SymbolicName: bundle1a;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Require-Bundle: bundle1

--- a/tycho-its/projects/reactor.makeBehaviour/bundle1a/build.properties
+++ b/tycho-its/projects/reactor.makeBehaviour/bundle1a/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/reactor.makeBehaviour/bundle1a/pom.xml
+++ b/tycho-its/projects/reactor.makeBehaviour/bundle1a/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<version>1.0.0-SNAPSHOT</version>
+	<artifactId>bundle1a</artifactId>
+	<packaging>eclipse-plugin</packaging>
+
+	<parent>
+		<groupId>tycho-its-project.reactor.makeBehaviour</groupId>
+		<artifactId>parent</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+
+</project>

--- a/tycho-its/projects/reactor.makeBehaviour/bundle1b/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/reactor.makeBehaviour/bundle1b/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Bundle 1b
+Bundle-SymbolicName: bundle1b;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Require-Bundle: bundle1a

--- a/tycho-its/projects/reactor.makeBehaviour/bundle1b/build.properties
+++ b/tycho-its/projects/reactor.makeBehaviour/bundle1b/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/reactor.makeBehaviour/bundle1b/pom.xml
+++ b/tycho-its/projects/reactor.makeBehaviour/bundle1b/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<version>1.0.0-SNAPSHOT</version>
+	<artifactId>bundle1b</artifactId>
+	<packaging>eclipse-plugin</packaging>
+
+	<parent>
+		<groupId>tycho-its-project.reactor.makeBehaviour</groupId>
+		<artifactId>parent</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+
+</project>

--- a/tycho-its/projects/reactor.makeBehaviour/pom.xml
+++ b/tycho-its/projects/reactor.makeBehaviour/pom.xml
@@ -11,6 +11,8 @@
     <module>feature1</module>
     <module>feature2</module>
     <module>bundle1</module>
+    <module>bundle1a</module>
+    <module>bundle1b</module>
     <module>bundle2</module>
   </modules>
 


### PR DESCRIPTION
`-amd` in general is of little practical use in Tycho build environments that typically contain downstream features + updatesites that depend on practically everything.

To make it somewhat useful (i.e. get something buildable in the first place out of it), `-amd` should pick up dependencies of dependents.

Also add a few more integration tests.

Change-Id: I0538fb5bd285c8d2d4132e95c4d44d09c5b2026c