### PR TITLE
[Oomph-Setup] add missing/remove obsolete projects and remove mavendev

### DIFF
--- a/setup/Tycho.setup
+++ b/setup/Tycho.setup
@@ -90,8 +90,6 @@
     <requirement
         name="org.sonatype.m2e.plexus.annotations.feature.feature.group"/>
     <requirement
-        name="com.ifedorenko.m2e.mavendev.feature.feature.group"/>
-    <requirement
         name="com.ianbrandt.tools.m2e.mdp.feature.feature.group"/>
     <requirement
         name="org.eclipse.m2e.feature.feature.group"/>
@@ -185,6 +183,13 @@
         xsi:type="maven:MavenImportTask"
         projectNameTemplate="">
       <sourceLocator
+          rootFolder="${git.cloneTycho.location}/tycho-build"/>
+      <description>Import Maven Project</description>
+    </setupTask>
+    <setupTask
+        xsi:type="maven:MavenImportTask"
+        projectNameTemplate="">
+      <sourceLocator
           rootFolder="${git.cloneTycho.location}/tycho-bundles"
           locateNestedProjects="true"/>
       <description>Import Maven Project</description>
@@ -223,6 +228,20 @@
       <sourceLocator
           rootFolder="${git.cloneTycho.location}/tycho-extras"
           locateNestedProjects="true"/>
+      <description>Import Maven Project</description>
+    </setupTask>
+    <setupTask
+        xsi:type="maven:MavenImportTask"
+        projectNameTemplate="">
+      <sourceLocator
+          rootFolder="${git.cloneTycho.location}/tycho-gpg-plugin"/>
+      <description>Import Maven Project</description>
+    </setupTask>
+    <setupTask
+        xsi:type="maven:MavenImportTask"
+        projectNameTemplate="">
+      <sourceLocator
+          rootFolder="${git.cloneTycho.location}/tycho-its"/>
       <description>Import Maven Project</description>
     </setupTask>
     <setupTask
@@ -280,13 +299,6 @@
         xsi:type="maven:MavenImportTask"
         projectNameTemplate="">
       <sourceLocator
-          rootFolder="${git.cloneTycho.location}/tycho-releng"/>
-      <description>Import Maven Project</description>
-    </setupTask>
-    <setupTask
-        xsi:type="maven:MavenImportTask"
-        projectNameTemplate="">
-      <sourceLocator
           rootFolder="${git.cloneTycho.location}/tycho-source-plugin"/>
       <description>Import Maven Project</description>
     </setupTask>
@@ -303,13 +315,6 @@
         projectNameTemplate="">
       <sourceLocator
           rootFolder="${git.cloneTycho.location}/tycho-testing-harness"/>
-      <description>Import Maven Project</description>
-    </setupTask>
-    <setupTask
-        xsi:type="maven:MavenImportTask"
-        projectNameTemplate="">
-      <sourceLocator
-          rootFolder="${git.cloneTycho.location}/tycho-its"/>
       <description>Import Maven Project</description>
     </setupTask>
     <description>Maven Project Import</description>


### PR DESCRIPTION
This adapts Tycho's Oomph-setup to recent project changes and adds the new projects (`tycho-build` and `tycho-gpg)` and removes `tycho-releng` and moves `tycho-its` to its place in the otherwise alpabetically sorted list of projects.

Furthermore the `com.ifedorenko.m2e.mavendev.feature` is removed from the P2-Director since it uses internal API of M2E that has been removed recently (https://github.com/eclipse-m2e/m2e-core/pull/548) and therefore makes it impossible to launch Maven builds from the IDE.