### PR TITLE
Update to plexus-archiver to 4.2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- - Copyright (c) 2008, 2020 Sonatype Inc. and others.
+ - Copyright (c) 2008, 2022 Sonatype Inc. and others.
  - All rights reserved. This program and the accompanying materials
  - are made available under the terms of the Eclipse Public License v1.0
  - which accompanies this distribution, and is available at
@@ -173,7 +173,7 @@
 			<dependency>
 				<groupId>org.codehaus.plexus</groupId>
 				<artifactId>plexus-archiver</artifactId>
-				<version>4.2.2</version>
+				<version>4.2.7</version>
 			</dependency>
 			<dependency>
 				<groupId>org.codehaus.plexus</groupId>

--- a/tycho-extras/tycho-buildtimestamp-jgit/src/it/basic/prebuild.groovy
+++ b/tycho-extras/tycho-buildtimestamp-jgit/src/it/basic/prebuild.groovy
@@ -1,5 +1,6 @@
 import java.io.File;
 
+new File(basedir, "pom.xml").delete();
 org.eclipse.tycho.extras.buildtimestamp.jgit.test.UnzipFile.unzip(new File(basedir, "basic.zip"), basedir);
 
 return true;

--- a/tycho-extras/tycho-buildtimestamp-jgit/src/it/dirtySubmodules/prebuild.groovy
+++ b/tycho-extras/tycho-buildtimestamp-jgit/src/it/dirtySubmodules/prebuild.groovy
@@ -1,5 +1,6 @@
 import java.io.File;
 
+new File(basedir, "pom.xml").delete();
 org.eclipse.tycho.extras.buildtimestamp.jgit.test.UnzipFile.unzip(new File(basedir, "dirtySubmodules.zip"), basedir);
 
 // this will cause the build to fail due to dirty working tree

--- a/tycho-extras/tycho-buildtimestamp-jgit/src/it/dirtyUnrelatedSubmodules/prebuild.groovy
+++ b/tycho-extras/tycho-buildtimestamp-jgit/src/it/dirtyUnrelatedSubmodules/prebuild.groovy
@@ -1,5 +1,6 @@
 import java.io.File;
 
+new File(basedir, "pom.xml").delete();
 org.eclipse.tycho.extras.buildtimestamp.jgit.test.UnzipFile.unzip(new File(basedir, "dirtyUnrelatedSubmodules.zip"), basedir);
 
 // this will cause a dirty unrelated submodule "unrelatedSubmodule"

--- a/tycho-extras/tycho-buildtimestamp-jgit/src/it/dirtyWorkingTreeWarningOnly/prebuild.groovy
+++ b/tycho-extras/tycho-buildtimestamp-jgit/src/it/dirtyWorkingTreeWarningOnly/prebuild.groovy
@@ -1,5 +1,6 @@
 import java.io.File;
 
+new File(basedir, "pom.xml").delete();
 org.eclipse.tycho.extras.buildtimestamp.jgit.test.UnzipFile.unzip(new File(basedir, "basic.zip"), basedir);
 
 // this will cause a warning and fallback to default timestamp provider due to dirty working tree

--- a/tycho-extras/tycho-buildtimestamp-jgit/src/it/dirtyworkingtree/prebuild.groovy
+++ b/tycho-extras/tycho-buildtimestamp-jgit/src/it/dirtyworkingtree/prebuild.groovy
@@ -1,5 +1,6 @@
 import java.io.File;
 
+new File(basedir, "pom.xml").delete();
 org.eclipse.tycho.extras.buildtimestamp.jgit.test.UnzipFile.unzip(new File(basedir, "basic.zip"), basedir);
 
 // this will cause the build to fail due to dirty working tree

--- a/tycho-extras/tycho-buildtimestamp-jgit/src/it/submodules/prebuild.groovy
+++ b/tycho-extras/tycho-buildtimestamp-jgit/src/it/submodules/prebuild.groovy
@@ -1,5 +1,6 @@
 import java.io.File;
 
+new File(basedir, "pom.xml").delete();
 org.eclipse.tycho.extras.buildtimestamp.jgit.test.UnzipFile.unzip(new File(basedir, "submodules.zip"), basedir);
 
 return true;


### PR DESCRIPTION
Dummy pom.xml file is needed for invoker to start but it overrides it
with content of zip file.
Due to https://github.com/codehaus-plexus/plexus-archiver/pull/128
archiver never overrides it as it has newer mdate than what's in
archive. Delete manually before extracting.