### PR TITLE
Fix #643 - tycho-surefire-plugin:integration-test does not execute any test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin/
 .settings/
 *.iml
 .idea/
+.tycho-consumer-pom.xml

--- a/sisu-equinox/sisu-equinox-launching/src/main/java/org/eclipse/sisu/equinox/launching/DefaultEquinoxInstallationDescription.java
+++ b/sisu-equinox/sisu-equinox-launching/src/main/java/org/eclipse/sisu/equinox/launching/DefaultEquinoxInstallationDescription.java
@@ -144,7 +144,7 @@ public class DefaultEquinoxInstallationDescription implements EquinoxInstallatio
     @Override
     public void addDevEntries(String id, String entries) {
         if (entries != null) {
-            devEntries.put(id, entries);
+            devEntries.merge(id, entries, (s1, s2) -> s1 + "," + s2);
         }
     }
 

--- a/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/TychoConstants.java
+++ b/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/TychoConstants.java
@@ -28,6 +28,7 @@ public interface TychoConstants {
     static final String CTX_TEST_DEPENDENCY_ARTIFACTS = CTX_BASENAME + "/testDependencyArtifacts";
     static final String CTX_ECLIPSE_PLUGIN_PROJECT = CTX_BASENAME + "/eclipsePluginProject";
     static final String CTX_ECLIPSE_PLUGIN_TEST_CLASSPATH = CTX_BASENAME + "/eclipsePluginTestClasspath";
+    static final String CTX_ECLIPSE_PLUGIN_TEST_EXTRA_CLASSPATH = CTX_BASENAME + "/eclipsePluginTestClasspathExtra";
 
     static final String CTX_MERGED_PROPERTIES = CTX_BASENAME + "/mergedProperties";
     static final String CTX_TARGET_PLATFORM_CONFIGURATION = CTX_BASENAME + "/targetPlatformConfiguration";

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/BundleProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/BundleProject.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2011 Sonatype Inc. and others.
+ * Copyright (c) 2008, 2022 Sonatype Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -37,6 +37,8 @@ public interface BundleProject extends TychoProject {
 
     public List<ArtifactKey> getExtraTestRequirements(ReactorProject project);
 
-    public List<ClasspathEntry> getTestClasspath(ReactorProject adapt);
+    public List<ClasspathEntry> getTestClasspath(ReactorProject project);
+
+    public List<ClasspathEntry> getTestClasspath(ReactorProject project, boolean complete);
 
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiBundleProject.java
@@ -663,16 +663,28 @@ public class OsgiBundleProject extends AbstractTychoProject implements BundlePro
 
     @Override
     public List<ClasspathEntry> getTestClasspath(ReactorProject reactorProject) {
-        @SuppressWarnings("unchecked")
+        return getTestClasspath(reactorProject, true);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<ClasspathEntry> getTestClasspath(ReactorProject reactorProject, boolean complete) {
         List<ClasspathEntry> classpath = (List<ClasspathEntry>) reactorProject
                 .getContextValue(TychoConstants.CTX_ECLIPSE_PLUGIN_TEST_CLASSPATH);
         if (classpath == null) {
             List<ClasspathEntry> testClasspath = new ArrayList<>(getClasspath(reactorProject));
-            testClasspath.addAll(computeExtraTestClasspath(reactorProject));
+            Collection<ClasspathEntry> extraTestClasspath = computeExtraTestClasspath(reactorProject);
+            reactorProject.setContextValue(TychoConstants.CTX_ECLIPSE_PLUGIN_TEST_EXTRA_CLASSPATH, extraTestClasspath);
+            testClasspath.addAll(extraTestClasspath);
             reactorProject.setContextValue(TychoConstants.CTX_ECLIPSE_PLUGIN_TEST_CLASSPATH, testClasspath);
             return testClasspath;
         }
-        return classpath;
+        if (complete) {
+            return classpath;
+        } else {
+            return (List<ClasspathEntry>) reactorProject
+                    .getContextValue(TychoConstants.CTX_ECLIPSE_PLUGIN_TEST_EXTRA_CLASSPATH);
+        }
     }
 
     public DependencyArtifacts getTestDependencyArtifacts(ReactorProject project) {

--- a/tycho-its/projects/surefire.combinedtests/bundle.test/.classpath
+++ b/tycho-its/projects/surefire.combinedtests/bundle.test/.classpath
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
-		<attributes>
-			<attribute name="module" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" output="test" path="src_test">
 		<attributes>
@@ -18,5 +12,12 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/tycho-its/projects/surefire.combinedtests/bundle.test/build.properties
+++ b/tycho-its/projects/surefire.combinedtests/bundle.test/build.properties
@@ -2,4 +2,3 @@ source.. = src/,src2/
 output.. = bin/
 bin.includes = META-INF/,\
                .
-additional.bundles = org.junit

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/TestsInBundleTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/TestsInBundleTest.java
@@ -13,34 +13,59 @@
 package org.eclipse.tycho.test.surefire;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.util.Arrays;
 
+import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.junit.Test;
 
 public class TestsInBundleTest extends AbstractTychoIntegrationTest {
 
-    @Test
-    public void testCompile() throws Exception {
-        Verifier verifier = getVerifier("surefire.combinedtests/bundle.test");
-        verifier.executeGoals(Arrays.asList("clean", "test-compile"));
-        verifier.verifyErrorFreeLog();
-        assertTrue("compiled class file does not exist",
-                new File(verifier.getBasedir(), "target/classes/bundle/test/Counter.class").exists());
-        assertTrue("compiled test-class file does not exist",
-                new File(verifier.getBasedir(), "target/test-classes/bundle/test/AdderTest.class").exists());
-    }
+	@Test
+	public void testCompile() throws Exception {
+		Verifier verifier = getVerifier("surefire.combinedtests/bundle.test");
+		verifier.executeGoals(Arrays.asList("clean", "test-compile"));
+		verifier.verifyErrorFreeLog();
+		assertTrue("compiled class file does not exist",
+				new File(verifier.getBasedir(), "target/classes/bundle/test/Counter.class").exists());
+		assertTrue("compiled test-class file does not exist",
+				new File(verifier.getBasedir(), "target/test-classes/bundle/test/AdderTest.class").exists());
+	}
 
-    @Test
-    public void testTest() throws Exception {
-        Verifier verifier = getVerifier("surefire.combinedtests/bundle.test");
-        verifier.executeGoals(Arrays.asList("clean", "test"));
-        verifier.verifyErrorFreeLog();
-        assertTrue("tests were not run",
-                new File(verifier.getBasedir(), "target/surefire-reports/bundle.test.AdderTest.txt").exists());
-    }
+	@Test
+	public void testTest() throws Exception {
+		Verifier verifier = getVerifier("surefire.combinedtests/bundle.test");
+		verifier.executeGoals(Arrays.asList("clean", "test"));
+		verifier.verifyErrorFreeLog();
+		assertTrue("tests were not run",
+				new File(verifier.getBasedir(), "target/surefire-reports/bundle.test.AdderTest.txt").exists());
+	}
+
+	@Test
+	public void testIntegrationTest() throws Exception {
+		Verifier verifier = getVerifier("surefire.combinedtests/bundle.test");
+		verifier.executeGoals(Arrays.asList("clean", "integration-test"));
+		verifier.verifyErrorFreeLog();
+		assertTrue("summary report not found",
+				new File(verifier.getBasedir(), "target/failsafe-reports/failsafe-summary.xml").exists());
+		verifier.verifyTextInLog("Tests run: 2, Failures: 1, Errors: 0, Skipped: 0");
+		verifier.verifyTextInLog("OSGiRunningIT.willFail:30 This fail is intentional");
+	}
+
+	@Test
+	public void testVerify() throws Exception {
+		Verifier verifier = getVerifier("surefire.combinedtests/bundle.test");
+		try {
+			verifier.executeGoals(Arrays.asList("clean", "verify"));
+			fail("the build succeed but test-failures are expected!");
+		} catch (VerificationException e) {
+			// thats good indeed...
+			verifier.verifyTextInLog("There are test failures");
+		}
+	}
 
 }

--- a/tycho-surefire/tycho-surefire-plugin/pom.xml
+++ b/tycho-surefire/tycho-surefire-plugin/pom.xml
@@ -107,6 +107,13 @@
 		</dependency>
 
 		<dependency>
+			<groupId>biz.aQute.bnd</groupId>
+			<artifactId>biz.aQute.bndlib</artifactId>
+			<version>5.1.2</version>
+			<type>jar</type>
+		</dependency>
+
+		<dependency>
 			<groupId>org.eclipse.tycho</groupId>
 			<artifactId>org.eclipse.tycho.surefire.osgibooter</artifactId>
 			<version>${project.version}</version>

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TychoIntegrationTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/TychoIntegrationTestMojo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Sonatype Inc. and others.
+ * Copyright (c) 2021, 2022 Christoph Läubrich and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,18 +14,41 @@ package org.eclipse.tycho.surefire;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
+import java.util.jar.Manifest;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.apache.commons.io.FilenameUtils;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.resolver.ArtifactResolutionRequest;
+import org.apache.maven.artifact.resolver.ArtifactResolutionResult;
+import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
+import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.surefire.booter.PropertiesWrapper;
 import org.apache.maven.surefire.util.ScanResult;
+import org.eclipse.sisu.equinox.launching.EquinoxInstallationDescription;
+import org.eclipse.tycho.ArtifactKey;
 import org.eclipse.tycho.PackagingType;
+import org.eclipse.tycho.ReactorProject;
+import org.eclipse.tycho.classpath.ClasspathEntry;
+import org.eclipse.tycho.core.osgitools.DefaultReactorProject;
+import org.eclipse.tycho.surefire.provider.impl.NoopTestFrameworkProvider;
 import org.eclipse.tycho.surefire.provider.spi.TestFrameworkProvider;
+import org.osgi.framework.Constants;
+
+import aQute.bnd.osgi.Analyzer;
+import aQute.bnd.osgi.Jar;
 
 /**
  * <p>
@@ -75,6 +98,18 @@ public class TychoIntegrationTestMojo extends AbstractTestMojo {
     @Parameter(defaultValue = "${project.build.directory}/failsafe-reports", required = true)
     private File reportDirectory;
 
+    @Parameter(defaultValue = "${plugin}", readonly = true, required = true)
+    private PluginDescriptor pluginDescriptor;
+
+    @Parameter(defaultValue = "${project.pluginArtifactRepositories}", readonly = true, required = true)
+    private List<ArtifactRepository> pluginRemoteRepositories;
+
+    @Parameter(defaultValue = "${project.remoteArtifactRepositories}", required = true, readonly = true)
+    private List<ArtifactRepository> projectRemoteRepositories;
+
+    @Parameter(defaultValue = "${localRepository}", required = true, readonly = true)
+    private ArtifactRepository localRepository;
+
     @Override
     protected boolean shouldRun() {
         return PackagingType.TYPE_ECLIPSE_PLUGIN.equals(project.getPackaging()) && scanForTests().size() > 0;
@@ -123,4 +158,123 @@ public class TychoIntegrationTestMojo extends AbstractTestMojo {
     protected void handleTestFailures() throws MojoFailureException {
         //nothing to do will be handled in verify phase
     }
+
+    @Override
+    protected void setupTestBundles(TestFrameworkProvider provider, EquinoxInstallationDescription testRuntime)
+            throws MojoExecutionException {
+        List<Dependency> dependencies = pluginDescriptor.getPlugin().getDependencies();
+        if (dependencies.isEmpty()) {
+            super.setupTestBundles(provider, testRuntime);
+        } else {
+            super.setupTestBundles(new NoopTestFrameworkProvider(), testRuntime);
+            for (Dependency dependency : dependencies) {
+                ArtifactResolutionResult resolveArtifact = resolveDependency(dependency);
+                for (Artifact artifact : resolveArtifact.getArtifacts()) {
+                    File file = artifact.getFile();
+                    if (file != null) {
+                        testRuntime.addDevEntries("org.eclipse.tycho.surefire.osgibooter", file.getAbsolutePath());
+                    }
+                }
+            }
+        }
+        ReactorProject reactorProject = DefaultReactorProject.adapt(project);
+        File testPluginJar = createTestPluginJar(reactorProject);
+        ArtifactKey bundleArtifactKey = getBundleArtifactKey(testPluginJar);
+        testRuntime.addBundle(bundleArtifactKey, testPluginJar, true);
+        String bsn = bundleArtifactKey.getId();
+        List<ClasspathEntry> testClasspath = osgiBundle.getTestClasspath(reactorProject, false);
+        //here we add the whole (test) classpath as a dev-entry to the runtime fragment, this is required to optionally load any test-scoped class that is not imported and not available as an OSGi bundle
+        String testDevEntries = testClasspath.stream().map(ClasspathEntry::getLocations).flatMap(Collection::stream)
+                .map(File::getAbsolutePath).collect(Collectors.joining(","));
+        testRuntime.addDevEntries(bsn, testDevEntries);
+    }
+
+    /**
+     * This generates a bundle that is a fragment to the host that enhances the original bundle by
+     * the following items:
+     * <ol>
+     * <li>any 'additional bundle', even though this is not really meant to be used that way, is
+     * added as an optional dependency</li>
+     * <li>a <code>DynamicImport-Package: *</code> is added to allow dynamic classloading from the
+     * bundle classpath</li>
+     * <li>computes package imports based on the generated test classes and add them as optional
+     * imports, so that any class is consumed from the OSGi runtime before the inner classes are
+     * searched.</li>
+     * </ol>
+     * 
+     * @param reactorProject
+     * @return
+     * @throws MojoExecutionException
+     */
+    private File createTestPluginJar(ReactorProject reactorProject) throws MojoExecutionException {
+        try {
+            UUID uuid = UUID.randomUUID();
+            File fragmentFile = new File(project.getBuild().getDirectory(),
+                    FilenameUtils.getBaseName(reactorProject.getArtifact().getName()) + "_test_fragment_" + uuid
+                            + ".jar");
+            if (fragmentFile.exists()) {
+                fragmentFile.delete();
+            }
+            try (Jar mainArtifact = new Jar(reactorProject.getArtifact());
+                    Jar jar = new Jar(reactorProject.getName() + " test classes",
+                            new File(project.getBuild().getTestOutputDirectory()), null);
+                    Analyzer analyzer = new Analyzer(jar)) {
+                Manifest bundleManifest = mainArtifact.getManifest();
+                String hostVersion = bundleManifest.getMainAttributes().getValue(Constants.BUNDLE_VERSION);
+                String hostSymbolicName = bundleManifest.getMainAttributes().getValue(Constants.BUNDLE_SYMBOLICNAME);
+                analyzer.setProperty(Constants.BUNDLE_VERSION, hostVersion);
+                analyzer.setProperty(Constants.BUNDLE_SYMBOLICNAME, hostSymbolicName + "." + uuid);
+                analyzer.setProperty(Constants.FRAGMENT_HOST,
+                        hostSymbolicName + ";" + Constants.BUNDLE_VERSION_ATTRIBUTE + "=\"" + hostVersion + "\"");
+                analyzer.setProperty(Constants.BUNDLE_NAME, "Test Fragment for " + project.getGroupId() + ":"
+                        + project.getArtifactId() + ":" + project.getVersion());
+                analyzer.setProperty(Constants.IMPORT_PACKAGE, "*;resolution:=optional");
+                Collection<String> additionalBundles = reactorProject.getBuildProperties().getAdditionalBundles();
+                if (!additionalBundles.isEmpty()) {
+                    analyzer.setProperty(Constants.REQUIRE_BUNDLE, additionalBundles.stream()
+                            .map(b -> b + ";resolution:=optional").collect(Collectors.joining(",")));
+                }
+                analyzer.setProperty(Constants.DYNAMICIMPORT_PACKAGE, "*");
+                List<ClasspathEntry> testClasspath = osgiBundle.getTestClasspath(reactorProject);
+                for (ClasspathEntry classpathEntry : testClasspath) {
+                    for (File loc : classpathEntry.getLocations()) {
+                        analyzer.addClasspath(loc);
+                    }
+                }
+                analyzer.addClasspath(mainArtifact);
+                jar.setManifest(analyzer.calcManifest());
+                jar.write(fragmentFile);
+            }
+            return fragmentFile;
+        } catch (Exception e) {
+            throw new MojoExecutionException("Error assembling test fragment jar", e);
+        }
+
+    }
+
+    private ArtifactResolutionResult resolveDependency(Dependency dependency) {
+        Artifact artifact = repositorySystem.createDependencyArtifact(dependency);
+        ArtifactResolutionRequest request = new ArtifactResolutionRequest()//
+                .setOffline(session.isOffline())//
+                .setArtifact(artifact)//
+                .setLocalRepository(localRepository)//
+                .setResolveTransitively(true)//
+                .setCollectionFilter(new ProviderDependencyArtifactFilter())//
+                .setRemoteRepositories(
+                        Stream.concat(pluginRemoteRepositories.stream(), projectRemoteRepositories.stream())
+                                .collect(Collectors.toList()));
+        return repositorySystem.resolve(request);
+    }
+
+    private static final class ProviderDependencyArtifactFilter implements ArtifactFilter {
+        private static final Collection<String> SCOPES = List.of(Artifact.SCOPE_COMPILE,
+                Artifact.SCOPE_COMPILE_PLUS_RUNTIME, Artifact.SCOPE_RUNTIME);
+
+        @Override
+        public boolean include(Artifact artifact) {
+            String scope = artifact.getScope();
+            return !artifact.isOptional() && (scope == null || SCOPES.contains(scope));
+        }
+    }
+
 }

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/impl/NoopTestFrameworkProvider.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/impl/NoopTestFrameworkProvider.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.surefire.provider.impl;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.maven.model.Dependency;
+import org.eclipse.tycho.classpath.ClasspathEntry;
+import org.eclipse.tycho.surefire.provider.spi.TestFrameworkProvider;
+import org.osgi.framework.Version;
+
+public final class NoopTestFrameworkProvider implements TestFrameworkProvider {
+
+    @Override
+    public String getType() {
+        return "noop";
+    }
+
+    @Override
+    public Version getVersion() {
+        return Version.emptyVersion;
+    }
+
+    @Override
+    public String getSurefireProviderClassName() {
+        return "none";
+    }
+
+    @Override
+    public boolean isEnabled(List<ClasspathEntry> testBundleClassPath, Properties providerProperties) {
+        return false;
+    }
+
+    @Override
+    public List<Dependency> getRequiredBundles() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Properties getProviderSpecificProperties() {
+        return new Properties();
+    }
+
+}


### PR DESCRIPTION
- add delete integration tests back
- generate a fragment to the host for additional imports

FYI @LorenzoBettini  this will at least get back the integration tests even though the test should better not use additional-bundles but a JUNIT classpath container....