### PR TITLE
Fix #588 resolve the extension from the artifact type

### DIFF
--- a/sisu-equinox/sisu-equinox-launching/src/main/java/org/eclipse/sisu/equinox/launching/DefaultEquinoxInstallationDescription.java
+++ b/sisu-equinox/sisu-equinox-launching/src/main/java/org/eclipse/sisu/equinox/launching/DefaultEquinoxInstallationDescription.java
@@ -84,7 +84,7 @@ public class DefaultEquinoxInstallationDescription implements EquinoxInstallatio
     @Override
     public List<ArtifactDescriptor> getBundles() {
         return bundles.getArtifacts(key -> ArtifactType.TYPE_ECLIPSE_PLUGIN.equals(key.getType())
-                || ArtifactType.TYPE_ECLIPSE_TEST_FRAGMENT.equals(key.getType()));
+                || ArtifactType.TYPE_ECLIPSE_TEST_PLUGIN.equals(key.getType()));
     }
 
     @Override

--- a/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/core/shared/MavenContext.java
+++ b/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/core/shared/MavenContext.java
@@ -50,4 +50,13 @@ public interface MavenContext {
      */
     public Collection<ReactorProject> getProjects();
 
+    /**
+     * Returns the assigned extension for a given artifact type
+     * 
+     * @param artifactType
+     *            type of the artifact
+     * @return the extension for the given type
+     */
+    public String getExtension(String artifactType);
+
 }

--- a/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/core/shared/MavenContextImpl.java
+++ b/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/core/shared/MavenContextImpl.java
@@ -22,7 +22,7 @@ import java.util.Properties;
 
 import org.eclipse.tycho.ReactorProject;
 
