### PR TITLE
Fix #671 - fix and consider tycho.mode=maven

### DIFF
--- a/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoPomlessLifecycleParticipant.java
+++ b/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoPomlessLifecycleParticipant.java
@@ -39,7 +39,6 @@ public class TychoPomlessLifecycleParticipant extends AbstractMavenLifecyclePart
 
     @Override
     public void afterSessionStart(MavenSession session) throws MavenExecutionException {
-        session.getUserProperties().setProperty("tycho.mode", "extension");
         File moduleProjectDirectory = session.getRequest().getMultiModuleProjectDirectory();
         if (moduleProjectDirectory != null) {
             File extensionsFile = new File(moduleProjectDirectory, ".mvn/extensions.xml");


### PR DESCRIPTION
This PR aims to fix issue #671 that `tycho.mode=maven` is not considered correctly anymore.

The first problem is that the value of `tycho.mode` is overwritten in `TychoGraphBuilder` and `TychoPomlessLifecycleParticipant` by the value `extension`. Since I was not able to identify a use case for the overwritten value I simply removed the assignment.

The second problem is that the `TargetPlatformMojo` and the `ValidateClasspathMojo` are not executed correctly when `tycho.mode=maven` is set. One way is to handle this in Tycho is to skip the runs as I just did now in this PR. Another way should be to handle this in the m2e build by binding the default execution of those two mojos to the `None` phase and to suppress them this way. I will check if that works out tomorrow. 

