### PR TITLE
Increase bootstramp version of Tycho to 2.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
 		<ecjVersion>3.28.0</ecjVersion>
 
 		<!-- version of Tycho used by this build -->
-		<tychoBootstrapVersion>2.6.0</tychoBootstrapVersion>
+		<tychoBootstrapVersion>2.7.0</tychoBootstrapVersion>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
Without this setting the local Tycho build fails for me very early with
errors bundlelocation not found