-public class MavenContextImpl implements MavenContext {
+public abstract class MavenContextImpl implements MavenContext {
 
     private File localRepositoryRoot;
     private MavenLogger mavenLogger;

--- a/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/core/shared/MockMavenContext.java
+++ b/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/core/shared/MockMavenContext.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.core.shared;
+
+import java.io.File;
+import java.util.Properties;
+
+import org.eclipse.tycho.ArtifactType;
+import org.eclipse.tycho.PackagingType;
+
+public class MockMavenContext extends MavenContextImpl {
+
+    public MockMavenContext(File localRepositoryRoot, boolean offline, MavenLogger mavenLogger,
+            Properties mergedProperties) {
+        super(localRepositoryRoot, offline, mavenLogger, mergedProperties);
+    }
+
+    public MockMavenContext(File newFolder, MavenLogger logger) {
+        super(newFolder, logger);
+    }
+
+    @Override
+    public String getExtension(String artifactType) {
+        if (artifactType == null) {
+            return "jar";
+        }
+        switch (artifactType) {
+        case ArtifactType.TYPE_ECLIPSE_PLUGIN:
+        case ArtifactType.TYPE_ECLIPSE_FEATURE:
+        case ArtifactType.TYPE_ECLIPSE_TEST_PLUGIN:
+        case "ejb":
+        case "ejb-client":
+        case "test-jar":
+        case "javadoc":
+        case "java-source":
+        case "maven-plugin":
+            return "jar";
+        case PackagingType.TYPE_ECLIPSE_UPDATE_SITE:
+        case PackagingType.TYPE_ECLIPSE_REPOSITORY:
+        case PackagingType.TYPE_ECLIPSE_APPLICATION:
+        case ArtifactType.TYPE_ECLIPSE_PRODUCT:
+            return "zip";
+        case ArtifactType.TYPE_INSTALLABLE_UNIT:
+            return "xml";
+        case PackagingType.TYPE_ECLIPSE_TARGET_DEFINITION:
+            return "target";
+        default:
+            return "jar";
+        }
+    }
+
+}

--- a/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/ArtifactType.java
+++ b/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/ArtifactType.java
@@ -20,14 +20,11 @@ package org.eclipse.tycho;
 public final class ArtifactType {
 
     public static final String TYPE_ECLIPSE_PLUGIN = "eclipse-plugin";
-    /**
-     * This ArtifactType is for the generated test fragment (tests from an eclipse-plugin module).
-     * It should also be used as the <b>classifier</b> to attach and get this test fragment on a
-     * given MavenProject.
-     */
-    public static final String TYPE_ECLIPSE_TEST_FRAGMENT = "eclipse-test-fragment";
+    public static final String TYPE_ECLIPSE_TEST_PLUGIN = "eclipse-test-plugin";
     public static final String TYPE_ECLIPSE_FEATURE = "eclipse-feature";
     public static final String TYPE_ECLIPSE_PRODUCT = "eclipse-product";
     public static final String TYPE_INSTALLABLE_UNIT = "p2-installable-unit";
+    public static final String TYPE_P2_ARTIFACTS = "p2-artifacts";
+    public static final String TYPE_P2_METADATA = "p2-metadata";
 
 }

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/local/GAVArtifactDescriptorTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/local/GAVArtifactDescriptorTest.java
@@ -22,6 +22,7 @@ import org.eclipse.equinox.p2.metadata.IArtifactKey;
 import org.eclipse.equinox.p2.metadata.Version;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactDescriptor;
 import org.eclipse.equinox.p2.repository.artifact.spi.ArtifactDescriptor;
+import org.eclipse.tycho.core.shared.MavenContextImpl;
 import org.eclipse.tycho.p2.repository.GAV;
 import org.eclipse.tycho.p2.repository.MavenRepositoryCoordinates;
 import org.junit.Test;
@@ -182,8 +183,13 @@ public class GAVArtifactDescriptorTest {
                 OTHER_EXTENSION);
         subject = new GAVArtifactDescriptor(createP2Descriptor(), coordinates);
 
-        assertThat(subject.getMavenCoordinates().getLocalRepositoryPath(),
-                is("mvn/group/mvn.id/4.3.0-SNAPSHOT/mvn.id-4.3.0-SNAPSHOT-mvn.classifier.mvn.fileextension"));
+        assertThat(subject.getMavenCoordinates().getLocalRepositoryPath(new MavenContextImpl(null, false, null, null) {
+
+            @Override
+            public String getExtension(String artifactType) {
+                return artifactType;
+            }
+        }), is("mvn/group/mvn.id/4.3.0-SNAPSHOT/mvn.id-4.3.0-SNAPSHOT-mvn.classifier.mvn.fileextension"));
     }
 
     @Test
@@ -192,8 +198,13 @@ public class GAVArtifactDescriptorTest {
                 DEFAULT_EXTENSION);
         subject = new GAVArtifactDescriptor(createP2Descriptor(), coordinates);
 
-        assertThat(subject.getMavenCoordinates().getLocalRepositoryPath(),
-                is("mvn/group/mvn.id/4.3.0-SNAPSHOT/mvn.id-4.3.0-SNAPSHOT.jar"));
+        assertThat(subject.getMavenCoordinates().getLocalRepositoryPath(new MavenContextImpl(null, false, null, null) {
+
+            @Override
+            public String getExtension(String artifactType) {
+                return "jar";
+            }
+        }), is("mvn/group/mvn.id/4.3.0-SNAPSHOT/mvn.id-4.3.0-SNAPSHOT.jar"));
     }
 
     private static ArtifactDescriptor createP2Descriptor() {

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/local/LocalArtifactRepositoryTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/local/LocalArtifactRepositoryTest.java
@@ -40,6 +40,7 @@ import org.eclipse.equinox.p2.repository.artifact.spi.ArtifactDescriptor;
 import org.eclipse.equinox.p2.repository.artifact.spi.ProcessingStepDescriptor;
 import org.eclipse.equinox.spi.p2.publisher.PublisherHelper;
 import org.eclipse.tycho.core.shared.MavenLogger;
+import org.eclipse.tycho.core.shared.MockMavenContext;
 import org.eclipse.tycho.p2.repository.RepositoryLayoutHelper;
 import org.eclipse.tycho.p2.repository.TychoRepositoryIndex;
 import org.eclipse.tycho.repository.local.index.FileBasedTychoRepositoryIndex;
@@ -70,7 +71,7 @@ public class LocalArtifactRepositoryTest {
 
     private TychoRepositoryIndex createArtifactsIndex(File location) {
         return FileBasedTychoRepositoryIndex.createArtifactsIndex(location, new NoopFileLockService(),
-                mock(MavenLogger.class));
+                new MockMavenContext(location, mock(MavenLogger.class)));
     }
 
     @Test

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/local/LocalMetadataRepositoryTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/local/LocalMetadataRepositoryTest.java
@@ -31,6 +31,7 @@ import org.eclipse.equinox.p2.query.IQueryResult;
 import org.eclipse.equinox.p2.query.QueryUtil;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
 import org.eclipse.tycho.core.shared.MavenLogger;
+import org.eclipse.tycho.core.shared.MockMavenContext;
 import org.eclipse.tycho.p2.repository.LocalRepositoryReader;
 import org.eclipse.tycho.p2.repository.RepositoryLayoutHelper;
 import org.eclipse.tycho.p2.repository.TychoRepositoryIndex;
@@ -53,12 +54,12 @@ public class LocalMetadataRepositoryTest {
 
     protected IMetadataRepository loadRepository(File location) throws ProvisionException {
         return new LocalMetadataRepository(location.toURI(), createMetadataIndex(location),
-                new LocalRepositoryReader(location));
+                new LocalRepositoryReader(new MockMavenContext(location, mock(MavenLogger.class))));
     }
 
     private TychoRepositoryIndex createMetadataIndex(File location) {
         return FileBasedTychoRepositoryIndex.createMetadataIndex(location, new NoopFileLockService(),
-                mock(MavenLogger.class));
+                new MockMavenContext(location, mock(MavenLogger.class)));
     }
 
     private LocalMetadataRepository createRepository(File location) throws ProvisionException {

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository/src/main/java/org/eclipse/tycho/p2/maven/repository/AbstractMavenMetadataRepository.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository/src/main/java/org/eclipse/tycho/p2/maven/repository/AbstractMavenMetadataRepository.java
@@ -31,6 +31,7 @@ import org.eclipse.equinox.p2.query.IQuery;
 import org.eclipse.equinox.p2.query.IQueryResult;
 import org.eclipse.equinox.p2.repository.IRepositoryReference;
 import org.eclipse.equinox.p2.repository.metadata.spi.AbstractMetadataRepository;
+import org.eclipse.tycho.ArtifactType;
 import org.eclipse.tycho.p2.maven.repository.xmlio.MetadataIO;
 import org.eclipse.tycho.p2.repository.GAV;
 import org.eclipse.tycho.p2.repository.RepositoryLayoutHelper;
@@ -72,7 +73,7 @@ public abstract class AbstractMavenMetadataRepository extends AbstractMetadataRe
         for (GAV gav : metadataIndex.getProjectGAVs()) {
             try {
                 File localArtifactFileLocation = contentLocator.getLocalArtifactLocation(gav,
-                        RepositoryLayoutHelper.CLASSIFIER_P2_METADATA, RepositoryLayoutHelper.EXTENSION_P2_METADATA);
+                        RepositoryLayoutHelper.CLASSIFIER_P2_METADATA, ArtifactType.TYPE_P2_METADATA);
                 if (!localArtifactFileLocation.exists()) {
                     // if files have been manually removed from the repository, simply remove them from the index (bug 351080)
                     metadataIndex.removeGav(gav);

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository/src/main/java/org/eclipse/tycho/p2/maven/repository/xmlio/ArtifactsIO.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository/src/main/java/org/eclipse/tycho/p2/maven/repository/xmlio/ArtifactsIO.java
@@ -31,6 +31,7 @@ import org.osgi.framework.BundleContext;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
 
 @SuppressWarnings("restriction")
 public class ArtifactsIO {
@@ -62,7 +63,7 @@ public class ArtifactsIO {
             try {
                 // TODO: currently not caching the parser since we make no assumptions
                 // or restrictions on concurrent parsing
-                getParser();
+                XMLReader xmlReader = getParser().getXMLReader();
                 ArtifactsHandler artifactsHandler = new ArtifactsHandler();
                 xmlReader.setContentHandler(new RepositoryDocHandler(ARTIFACTS_ELEMENT, artifactsHandler));
                 xmlReader.parse(new InputSource(stream));

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository/src/main/java/org/eclipse/tycho/repository/local/LocalMetadataRepository.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository/src/main/java/org/eclipse/tycho/repository/local/LocalMetadataRepository.java
@@ -20,6 +20,8 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.tycho.ArtifactType;
+import org.eclipse.tycho.core.shared.MavenContext;
 import org.eclipse.tycho.p2.maven.repository.AbstractMavenMetadataRepository;
 import org.eclipse.tycho.p2.maven.repository.xmlio.MetadataIO;
 import org.eclipse.tycho.p2.repository.GAV;
@@ -84,8 +86,14 @@ public class LocalMetadataRepository extends AbstractMavenMetadataRepository {
             Set<IInstallableUnit> gavUnits = unitsMap.get(gav);
 
             if (gavUnits != null && !gavUnits.isEmpty()) {
+                MavenContext mavenContext;
+                if (contentLocator != null) {
+                    mavenContext = contentLocator.getMavenContext();
+                } else {
+                    mavenContext = metadataIndex.getMavenContext();
+                }
                 String relpath = RepositoryLayoutHelper.getRelativePath(gav,
-                        RepositoryLayoutHelper.CLASSIFIER_P2_METADATA, RepositoryLayoutHelper.EXTENSION_P2_METADATA);
+                        RepositoryLayoutHelper.CLASSIFIER_P2_METADATA, ArtifactType.TYPE_P2_METADATA, mavenContext);
 
                 File file = new File(basedir, relpath);
                 file.getParentFile().mkdirs();

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository/src/main/java/org/eclipse/tycho/repository/local/index/FileBasedTychoRepositoryIndex.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository/src/main/java/org/eclipse/tycho/repository/local/index/FileBasedTychoRepositoryIndex.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import org.eclipse.tycho.core.shared.MavenContext;
 import org.eclipse.tycho.core.shared.MavenLogger;
 import org.eclipse.tycho.locking.facade.FileLockService;
 import org.eclipse.tycho.locking.facade.FileLocker;
@@ -53,12 +54,14 @@ public class FileBasedTychoRepositoryIndex implements TychoRepositoryIndex {
     private Set<GAV> addedGavs = new HashSet<>();
     private Set<GAV> removedGavs = new HashSet<>();
     private Set<GAV> gavs = new HashSet<>();
+    private MavenContext mavenContext;
 
-    private FileBasedTychoRepositoryIndex(File indexFile, FileLockService fileLockService, MavenLogger logger) {
+    private FileBasedTychoRepositoryIndex(File indexFile, FileLockService fileLockService, MavenContext mavenContext) {
         super();
         this.indexFile = indexFile;
+        this.mavenContext = mavenContext;
         this.fileLocker = fileLockService.getFileLocker(indexFile);
-        this.logger = logger;
+        this.logger = mavenContext.getLogger();
         if (indexFile.isFile()) {
             lock();
             try {
@@ -77,6 +80,11 @@ public class FileBasedTychoRepositoryIndex implements TychoRepositoryIndex {
 
     private void unlock() {
         fileLocker.release();
+    }
+
+    @Override
+    public MavenContext getMavenContext() {
+        return mavenContext;
     }
 
     @Override
@@ -169,13 +177,13 @@ public class FileBasedTychoRepositoryIndex implements TychoRepositoryIndex {
     }
 
     public static TychoRepositoryIndex createMetadataIndex(File basedir, FileLockService fileLockService,
-            MavenLogger logger) {
-        return new FileBasedTychoRepositoryIndex(new File(basedir, METADATA_INDEX_RELPATH), fileLockService, logger);
+            MavenContext context) {
+        return new FileBasedTychoRepositoryIndex(new File(basedir, METADATA_INDEX_RELPATH), fileLockService, context);
     }
 
     public static TychoRepositoryIndex createArtifactsIndex(File basedir, FileLockService fileLockService,
-            MavenLogger logger) {
-        return new FileBasedTychoRepositoryIndex(new File(basedir, ARTIFACTS_INDEX_RELPATH), fileLockService, logger);
+            MavenContext context) {
+        return new FileBasedTychoRepositoryIndex(new File(basedir, ARTIFACTS_INDEX_RELPATH), fileLockService, context);
     }
 
 }

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository/src/main/java/org/eclipse/tycho/repository/local/index/LocalRepositoryP2IndicesImpl.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository/src/main/java/org/eclipse/tycho/repository/local/index/LocalRepositoryP2IndicesImpl.java
@@ -32,13 +32,22 @@ public class LocalRepositoryP2IndicesImpl implements LocalRepositoryP2Indices {
     private boolean initialized = false;
     private TychoRepositoryIndex artifactsIndex;
     private TychoRepositoryIndex metadataIndex;
+    private MavenContext mavenContext;
 
     // constructor for DS
     public LocalRepositoryP2IndicesImpl() {
     }
 
+    // test constructor
+    public LocalRepositoryP2IndicesImpl(MavenContext mavenContext, FileLockService fileLockService) {
+        this.localRepositoryRoot = mavenContext.getLocalRepositoryRoot();
+        this.mavenContext = mavenContext;
+        this.fileLockService = fileLockService;
+    }
+
     // injected by DS runtime
     public void setMavenContext(MavenContext mavenContext) {
+        this.mavenContext = mavenContext;
         this.localRepositoryRoot = mavenContext.getLocalRepositoryRoot();
         this.logger = mavenContext.getLogger();
     }
@@ -48,20 +57,14 @@ public class LocalRepositoryP2IndicesImpl implements LocalRepositoryP2Indices {
         this.fileLockService = fileLockService;
     }
 
-    // test constructor
-    public LocalRepositoryP2IndicesImpl(File localRepositoryRoot, FileLockService fileLockService) {
-        this.localRepositoryRoot = localRepositoryRoot;
-        this.fileLockService = fileLockService;
-    }
-
     private void checkInitialized() {
         if (initialized) {
             return;
         }
         this.artifactsIndex = FileBasedTychoRepositoryIndex.createArtifactsIndex(localRepositoryRoot, fileLockService,
-                logger);
+                mavenContext);
         this.metadataIndex = FileBasedTychoRepositoryIndex.createMetadataIndex(localRepositoryRoot, fileLockService,
-                logger);
+                mavenContext);
         initialized = true;
     }
 
@@ -80,6 +83,11 @@ public class LocalRepositoryP2IndicesImpl implements LocalRepositoryP2Indices {
     @Override
     public File getBasedir() {
         return localRepositoryRoot;
+    }
+
+    @Override
+    public MavenContext getMavenContext() {
+        return mavenContext;
     }
 
 }

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/META-INF/MANIFEST.MF
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/META-INF/MANIFEST.MF
@@ -8,7 +8,8 @@ Fragment-Host: org.eclipse.tycho.p2.resolver.impl
 Require-Bundle: org.junit,
  org.hamcrest.core,
  org.apache.commons.io,
- org.eclipse.equinox.p2.transport.ecf
+ org.eclipse.equinox.p2.transport.ecf,
+ biz.aQute.bndlib
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName
 Import-Package: org.eclipse.tycho.p2.remote.testutil,

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/build.properties
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/build.properties
@@ -14,3 +14,4 @@ bin.includes = META-INF/,\
                .,\
                plugin.properties,\
                about.html
+additional.bundles = biz.aQute.bndlib

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/manager/ReactorRepositoryManagerTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/manager/ReactorRepositoryManagerTest.java
@@ -27,7 +27,7 @@ import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.ReactorProjectIdentities;
 import org.eclipse.tycho.core.ee.shared.ExecutionEnvironmentConfigurationStub;
 import org.eclipse.tycho.core.resolver.shared.MavenRepositoryLocation;
-import org.eclipse.tycho.core.shared.MavenContextImpl;
+import org.eclipse.tycho.core.shared.MockMavenContext;
 import org.eclipse.tycho.p2.impl.test.ReactorProjectStub;
 import org.eclipse.tycho.p2.impl.test.ResourceUtil;
 import org.eclipse.tycho.p2.target.P2TargetPlatform;
@@ -56,7 +56,7 @@ public class ReactorRepositoryManagerTest extends MavenServiceStubbingTestBase {
     @Before
     public void setUpContext() throws Exception {
         pomDependencyCollector = new PomDependencyCollectorImpl(
-                new MavenContextImpl(tempManager.newFolder("localRepo"), logVerifier.getLogger()),
+                new MockMavenContext(tempManager.newFolder("localRepo"), logVerifier.getLogger()),
                 new ReactorProjectStub(tempManager.newFolder(), "test"));
     }
 

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/remote/RemoteAgentCompositeLoadingTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/remote/RemoteAgentCompositeLoadingTest.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.equinox.p2.core.ProvisionException;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactRepositoryManager;
-import org.eclipse.tycho.core.shared.MavenContextImpl;
+import org.eclipse.tycho.core.shared.MockMavenContext;
 import org.eclipse.tycho.p2.impl.test.ResourceUtil;
 import org.eclipse.tycho.test.util.LogVerifier;
 import org.junit.Before;
@@ -43,7 +43,7 @@ public class RemoteAgentCompositeLoadingTest {
     @Before
     public void initSubject() throws Exception {
         File localRepo = tempManager.newFolder("localRepo");
-        subject = new RemoteAgent(new MavenContextImpl(localRepo, logVerifier.getLogger()));
+        subject = new RemoteAgent(new MockMavenContext(localRepo, logVerifier.getLogger()));
     }
 
     @Test

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/remote/RemoteAgentDisableP2MirrorsTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/remote/RemoteAgentDisableP2MirrorsTest.java
@@ -24,7 +24,7 @@ import org.eclipse.equinox.p2.core.ProvisionException;
 import org.eclipse.equinox.p2.repository.IRepository;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactRepository;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactRepositoryManager;
-import org.eclipse.tycho.core.shared.MavenContextImpl;
+import org.eclipse.tycho.core.shared.MockMavenContext;
 import org.eclipse.tycho.p2.impl.test.ResourceUtil;
 import org.eclipse.tycho.test.util.LogVerifier;
 import org.junit.Before;
@@ -61,7 +61,7 @@ public class RemoteAgentDisableP2MirrorsTest {
 
     private IProvisioningAgent createRemoteAgent(boolean disableMirrors) throws Exception {
         File localRepo = tempManager.newFolder("localRepo");
-        return new RemoteAgent(new MavenContextImpl(localRepo, logVerifier.getLogger()), disableMirrors);
+        return new RemoteAgent(new MockMavenContext(localRepo, logVerifier.getLogger()), disableMirrors);
     }
 
     private static IArtifactRepository loadRepository(IProvisioningAgent agent, URI location)

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/remote/RemoteAgentMavenMirrorsTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/remote/RemoteAgentMavenMirrorsTest.java
@@ -26,7 +26,7 @@ import org.eclipse.equinox.p2.repository.artifact.IArtifactRepositoryManager;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepositoryManager;
 import org.eclipse.tycho.core.shared.MavenContext;
-import org.eclipse.tycho.core.shared.MavenContextImpl;
+import org.eclipse.tycho.core.shared.MockMavenContext;
 import org.eclipse.tycho.p2.impl.test.ResourceUtil;
 import org.eclipse.tycho.p2.remote.testutil.MavenRepositorySettingsStub;
 import org.eclipse.tycho.test.util.HttpServer;
@@ -53,7 +53,7 @@ public class RemoteAgentMavenMirrorsTest {
     @Before
     public void initSubject() throws Exception {
         File localRepository = tempManager.newFolder("localRepo");
-        MavenContext mavenContext = new MavenContextImpl(localRepository, OFFLINE, logVerifier.getLogger(),
+        MavenContext mavenContext = new MockMavenContext(localRepository, OFFLINE, logVerifier.getLogger(),
                 new Properties());
 
         mavenRepositorySettings = new MavenRepositorySettingsStub();

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/remote/RemoteAgentMetadataRepositoryCacheTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/remote/RemoteAgentMetadataRepositoryCacheTest.java
@@ -25,7 +25,7 @@ import java.util.Properties;
 import org.eclipse.equinox.p2.core.ProvisionException;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepositoryManager;
-import org.eclipse.tycho.core.shared.MavenContextImpl;
+import org.eclipse.tycho.core.shared.MockMavenContext;
 import org.eclipse.tycho.test.util.HttpServer;
 import org.eclipse.tycho.test.util.LogVerifier;
 import org.junit.Before;
@@ -128,12 +128,12 @@ public class RemoteAgentMetadataRepositoryCacheTest {
 
     private RemoteAgent newOnlineAgent() throws Exception {
         return new RemoteAgent(
-                new MavenContextImpl(localMavenRepository, false, logVerifier.getLogger(), new Properties()));
+                new MockMavenContext(localMavenRepository, false, logVerifier.getLogger(), new Properties()));
     }
 
     private RemoteAgent newOfflineAgent() throws Exception {
         return new RemoteAgent(
-                new MavenContextImpl(localMavenRepository, true, logVerifier.getLogger(), new Properties()));
+                new MockMavenContext(localMavenRepository, true, logVerifier.getLogger(), new Properties()));
     }
 
     private IMetadataRepository loadHttpRepository(RemoteAgent agent) throws ProvisionException {

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/PomDependencyCollectorTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/PomDependencyCollectorTest.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.tycho.PackagingType;
 import org.eclipse.tycho.core.shared.MavenContextImpl;
+import org.eclipse.tycho.core.shared.MockMavenContext;
 import org.eclipse.tycho.p2.impl.test.ArtifactMock;
 import org.eclipse.tycho.p2.impl.test.ReactorProjectStub;
 import org.eclipse.tycho.p2.target.facade.PomDependencyCollector;
@@ -48,7 +49,7 @@ public class PomDependencyCollectorTest {
 
     @Before
     public void setUpSubject() throws Exception {
-        MavenContextImpl mavenContext = new MavenContextImpl(new File("dummy"), logVerifier.getLogger());
+        MavenContextImpl mavenContext = new MockMavenContext(new File("dummy"), logVerifier.getLogger());
         subject = new PomDependencyCollectorImpl(mavenContext, new ReactorProjectStub(tempManager.newFolder(), "test"));
     }
 

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TargetDefinitionResolverExecutionEnvironmentTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TargetDefinitionResolverExecutionEnvironmentTest.java
@@ -32,7 +32,7 @@ import org.eclipse.equinox.p2.metadata.VersionedId;
 import org.eclipse.equinox.p2.query.QueryUtil;
 import org.eclipse.tycho.core.ee.shared.ExecutionEnvironmentStub;
 import org.eclipse.tycho.core.resolver.shared.IncludeSourceMode;
-import org.eclipse.tycho.core.shared.MavenContextImpl;
+import org.eclipse.tycho.core.shared.MockMavenContext;
 import org.eclipse.tycho.p2.target.TargetDefinitionResolverIncludeModeTest.PlannerLocationStub;
 import org.eclipse.tycho.p2.target.TargetDefinitionResolverTest.RepositoryStub;
 import org.eclipse.tycho.p2.target.ee.StandardEEResolutionHints;
@@ -60,7 +60,7 @@ public class TargetDefinitionResolverExecutionEnvironmentTest {
         return new TargetDefinitionResolver(defaultEnvironments(),
                 new StandardEEResolutionHints(new ExecutionEnvironmentStub(executionEnvironmentName, systemPackages)),
                 IncludeSourceMode.honor,
-                new MavenContextImpl(tempManager.newFolder("localRepo"), logVerifier.getLogger()), null);
+                new MockMavenContext(tempManager.newFolder("localRepo"), logVerifier.getLogger()), null);
     }
 
     @Test

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TargetDefinitionResolverIncludeModeTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TargetDefinitionResolverIncludeModeTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.equinox.p2.metadata.IVersionedId;
 import org.eclipse.tycho.core.resolver.shared.IncludeSourceMode;
-import org.eclipse.tycho.core.shared.MavenContextImpl;
+import org.eclipse.tycho.core.shared.MockMavenContext;
 import org.eclipse.tycho.p2.target.TargetDefinitionResolverTest.LocationStub;
 import org.eclipse.tycho.p2.target.TargetDefinitionResolverTest.TestRepositories;
 import org.eclipse.tycho.p2.target.facade.TargetDefinition;
@@ -57,7 +57,7 @@ public class TargetDefinitionResolverIncludeModeTest {
     public void initSubject() throws Exception {
         subject = new TargetDefinitionResolver(defaultEnvironments(),
                 ExecutionEnvironmentTestUtils.NOOP_EE_RESOLUTION_HINTS, IncludeSourceMode.honor,
-                new MavenContextImpl(tempManager.newFolder("localRepo"), logVerifier.getLogger()), null);
+                new MockMavenContext(tempManager.newFolder("localRepo"), logVerifier.getLogger()), null);
     }
 
     @Test

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TargetDefinitionResolverIncludeSourceTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TargetDefinitionResolverIncludeSourceTest.java
@@ -25,7 +25,7 @@ import org.eclipse.equinox.p2.metadata.IVersionedId;
 import org.eclipse.equinox.p2.metadata.VersionedId;
 import org.eclipse.equinox.p2.query.QueryUtil;
 import org.eclipse.tycho.core.resolver.shared.IncludeSourceMode;
-import org.eclipse.tycho.core.shared.MavenContextImpl;
+import org.eclipse.tycho.core.shared.MockMavenContext;
 import org.eclipse.tycho.p2.target.TargetDefinitionResolverTest.LocationStub;
 import org.eclipse.tycho.p2.target.TargetDefinitionResolverTest.TestRepositories;
 import org.eclipse.tycho.p2.target.facade.TargetDefinition;
@@ -59,7 +59,7 @@ public class TargetDefinitionResolverIncludeSourceTest {
     public void initSubject() throws Exception {
         subject = new TargetDefinitionResolver(defaultEnvironments(),
                 ExecutionEnvironmentTestUtils.NOOP_EE_RESOLUTION_HINTS, IncludeSourceMode.honor,
-                new MavenContextImpl(tempManager.newFolder("localRepo"), logVerifier.getLogger()), null);
+                new MockMavenContext(tempManager.newFolder("localRepo"), logVerifier.getLogger()), null);
     }
 
     @Test(expected = TargetDefinitionResolutionException.class)

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TargetDefinitionResolverTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TargetDefinitionResolverTest.java
@@ -34,7 +34,7 @@ import org.eclipse.equinox.p2.metadata.VersionedId;
 import org.eclipse.equinox.p2.query.QueryUtil;
 import org.eclipse.tycho.core.resolver.shared.IncludeSourceMode;
 import org.eclipse.tycho.core.shared.BuildFailureException;
-import org.eclipse.tycho.core.shared.MavenContextImpl;
+import org.eclipse.tycho.core.shared.MockMavenContext;
 import org.eclipse.tycho.core.shared.TargetEnvironment;
 import org.eclipse.tycho.p2.impl.test.ResourceUtil;
 import org.eclipse.tycho.p2.target.facade.TargetDefinition;
@@ -89,7 +89,7 @@ public class TargetDefinitionResolverTest {
     public void initContext() throws Exception {
         subject = new TargetDefinitionResolver(defaultEnvironments(),
                 ExecutionEnvironmentTestUtils.NOOP_EE_RESOLUTION_HINTS, IncludeSourceMode.honor,
-                new MavenContextImpl(tempManager.newFolder("localRepo"), logVerifier.getLogger()), null);
+                new MockMavenContext(tempManager.newFolder("localRepo"), logVerifier.getLogger()), null);
     }
 
     static List<TargetEnvironment> defaultEnvironments() {

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TargetDefinitionResolverWithPlatformSpecificUnitsTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TargetDefinitionResolverWithPlatformSpecificUnitsTest.java
@@ -28,7 +28,7 @@ import org.eclipse.equinox.p2.core.ProvisionException;
 import org.eclipse.equinox.p2.metadata.IVersionedId;
 import org.eclipse.equinox.p2.metadata.VersionedId;
 import org.eclipse.tycho.core.resolver.shared.IncludeSourceMode;
-import org.eclipse.tycho.core.shared.MavenContextImpl;
+import org.eclipse.tycho.core.shared.MockMavenContext;
 import org.eclipse.tycho.core.shared.TargetEnvironment;
 import org.eclipse.tycho.p2.target.TargetDefinitionResolverTest.RepositoryStub;
 import org.eclipse.tycho.p2.target.TargetDefinitionResolverTest.UnitStub;
@@ -154,7 +154,7 @@ public class TargetDefinitionResolverWithPlatformSpecificUnitsTest {
             throws ProvisionException, IOException {
         return new TargetDefinitionResolver(environments, ExecutionEnvironmentTestUtils.NOOP_EE_RESOLUTION_HINTS,
                 IncludeSourceMode.honor,
-                new MavenContextImpl(tempManager.newFolder("localRepo"), logVerifier.getLogger()), null);
+                new MockMavenContext(tempManager.newFolder("localRepo"), logVerifier.getLogger()), null);
     }
 
     private static class FilterRepoLocationStubWithLauncherUnit implements TargetDefinition.InstallableUnitLocation {

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TargetPlatformBundlePublisherTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TargetPlatformBundlePublisherTest.java
@@ -28,12 +28,14 @@ import static org.junit.Assert.assertNull;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.equinox.p2.metadata.IArtifactKey;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactDescriptor;
 import org.eclipse.equinox.p2.repository.artifact.spi.ArtifactDescriptor;
+import org.eclipse.tycho.core.shared.MockMavenContext;
 import org.eclipse.tycho.p2.impl.test.ArtifactMock;
 import org.eclipse.tycho.p2.impl.test.ReactorProjectStub;
 import org.eclipse.tycho.p2.metadata.IArtifactFacade;
@@ -68,8 +70,10 @@ public class TargetPlatformBundlePublisherTest {
     public void initSubject() throws IOException {
 
         localRepositoryRoot = tempFolder.getRoot();
-        subject = new TargetPlatformBundlePublisher(localRepositoryRoot,
-                new ReactorProjectStub(tempFolder.newFolder(), "test"), logVerifier.getLogger());
+        MockMavenContext mavenContext = new MockMavenContext(localRepositoryRoot, false, logVerifier.getLogger(),
+                new Properties());
+        subject = new TargetPlatformBundlePublisher(new ReactorProjectStub(tempFolder.newFolder(), "test"),
+                mavenContext);
     }
 
     @Test
@@ -119,7 +123,8 @@ public class TargetPlatformBundlePublisherTest {
                 containsString("is not a bundle and was automatically wrapped with bundle-symbolic name"));
         File jarFile = resourceFile("platformbuilder/pom-dependencies/non-bundle.jar");
         IArtifactFacade jarArtifact = new ArtifactMock(jarFile, GROUP_ID, ARTIFACT_ID, VERSION, "jar");
-        assertNotNull(subject.attemptToPublishBundle(jarArtifact, true));
+        MavenBundleInfo publishBundle = subject.attemptToPublishBundle(jarArtifact, true);
+        assertNotNull(publishBundle);
     }
 
     @Test

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TargetPlatformFactoryTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TargetPlatformFactoryTest.java
@@ -50,7 +50,7 @@ import org.eclipse.tycho.artifacts.TargetPlatformFilter;
 import org.eclipse.tycho.artifacts.TargetPlatformFilter.CapabilityPattern;
 import org.eclipse.tycho.artifacts.TargetPlatformFilter.CapabilityType;
 import org.eclipse.tycho.core.ee.shared.ExecutionEnvironmentStub;
-import org.eclipse.tycho.core.shared.MavenContextImpl;
+import org.eclipse.tycho.core.shared.MockMavenContext;
 import org.eclipse.tycho.core.shared.TargetEnvironment;
 import org.eclipse.tycho.p2.impl.publisher.DependencyMetadata;
 import org.eclipse.tycho.p2.impl.test.ReactorProjectStub;
@@ -101,7 +101,7 @@ public class TargetPlatformFactoryTest {
         tpConfig = new TargetPlatformConfigurationStub();
         tpConfig.setEnvironments(Collections.singletonList(new TargetEnvironment(null, null, null))); // dummy value for target file resolution
         pomDependencyCollector = new PomDependencyCollectorImpl(
-                new MavenContextImpl(tempManager.newFolder("localRepo"), logVerifier.getLogger()),
+                new MockMavenContext(tempManager.newFolder("localRepo"), logVerifier.getLogger()),
                 new ReactorProjectStub(tempManager.newFolder(), "test"));
     }
 

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TestResolverFactory.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TestResolverFactory.java
@@ -30,10 +30,10 @@ import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.core.shared.DependencyResolutionException;
 import org.eclipse.tycho.core.shared.MavenArtifactRepositoryReference;
 import org.eclipse.tycho.core.shared.MavenContext;
-import org.eclipse.tycho.core.shared.MavenContextImpl;
 import org.eclipse.tycho.core.shared.MavenDependenciesResolver;
 import org.eclipse.tycho.core.shared.MavenLogger;
 import org.eclipse.tycho.core.shared.MavenModelFacade;
+import org.eclipse.tycho.core.shared.MockMavenContext;
 import org.eclipse.tycho.p2.impl.test.ArtifactMock;
 import org.eclipse.tycho.p2.impl.test.ReactorProjectStub;
 import org.eclipse.tycho.p2.remote.RemoteAgent;
@@ -99,7 +99,7 @@ public class TestResolverFactory implements P2ResolverFactory {
 
         File localMavenRepoRoot = mavenContext.getLocalRepositoryRoot();
         LocalRepositoryP2Indices localRepoIndices = createLocalRepoIndices(mavenContext);
-        LocalRepositoryReader localRepositoryReader = new LocalRepositoryReader(localMavenRepoRoot);
+        LocalRepositoryReader localRepositoryReader = new LocalRepositoryReader(mavenContext);
         localMetadataRepo = new LocalMetadataRepository(localMavenRepoRoot.toURI(), localRepoIndices.getMetadataIndex(),
                 localRepositoryReader);
         localArtifactRepo = new LocalArtifactRepository(localRepoIndices, localRepositoryReader);
@@ -110,7 +110,7 @@ public class TestResolverFactory implements P2ResolverFactory {
     }
 
     private MavenContext createMavenContext(boolean offline, MavenLogger logger) {
-        return new MavenContextImpl(getLocalRepositoryLocation(), offline, logger, new Properties());
+        return new MockMavenContext(getLocalRepositoryLocation(), offline, logger, new Properties());
     }
 
     // TODO use TemporaryLocalMavenRepository
@@ -128,7 +128,7 @@ public class TestResolverFactory implements P2ResolverFactory {
     @Override
     public PomDependencyCollectorImpl newPomDependencyCollector(ReactorProject project) {
         return new PomDependencyCollectorImpl(
-                new MavenContextImpl(mavenContext.getLocalRepositoryRoot(), mavenContext.getLogger()), project);
+                new MockMavenContext(mavenContext.getLocalRepositoryRoot(), mavenContext.getLogger()), project);
     }
 
     public PomDependencyCollectorImpl newPomDependencyCollector() {

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/ee/CustomEEResolutionHandlerTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/ee/CustomEEResolutionHandlerTest.java
@@ -29,7 +29,7 @@ import org.eclipse.tycho.core.ee.shared.ExecutionEnvironment;
 import org.eclipse.tycho.core.ee.shared.ExecutionEnvironmentConfiguration;
 import org.eclipse.tycho.core.ee.shared.SystemCapability;
 import org.eclipse.tycho.core.ee.shared.SystemCapability.Type;
-import org.eclipse.tycho.core.shared.MavenContextImpl;
+import org.eclipse.tycho.core.shared.MockMavenContext;
 import org.eclipse.tycho.p2.impl.test.ReactorProjectStub;
 import org.eclipse.tycho.p2.impl.test.ResourceUtil;
 import org.eclipse.tycho.p2.target.PomDependencyCollectorImpl;
@@ -61,7 +61,7 @@ public class CustomEEResolutionHandlerTest {
         tpFactory = new TestResolverFactory(logVerifier.getLogger()).getTargetPlatformFactory();
         tpConfig = new TargetPlatformConfigurationStub();
         pomDependencyCollector = new PomDependencyCollectorImpl(
-                new MavenContextImpl(tempManager.newFolder("localRepo"), logVerifier.getLogger()),
+                new MockMavenContext(tempManager.newFolder("localRepo"), logVerifier.getLogger()),
                 new ReactorProjectStub(tempManager.newFolder(), "test"));
     }
 

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/resolver/P2ResolverFactoryImpl.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/resolver/P2ResolverFactoryImpl.java
@@ -53,7 +53,7 @@ public class P2ResolverFactoryImpl implements P2ResolverFactory {
             LocalRepositoryP2Indices localRepoIndices) {
         if (localMetadataRepository == null) {
             File localMavenRepoRoot = context.getLocalRepositoryRoot();
-            RepositoryReader contentLocator = new LocalRepositoryReader(localMavenRepoRoot);
+            RepositoryReader contentLocator = new LocalRepositoryReader(context);
             localMetadataRepository = new LocalMetadataRepository(localMavenRepoRoot.toURI(),
                     localRepoIndices.getMetadataIndex(), contentLocator);
 
@@ -64,7 +64,7 @@ public class P2ResolverFactoryImpl implements P2ResolverFactory {
     private static synchronized LocalArtifactRepository getLocalArtifactRepository(MavenContext mavenContext,
             LocalRepositoryP2Indices localRepoIndices) {
         if (localArtifactRepository == null) {
-            RepositoryReader contentLocator = new LocalRepositoryReader(mavenContext.getLocalRepositoryRoot());
+            RepositoryReader contentLocator = new LocalRepositoryReader(mavenContext);
             localArtifactRepository = new LocalArtifactRepository(localRepoIndices, contentLocator);
         }
         return localArtifactRepository;

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/target/PomDependencyCollectorImpl.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/target/PomDependencyCollectorImpl.java
@@ -74,9 +74,7 @@ public class PomDependencyCollectorImpl implements PomDependencyCollector {
         this.project = project;
         this.logger = mavenContext.getLogger();
 
-        File localRepositoryRoot = mavenContext.getLocalRepositoryRoot();
-        this.bundlesPublisher = new TargetPlatformBundlePublisher(localRepositoryRoot, project,
-                mavenContext.getLogger());
+        this.bundlesPublisher = new TargetPlatformBundlePublisher(project, mavenContext);
         try {
             agent = Activator.createProvisioningAgent(project == null ? null : project.getBasedir().toURI());
         } catch (ProvisionException e) {

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/target/repository/MavenBundlesArtifactRepository.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/target/repository/MavenBundlesArtifactRepository.java
@@ -21,6 +21,7 @@ import java.io.File;
 import org.eclipse.core.runtime.AssertionFailedException;
 import org.eclipse.equinox.p2.metadata.IArtifactKey;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactDescriptor;
+import org.eclipse.tycho.core.shared.MavenContext;
 import org.eclipse.tycho.p2.metadata.IArtifactFacade;
 import org.eclipse.tycho.p2.repository.MavenRepositoryCoordinates;
 import org.eclipse.tycho.repository.local.GAVArtifactDescriptor;
@@ -49,8 +50,11 @@ import org.eclipse.tycho.repository.p2base.artifact.repository.ArtifactRepositor
  */
 public final class MavenBundlesArtifactRepository extends ArtifactRepositoryBaseImpl<GAVArtifactDescriptor> {
 
-    public MavenBundlesArtifactRepository(File localMavenRepositoryRoot) {
-        super(null, localMavenRepositoryRoot.toURI(), ArtifactTransferPolicies.forLocalArtifacts());
+    private MavenContext mavenContext;
+
+    public MavenBundlesArtifactRepository(MavenContext mavenContext) {
+        super(null, mavenContext.getLocalRepositoryRoot().toURI(), ArtifactTransferPolicies.forLocalArtifacts());
+        this.mavenContext = mavenContext;
     }
 
     public void addPublishedArtifact(IArtifactDescriptor baseDescriptor, IArtifactFacade mavenArtifact) {
@@ -62,7 +66,7 @@ public final class MavenBundlesArtifactRepository extends ArtifactRepositoryBase
                 repositoryCoordinates);
 
         File requiredArtifactLocation = new File(getBaseDir(),
-                descriptorForRepository.getMavenCoordinates().getLocalRepositoryPath());
+                descriptorForRepository.getMavenCoordinates().getLocalRepositoryPath(mavenContext));
         File actualArtifactLocation = mavenArtifact.getLocation();
         if (!equivalentPaths(requiredArtifactLocation, actualArtifactLocation)) {
             throw new AssertionFailedException(
@@ -102,7 +106,8 @@ public final class MavenBundlesArtifactRepository extends ArtifactRepositoryBase
 
     @Override
     protected File internalGetArtifactStorageLocation(IArtifactDescriptor descriptor) {
-        String relativePath = toInternalDescriptor(descriptor).getMavenCoordinates().getLocalRepositoryPath();
+        String relativePath = toInternalDescriptor(descriptor).getMavenCoordinates()
+                .getLocalRepositoryPath(mavenContext);
         return new File(getBaseDir(), relativePath);
     }
 

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.shared/src/main/java/org/eclipse/tycho/p2/repository/LocalRepositoryP2Indices.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.shared/src/main/java/org/eclipse/tycho/p2/repository/LocalRepositoryP2Indices.java
@@ -15,6 +15,8 @@ package org.eclipse.tycho.p2.repository;
 
 import java.io.File;
 
+import org.eclipse.tycho.core.shared.MavenContext;
+
 /**
  * This service provides access to the tycho p2 index files of the local maven repository.
  */
@@ -25,5 +27,7 @@ public interface LocalRepositoryP2Indices {
     public TychoRepositoryIndex getMetadataIndex();
 
     public File getBasedir();
+
+    MavenContext getMavenContext();
 
 }

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.shared/src/main/java/org/eclipse/tycho/p2/repository/LocalRepositoryReader.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.shared/src/main/java/org/eclipse/tycho/p2/repository/LocalRepositoryReader.java
@@ -13,18 +13,28 @@
 package org.eclipse.tycho.p2.repository;
 
 import java.io.File;
+import java.util.Objects;
+
+import org.eclipse.tycho.core.shared.MavenContext;
 
 public class LocalRepositoryReader implements RepositoryReader {
 
-    private final File localMavenRepositoryRoot;
+    private MavenContext mavenContext;
 
-    public LocalRepositoryReader(File localMavenRepositoryRoot) {
-        this.localMavenRepositoryRoot = localMavenRepositoryRoot;
+    public LocalRepositoryReader(MavenContext mavenContext) {
+        Objects.requireNonNull(mavenContext);
+        this.mavenContext = mavenContext;
     }
 
     @Override
-    public File getLocalArtifactLocation(GAV gav, String classifier, String extension) {
-        return new File(localMavenRepositoryRoot, RepositoryLayoutHelper.getRelativePath(gav, classifier, extension));
+    public File getLocalArtifactLocation(GAV gav, String classifier, String type) {
+        return new File(mavenContext.getLocalRepositoryRoot(),
+                RepositoryLayoutHelper.getRelativePath(gav, classifier, type, mavenContext));
+    }
+
+    @Override
+    public MavenContext getMavenContext() {
+        return mavenContext;
     }
 
 }

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.shared/src/main/java/org/eclipse/tycho/p2/repository/MavenRepositoryCoordinates.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.shared/src/main/java/org/eclipse/tycho/p2/repository/MavenRepositoryCoordinates.java
@@ -12,13 +12,15 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2.repository;
 
+import org.eclipse.tycho.core.shared.MavenContext;
+
 /**
  * Coordinates (groupId, artifactId, version, classifier, extension) of an artifact in the local
  * Maven repository.
  */
 public final class MavenRepositoryCoordinates {
 
-    public static final String DEFAULT_EXTENSION = RepositoryLayoutHelper.DEFAULT_EXTERNSION;
+    public static final String DEFAULT_EXTERNSION = "jar";
 
     private final GAV gav;
     private final String classifier;
@@ -27,7 +29,7 @@ public final class MavenRepositoryCoordinates {
     public MavenRepositoryCoordinates(GAV gav, String classifier, String extension) {
         this.gav = gav; // TODO check for null?
         this.classifier = classifier;
-        this.extension = DEFAULT_EXTENSION.equals(extension) ? null : extension;
+        this.extension = DEFAULT_EXTERNSION.equals(extension) ? null : extension;
     }
 
     public MavenRepositoryCoordinates(String groupId, String artifactId, String version, String classifier,
@@ -67,7 +69,7 @@ public final class MavenRepositoryCoordinates {
 
     public String getExtensionOrDefault() {
         if (extension == null)
-            return DEFAULT_EXTENSION;
+            return DEFAULT_EXTERNSION;
         else
             return extension;
     }
@@ -75,8 +77,10 @@ public final class MavenRepositoryCoordinates {
     /**
      * Returns the local Maven repository path corresponding to the these coordinates.
      */
-    public String getLocalRepositoryPath() {
-        return RepositoryLayoutHelper.getRelativePath(getGav(), getClassifier(), getExtension());
+    public String getLocalRepositoryPath(MavenContext mavenContext) {
+        //FIXME this is actually the type!!
+        String type = getExtension();
+        return RepositoryLayoutHelper.getRelativePath(getGav(), getClassifier(), type, mavenContext);
     }
 
     @Override

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.shared/src/main/java/org/eclipse/tycho/p2/repository/RepositoryReader.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.shared/src/main/java/org/eclipse/tycho/p2/repository/RepositoryReader.java
@@ -15,6 +15,8 @@ package org.eclipse.tycho.p2.repository;
 
 import java.io.File;
 
+import org.eclipse.tycho.core.shared.MavenContext;
+
 /**
  * Interface to obtain artifacts from GAV-indexed repositories.
  */
@@ -26,6 +28,8 @@ public interface RepositoryReader {
      * 
      * @return the local location of the artifact; never <code>null</code>
      */
-    File getLocalArtifactLocation(GAV gav, String classifier, String extension);
+    File getLocalArtifactLocation(GAV gav, String classifier, String type);
+
+    MavenContext getMavenContext();
 
 }

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.shared/src/main/java/org/eclipse/tycho/p2/repository/TychoRepositoryIndex.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.shared/src/main/java/org/eclipse/tycho/p2/repository/TychoRepositoryIndex.java
@@ -15,6 +15,8 @@ package org.eclipse.tycho.p2.repository;
 import java.io.IOException;
 import java.util.Set;
 
+import org.eclipse.tycho.core.shared.MavenContext;
+
 public interface TychoRepositoryIndex {
 
     /**
@@ -50,5 +52,7 @@ public interface TychoRepositoryIndex {
      * @throws IOException
      */
     void save() throws IOException;
+
+    MavenContext getMavenContext();
 
 }

--- a/tycho-bundles/org.eclipse.tycho.p2.tools.tests/src/test/java/org/eclipse/tycho/p2/tools/mirroring/MirrorApplicationServiceTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.tools.tests/src/test/java/org/eclipse/tycho/p2/tools/mirroring/MirrorApplicationServiceTest.java
@@ -37,7 +37,7 @@ import org.eclipse.equinox.p2.metadata.VersionedId;
 import org.eclipse.tycho.ReactorProjectIdentities;
 import org.eclipse.tycho.core.resolver.shared.DependencySeed;
 import org.eclipse.tycho.core.shared.MavenContext;
-import org.eclipse.tycho.core.shared.MavenContextImpl;
+import org.eclipse.tycho.core.shared.MockMavenContext;
 import org.eclipse.tycho.core.shared.TargetEnvironment;
 import org.eclipse.tycho.p2.tools.BuildContext;
 import org.eclipse.tycho.p2.tools.DestinationRepositoryDescriptor;
@@ -88,7 +88,7 @@ public class MirrorApplicationServiceTest {
         context = new BuildContext(currentProject, DEFAULT_QUALIFIER, DEFAULT_ENVIRONMENTS);
 
         subject = new MirrorApplicationServiceImpl();
-        MavenContext mavenContext = new MavenContextImpl(null, logVerifier.getLogger());
+        MavenContext mavenContext = new MockMavenContext(null, logVerifier.getLogger());
         subject.setMavenContext(mavenContext);
     }
 

--- a/tycho-bundles/org.eclipse.tycho.p2.tools.tests/src/test/java/org/eclipse/tycho/p2/tools/mirroring/MirrorStandaloneTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.tools.tests/src/test/java/org/eclipse/tycho/p2/tools/mirroring/MirrorStandaloneTest.java
@@ -25,7 +25,7 @@ import java.util.Collections;
 import org.eclipse.tycho.BuildDirectory;
 import org.eclipse.tycho.BuildOutputDirectory;
 import org.eclipse.tycho.core.shared.MavenContext;
-import org.eclipse.tycho.core.shared.MavenContextImpl;
+import org.eclipse.tycho.core.shared.MockMavenContext;
 import org.eclipse.tycho.p2.tools.DestinationRepositoryDescriptor;
 import org.eclipse.tycho.p2.tools.FacadeException;
 import org.eclipse.tycho.p2.tools.RepositoryReferences;
@@ -55,7 +55,7 @@ public class MirrorStandaloneTest {
     public void initTestContext() throws Exception {
         destinationRepo = new DestinationRepositoryDescriptor(tempFolder.newFolder("dest"), DEFAULT_NAME);
         subject = new MirrorApplicationServiceImpl();
-        MavenContext mavenContext = new MavenContextImpl(null, logVerifier.getLogger());
+        MavenContext mavenContext = new MockMavenContext(null, logVerifier.getLogger());
         subject.setMavenContext(mavenContext);
         targetFolder = new BuildOutputDirectory(tempFolder.getRoot());
     }

--- a/tycho-bundles/org.eclipse.tycho.p2.tools.tests/src/test/java/org/eclipse/tycho/p2/tools/verfier/VerifierServiceImplTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.tools.tests/src/test/java/org/eclipse/tycho/p2/tools/verfier/VerifierServiceImplTest.java
@@ -23,8 +23,8 @@ import java.util.Locale;
 
 import org.eclipse.tycho.BuildOutputDirectory;
 import org.eclipse.tycho.core.shared.MavenContext;
-import org.eclipse.tycho.core.shared.MavenContextImpl;
 import org.eclipse.tycho.core.shared.MavenLogger;
+import org.eclipse.tycho.core.shared.MockMavenContext;
 import org.eclipse.tycho.p2.tools.FacadeException;
 import org.eclipse.tycho.p2.tools.RepositoryReferences;
 import org.eclipse.tycho.p2.tools.verifier.VerifierServiceImpl;
@@ -45,7 +45,7 @@ public class VerifierServiceImplTest {
     public void setup() {
         subject = new VerifierServiceImpl();
         logger = new ErrorStoreMemoryLog();
-        MavenContext mavenContext = new MavenContextImpl(null, logger);
+        MavenContext mavenContext = new MockMavenContext(null, logger);
         subject.setMavenContext(mavenContext);
     }
 

--- a/tycho-bundles/org.eclipse.tycho.test.utils/src/main/java/org/eclipse/tycho/repository/local/testutil/TemporaryLocalMavenRepository.java
+++ b/tycho-bundles/org.eclipse.tycho.test.utils/src/main/java/org/eclipse/tycho/repository/local/testutil/TemporaryLocalMavenRepository.java
@@ -16,9 +16,11 @@ import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.equinox.internal.p2.core.helpers.FileUtils;
+import org.eclipse.tycho.core.shared.MockMavenContext;
 import org.eclipse.tycho.p2.repository.LocalRepositoryP2Indices;
 import org.eclipse.tycho.repository.local.LocalArtifactRepository;
 import org.eclipse.tycho.repository.local.index.LocalRepositoryP2IndicesImpl;
+import org.eclipse.tycho.test.util.LogVerifier;
 import org.eclipse.tycho.test.util.NoopFileLockService;
 import org.junit.Rule;
 import org.junit.rules.ExternalResource;
@@ -31,6 +33,8 @@ import org.junit.rules.TemporaryFolder;
  */
 @SuppressWarnings("restriction")
 public class TemporaryLocalMavenRepository extends ExternalResource {
+
+    public LogVerifier logVerifier = new LogVerifier();
     private final TemporaryFolder tempManager = new TemporaryFolder();
     private File repoRoot;
     private LocalRepositoryP2Indices repoIndex;
@@ -69,7 +73,8 @@ public class TemporaryLocalMavenRepository extends ExternalResource {
     }
 
     private void createLocalRepoIndices() {
-        repoIndex = new LocalRepositoryP2IndicesImpl(getLocalRepositoryRoot(), new NoopFileLockService());
+        repoIndex = new LocalRepositoryP2IndicesImpl(
+                new MockMavenContext(getLocalRepositoryRoot(), logVerifier.getLogger()), new NoopFileLockService());
     }
 
     public LocalArtifactRepository getLocalArtifactRepository() {

--- a/tycho-bundles/org.eclipse.tycho.test.utils/src/main/java/org/eclipse/tycho/test/util/MavenServiceStubbingTestBase.java
+++ b/tycho-bundles/org.eclipse.tycho.test.utils/src/main/java/org/eclipse/tycho/test/util/MavenServiceStubbingTestBase.java
@@ -49,7 +49,14 @@ public class MavenServiceStubbingTestBase {
     }
 
     private MavenContext createMavenContext() throws Exception {
-        MavenContext mavenContext = new MavenContextImpl(temporaryFolder.newFolder("target"), logVerifier.getLogger());
+        MavenContext mavenContext = new MavenContextImpl(temporaryFolder.newFolder("target"), logVerifier.getLogger()) {
+
+            @Override
+            public String getExtension(String artifactType) {
+                return artifactType;
+            }
+
+        };
         return mavenContext;
     }
 

--- a/tycho-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/tycho-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -452,5 +452,35 @@
     </component>
 
 
+    <component>
+      <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+      <role-hint>p2-artifacts</role-hint>
+      <implementation>
+        org.apache.maven.artifact.handler.DefaultArtifactHandler
+      </implementation>
+      <configuration>
+        <extension>xml</extension>
+        <type>p2-artifacts</type>
+        <language>P2</language>
+        <addedToClasspath>false</addedToClasspath>
+        <includesDependencies>false</includesDependencies>
+      </configuration>
+    </component>
+    
+     <component>
+      <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+      <role-hint>p2-metadata</role-hint>
+      <implementation>
+        org.apache.maven.artifact.handler.DefaultArtifactHandler
+      </implementation>
+      <configuration>
+        <extension>xml</extension>
+        <type>p2-metadata</type>
+        <language>P2</language>
+        <addedToClasspath>false</addedToClasspath>
+        <includesDependencies>false</includesDependencies>
+      </configuration>
+    </component>
+
   </components>
 </component-set>

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
@@ -840,13 +840,6 @@ public abstract class AbstractTestMojo extends AbstractMojo {
             }
             testRuntime.addBundle(artifact);
         }
-        for (Artifact artifact : project.getAttachedArtifacts()) {
-            if (ArtifactType.TYPE_ECLIPSE_TEST_FRAGMENT.equals(artifact.getClassifier())) {
-                DefaultArtifactKey key = new DefaultArtifactKey(artifact.getClassifier(), artifact.getId(),
-                        artifact.getVersion());
-                testRuntime.addBundle(key, artifact.getFile());
-            }
-        }
 
         Set<Artifact> testFrameworkBundles = providerHelper.filterTestFrameworkBundles(provider, pluginArtifacts);
         for (Artifact artifact : testFrameworkBundles) {


### PR DESCRIPTION
Currently Tycho uses a confusing mixture of "artifact-types" and "extensions". With this change, the extension for a given artifact type is looked up in the maven artifacthandler registry instead.

The whole code is rather deeply baked into tycho so we need some backward-compat handling to make it work, but we will be more flexible and possible remove some of them in the future.

This will especially become handy if we want better expression of tycho dependencies in the maven model.