### PR TITLE
[Tycho-Build] remove duplicated dependency

### DIFF
--- a/tycho-build/pom.xml
+++ b/tycho-build/pom.xml
@@ -35,11 +35,6 @@
 			<artifactId>org.eclipse.tycho.core.shared</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>org.eclipse.tycho</groupId>
-			<artifactId>org.eclipse.tycho.p2.maven.repository</artifactId>
-			<version>3.0.0-SNAPSHOT</version>
-		</dependency>
 		<!--
 		<dependency>
 			<groupId>org.eclipse.tycho</groupId>


### PR DESCRIPTION
When building Tycho I get a warning about a duplicated dependency `org.eclipse.tycho:org.eclipse.tycho.p2.maven.repository` one with specified version and one with a variable `${project.version}`. I think the variable version should be used instead.

I actually discovered this on the 2.7 branch but I expect the warning to persist on the master as well.