### PR TITLE
Issue #707 - fix logic detecting custom vs none EE profile

### DIFF
--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/target/ee/StandardEEResolutionHandler.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/target/ee/StandardEEResolutionHandler.java
@@ -15,7 +15,6 @@ package org.eclipse.tycho.p2.target.ee;
 
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
@@ -45,8 +44,6 @@ class StandardEEResolutionHandler extends ExecutionEnvironmentResolutionHandler 
     @Override
     public void readFullSpecification(Collection<IInstallableUnit> targetPlatformContent) {
         if (environmentConfiguration.ignoreExecutionEnvironment()) {
-            //if it is ignored not setting the specification leads to strange errors in downstream mojos...
-            environmentConfiguration.setFullSpecificationForCustomProfile(Collections.emptyList());
             //and we might want to inform the user about ignored items...
             logger.info("The following Execution Environments are currently known but are ignored by configuration:");
             Map<String, Collection<String>> map = targetPlatformContent.stream()//

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/ee/ExecutionEnvironmentConfigurationImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/ee/ExecutionEnvironmentConfigurationImpl.java
@@ -102,6 +102,9 @@ public class ExecutionEnvironmentConfigurationImpl implements ExecutionEnvironme
 
     @Override
     public boolean isCustomProfile() {
+        if (ignoreExecutionEnvironment()) {
+            return false;
+        }
         String profileName = getProfileName();
         boolean profileExists = ExecutionEnvironmentUtils.getProfileNames().contains(profileName);
         if (!profileExists && ignoredByResolver) {
@@ -127,15 +130,15 @@ public class ExecutionEnvironmentConfigurationImpl implements ExecutionEnvironme
 
     @Override
     public ExecutionEnvironment getFullSpecification() throws IllegalStateException {
+        if (ignoreExecutionEnvironment()) {
+            return NoExecutionEnvironment.INSTANCE;
+        }
         if (isCustomProfile()) {
             if (customExecutionEnvironment == null) {
                 throw new IllegalStateException(
                         "Full specification of custom profile '" + getProfileName() + "' is not (yet) determined");
             }
             return customExecutionEnvironment;
-        }
-        if (ignoreExecutionEnvironment()) {
-            return NoExecutionEnvironment.INSTANCE;
         }
         return ExecutionEnvironmentUtils.getExecutionEnvironment(getProfileName(), toolchainManager, session, logger);
     }

--- a/tycho-its/projects/eeProfile.none/feature/build.properties
+++ b/tycho-its/projects/eeProfile.none/feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/tycho-its/projects/eeProfile.none/feature/feature.xml
+++ b/tycho-its/projects/eeProfile.none/feature/feature.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="feature"
+      version="1.0.0.qualifier">
+
+</feature>

--- a/tycho-its/projects/eeProfile.none/feature/pom.xml
+++ b/tycho-its/projects/eeProfile.none/feature/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>tycho-its-project.eeProfile.none</groupId>
+	<artifactId>feature</artifactId>
+	<packaging>eclipse-feature</packaging>
+	<version>1.0.0-SNAPSHOT</version>
+	
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<executionEnvironment>none</executionEnvironment>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho.extras</groupId>
+				<artifactId>tycho-p2-extras-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<executions>
+					<execution>
+						<goals><goal>compare-version-with-baselines</goal></goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/compare/CompareWithBaselineTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/compare/CompareWithBaselineTest.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc. and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tycho.test.compare;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.Test;
+
+public class CompareWithBaselineTest extends AbstractTychoIntegrationTest {
+
+	@Test
+	public void testEENone() throws Exception {
+		Verifier verifier = getVerifier("eeProfile.none/feature", false);
+		verifier.executeGoal("verify");
+		verifier.verifyErrorFreeLog();
+	}
+}


### PR DESCRIPTION
Fix some methods and conditions to better distinguish cases of ee=none
vs custom EE.
This allows further invocations of
TargetPlatformFactoryImpl.createTargetPlatform to work with ee=none.