### PR TITLE
Integration tests for #658

### DIFF
--- a/tycho-extras/tycho-extras-its/src/test/java/org/eclipse/tycho/extras/mirror/TestMirrorRepositories.java
+++ b/tycho-extras/tycho-extras-its/src/test/java/org/eclipse/tycho/extras/mirror/TestMirrorRepositories.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Mat Booth and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.tycho.extras.mirror;
+
+import static java.util.Arrays.asList;
+import static org.eclipse.tycho.test.util.TychoMatchers.isFile;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.File;
+import java.util.List;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.extras.its.AbstractTychoExtrasIntegrationTest;
+import org.eclipse.tycho.test.util.P2RepositoryTool;
+import org.eclipse.tycho.test.util.P2RepositoryTool.IU;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestMirrorRepositories extends AbstractTychoExtrasIntegrationTest {
+
+    /*
+     * The test projects are configured to mirror mockito and its deps. Mockito is interesting to
+     * test because it is published with GPG signatures, so we can check that those are mirrored
+     * correctly too.
+     */
+    private static final String MOCKITO_ID = "org.mockito.mockito-core";
+
+    /**
+     * Mirror from explicit source repository specified here - bundles are pulled directly from the
+     * repository URL given in the plug-in configuration
+     */
+    @Test
+    public void testMirroringFromExplicitSource() throws Exception {
+        verifyMirrorRepo("mirrortest-from-explicit-source");
+    }
+
+    /**
+     * Test mirroring from the target platform - bundles are resolved from the target platform,
+     * which are resolved from the cache in ~/.m2/repository/p2
+     */
+    @Test
+    public void testMirroringFromTargetPlatform() throws Exception {
+        verifyMirrorRepo("mirrortest-from-target-platform");
+    }
+
+    private void verifyMirrorRepo(String testCase) throws Exception {
+        Verifier verifier = getVerifier(testCase, false);
+        File mirrorLocation = new File(verifier.getBasedir(), "target/repository");
+        verifier.addCliOption("-Dmirror.location=" + mirrorLocation);
+        verifier.executeGoals(asList("clean", "verify"));
+        verifier.verifyErrorFreeLog();
+        Assert.assertTrue("Repo mirror does not exist at " + mirrorLocation, mirrorLocation.exists());
+        P2RepositoryTool repo = P2RepositoryTool.forEclipseRepositoryModule(new File(verifier.getBasedir()));
+
+        // Ensure the bundle exists in the metadata repo and a physical artifact exists
+        IU mockito = repo.getUniqueIU(MOCKITO_ID);
+        assertThat(repo.getBundleArtifact(MOCKITO_ID, mockito.getVersion()), isFile());
+        repo.getBundleArtifact(MOCKITO_ID, mockito.getVersion());
+
+        // Check for mirrored GPG properties in the artifact repo -- we know these are present in the upstream repo that is being mirrored
+        List<String> properties = mockito.getArtifactProperties();
+        String sigBlock = null;
+        String pubKeyBlock = null;
+        for (String property : properties) {
+            if (property.startsWith("pgp.signatures=-----BEGIN PGP SIGNATURE-----")
+                    && property.endsWith("-----END PGP SIGNATURE-----")) {
+                sigBlock = property;
+            }
+            if (property.startsWith("pgp.publicKeys=-----BEGIN PGP PUBLIC KEY BLOCK-----")
+                    && property.endsWith("-----END PGP PUBLIC KEY BLOCK-----")) {
+                pubKeyBlock = property;
+            }
+        }
+        assertNotNull("No GPG signature property found in artifact repo for " + MOCKITO_ID, sigBlock);
+        assertNotNull("No GPG public key property found in artifact repo for " + MOCKITO_ID, pubKeyBlock);
+    }
+}

--- a/tycho-extras/tycho-extras-its/src/test/resources/mirrortest-from-explicit-source/category.xml
+++ b/tycho-extras/tycho-extras-its/src/test/resources/mirrortest-from-explicit-source/category.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+</site>

