### PR TITLE
NPE in MirrorMojo when using target platform as source

### DIFF
--- a/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/MirrorMojo.java
+++ b/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/MirrorMojo.java
@@ -236,12 +236,14 @@ public class MirrorMojo extends AbstractMojo {
         } else {
             sourceDescriptor = new RepositoryReferences();
         }
-        for (final Repository sourceRepository : source) {
-            if (sourceRepository.getLayout().hasMetadata()) {
-                sourceDescriptor.addMetadataRepository(sourceRepository.getLocation());
-            }
-            if (sourceRepository.getLayout().hasArtifacts()) {
-                sourceDescriptor.addArtifactRepository(sourceRepository.getLocation());
+        if (source != null) {
+            for (final Repository sourceRepository : source) {
+                if (sourceRepository.getLayout().hasMetadata()) {
+                    sourceDescriptor.addMetadataRepository(sourceRepository.getLocation());
+                }
+                if (sourceRepository.getLayout().hasArtifacts()) {
+                    sourceDescriptor.addArtifactRepository(sourceRepository.getLocation());
+                }
             }
         }
         if (sourceDescriptor.getArtifactRepositories().isEmpty()

--- a/tycho-extras/tycho-p2-extras-plugin/src/test/java/org/eclipse/tycho/plugins/p2/extras/MirrorMojoTest.java
+++ b/tycho-extras/tycho-p2-extras-plugin/src/test/java/org/eclipse/tycho/plugins/p2/extras/MirrorMojoTest.java
@@ -26,6 +26,7 @@ import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.LegacySupport;
 import org.apache.maven.plugin.Mojo;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.repository.RepositorySystem;
 import org.apache.maven.shared.utils.io.FileUtils;
@@ -115,6 +116,21 @@ public class MirrorMojoTest extends AbstractTychoMojoTestCase {
         assertEquals(2, new File(mirrorDestinationDir, "plugins").listFiles().length);
         assertMirroredBundle(mirrorDestinationDir, "test.bundle1", "1.0.0.201108100850");
         assertMirroredBundle(mirrorDestinationDir, "test.bundle2", "1.0.0.201108100850");
+    }
+
+    public void testTargetPlatformAsSource() throws Exception {
+        Iu featureIU = new Iu();
+        featureIU.id = "test.feature.feature.group";
+        setVariableValueToObject(mirrorMojo, "ius", Collections.singletonList(featureIU));
+        setVariableValueToObject(mirrorMojo, "targetPlatformAsSource", Boolean.TRUE);
+        try {
+            // Source is allowed to be empty, for example when targetPlatformAsSource is set, but in this test
+            // project we have no target platform so it should fail gracefully instead of throwing a NPE
+            mirrorMojo.execute();
+            fail();
+        } catch (MojoExecutionException e) {
+            assertEquals(e.getMessage(), "No repository provided as 'source'");
+        }
     }
 
     private static void assertMirroredBundle(File publishedContentDir, String bundleID, String version) {


### PR DESCRIPTION
Source is allowed to be unset when sourcing bundles from the target
platform (i.e. when targetPlatformAsSource is set) so just add a
null check and continue.