--- a/tycho-extras/tycho-extras-its/src/test/resources/mirrortest-from-explicit-source/pom.xml
+++ b/tycho-extras/tycho-extras-its/src/test/resources/mirrortest-from-explicit-source/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (c) 2022 Mat Booth. This program and the accompanying materials 
+	are made available under the terms of the Eclipse Public License 2.0 which 
+	accompanies this distribution, and is available at https://www.eclipse.org/legal/epl-2.0/ 
+	SPDX-License-Identifier: EPL-2.0 -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.example</groupId>
+	<artifactId>mirrortest</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>eclipse-repository</packaging>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.eclipse.tycho.extras</groupId>
+					<artifactId>tycho-p2-extras-plugin</artifactId>
+					<version>${tycho-version}</version>
+					<configuration>
+						<ius>
+							<iu>
+								<id>org.mockito.mockito-core</id>
+							</iu>
+						</ius>
+						<includeOptional>false</includeOptional>
+						<includeNonGreedy>false</includeNonGreedy>
+						<latestVersionOnly>true</latestVersionOnly>
+						<compress>false</compress>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho.extras</groupId>
+				<artifactId>tycho-p2-extras-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<executions>
+					<!-- Mirror from explicit source repository specified here - bundles 
+						are pulled directly from the repository URL given in the plug-in configuration -->
+					<execution>
+						<id>mirror-from-explicit-source</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>mirror</goal>
+						</goals>
+						<configuration>
+							<destination>${mirror.location}</destination>
+							<targetPlatformAsSource>false</targetPlatformAsSource>
+							<currentModuleAsSource>false</currentModuleAsSource>
+							<source>
+								<repository>
+									<url>https://download.eclipse.org/eclipse/updates/4.23-I-builds/</url>
+									<layout>p2</layout>
+								</repository>
+							</source>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-extras/tycho-extras-its/src/test/resources/mirrortest-from-target-platform/category.xml
+++ b/tycho-extras/tycho-extras-its/src/test/resources/mirrortest-from-target-platform/category.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+   <bundle id="net.bytebuddy.byte-buddy" version="0.0.0"/>
+   <bundle id="net.bytebuddy.byte-buddy-agent" version="0.0.0"/>
+   <bundle id="org.mockito.mockito-core" version="0.0.0"/>
+   <bundle id="org.objenesis" version="0.0.0"/>
+</site>

--- a/tycho-extras/tycho-extras-its/src/test/resources/mirrortest-from-target-platform/mirrortest-target-platform.target
+++ b/tycho-extras/tycho-extras-its/src/test/resources/mirrortest-from-target-platform/mirrortest-target-platform.target
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target includeMode="feature" name="target-platform">
+	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/eclipse/updates/4.23-I-builds/"/>
+			<unit id="net.bytebuddy.byte-buddy" version="0.0.0"/>
+			<unit id="net.bytebuddy.byte-buddy-agent" version="0.0.0"/>
+			<unit id="org.mockito.mockito-core" version="0.0.0"/>
+			<unit id="org.objenesis" version="0.0.0"/>
+		</location>
+	</locations>
+	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+</target>

--- a/tycho-extras/tycho-extras-its/src/test/resources/mirrortest-from-target-platform/pom.xml
+++ b/tycho-extras/tycho-extras-its/src/test/resources/mirrortest-from-target-platform/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (c) 2022 Mat Booth. This program and the accompanying materials 
+	are made available under the terms of the Eclipse Public License 2.0 which 
+	accompanies this distribution, and is available at https://www.eclipse.org/legal/epl-2.0/ 
+	SPDX-License-Identifier: EPL-2.0 -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.example</groupId>
+	<artifactId>mirrortest</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>eclipse-repository</packaging>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.eclipse.tycho.extras</groupId>
+					<artifactId>tycho-p2-extras-plugin</artifactId>
+					<version>${tycho-version}</version>
+					<configuration>
+						<ius>
+							<iu>
+								<id>org.mockito.mockito-core</id>
+							</iu>
+						</ius>
+						<includeOptional>false</includeOptional>
+						<includeNonGreedy>false</includeNonGreedy>
+						<latestVersionOnly>true</latestVersionOnly>
+						<compress>false</compress>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<target>
+						<file>mirrortest-target-platform.target</file>
+					</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho.extras</groupId>
+				<artifactId>tycho-p2-extras-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<executions>
+					<!-- Mirror from the target platform - bundles are resolved from the 
+						target platform, which are resolved from the cache in ~/.m2/repository/p2 -->
+					<execution>
+						<id>mirror-from-target-platform</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>mirror</goal>
+						</goals>
+						<configuration>
+							<destination>${mirror.location}</destination>
+							<targetPlatformAsSource>true</targetPlatformAsSource>
+							<currentModuleAsSource>false</currentModuleAsSource>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>


### PR DESCRIPTION
Adds two mirror mojo-based integration tests:
 * Mirror a gpg-signed bundle direct from an upstream repo using
   explicit source configuration
 * Mirror a gpg-signed bundle indirectly from the tycho target
   platform
