### PR TITLE
Fix #757 - add a mojo to support generation of PDE headers

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,66 @@ This page describes the noteworthy improvements provided by each release of Ecli
 
 ## 3.0.0 (under development)
 
+### Automatic generation of PDE source bundles for pom-first bundles
+
+PDE requires some special headers to detect a bundle as a "Source Bundle", there is now a new mojo `tycho-source-plugin:generate-pde-source-header` that support this, it requires the following configuration:
+
+1. Enable the generation of a source-jar with the `maven-source-plugin`, please note that it needs to be explicitly bound to the `prepare-package` phase!
+```
+<plugin>
+	<groupId>org.apache.maven.plugins</groupId>
+	<artifactId>maven-source-plugin</artifactId>
+	<executions>
+		<execution>
+			<id>attach-sources</id>
+			<goals>
+				<goal>jar</goal>
+			</goals>
+			<phase>prepare-package</phase>
+		</execution>
+	</executions>
+</plugin>
+```
+2. enable the generation of the appropriate PDE header
+```
+<plugin>
+	<groupId>org.eclipse.tycho</groupId>
+	<artifactId>tycho-source-plugin</artifactId>
+	<version>${tycho-version}</version>
+	<executions>
+		<execution>
+			<id>generate-pde-source-header</id>
+			<goals>
+				<goal>generate-pde-source-header</goal>
+			</goals>
+		</execution>
+	</executions>
+</plugin>
+```
+3. finally enable generation of P2 metadata so tycho can use the source bundle in the build (you can omit this step if you don't want to reference the source bundle in a product, update-site or feature).
+```
+<plugin>
+	<groupId>org.eclipse.tycho</groupId>
+	<artifactId>tycho-p2-plugin</artifactId>
+	<version>${tycho-version}</version>
+	<executions>
+		<execution>
+			<id>attached-p2-metadata</id>
+			<phase>package</phase>
+			<goals>
+				<goal>p2-metadata</goal>
+			</goals>
+			<configuration>
+				<supportedProjectTypes>
+					<value>bundle</value>
+					<value>jar</value>
+				</supportedProjectTypes>
+			</configuration>
+		</execution>
+	</executions>
+</plugin>
+```
+
 ### Limit the number of parallel test executions across the reactor
 
 You can specify a `<reactorConcurrencyLevel>` (default unlimited) for the `tycho-surefire:integration-test` and `tycho-surefire:test` that limits the number of concurrent running tests.

--- a/tycho-source-plugin/pom.xml
+++ b/tycho-source-plugin/pom.xml
@@ -10,8 +10,7 @@
  -    Sonatype Inc. - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -83,6 +82,12 @@
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>biz.aQute.bnd</groupId>
+			<artifactId>biz.aQute.bndlib</artifactId>
+			<version>6.2.0</version>
+			<type>jar</type>
 		</dependency>
 	</dependencies>
 

--- a/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/OsgiSourceMojo.java
+++ b/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/OsgiSourceMojo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2020 Sonatype Inc. and others.
+ * Copyright (c) 2008, 2022 Sonatype Inc. and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -66,7 +66,7 @@ public class OsgiSourceMojo extends AbstractSourceJarMojo {
 
     private static final String GOAL = "plugin-source";
 
-    private static final String MANIFEST_HEADER_ECLIPSE_SOURCE_BUNDLE = "Eclipse-SourceBundle";
+    static final String MANIFEST_HEADER_ECLIPSE_SOURCE_BUNDLE = "Eclipse-SourceBundle";
     private static final String MANIFEST_BUNDLE_LOCALIZATION_BASENAME = BUNDLE_LOCALIZATION_DEFAULT_BASENAME + "-src";
     private static final String MANIFEST_BUNDLE_LOCALIZATION_FILENAME = MANIFEST_BUNDLE_LOCALIZATION_BASENAME
             + ".properties";

--- a/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/PDESourceBundleMojo.java
+++ b/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/PDESourceBundleMojo.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.tycho.source;
+
+import static org.osgi.framework.Constants.BUNDLE_MANIFESTVERSION;
+import static org.osgi.framework.Constants.BUNDLE_SYMBOLICNAME;
+import static org.osgi.framework.Constants.BUNDLE_VERSION;
+
+import java.io.File;
+import java.util.jar.Attributes;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.tycho.ReactorProject;
+
+import aQute.bnd.osgi.Jar;
+
+/**
+ * This mojo adds the required headers to a source artifact for it to be used in PDE as a source
+ * bundle
+ *
+ */
+@Mojo(name = "generate-pde-source-header", defaultPhase = LifecyclePhase.PACKAGE, threadSafe = true)
+public class PDESourceBundleMojo extends AbstractMojo {
+
+    @Parameter(property = "project", readonly = true, required = true)
+    protected MavenProject project;
+
+    @Parameter(property = "sourceBundleSuffix", defaultValue = ".source")
+    private String sourceBundleSuffix;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        String packaging = project.getPackaging();
+        if ("jar".equals(packaging) || "bundle".equals(packaging)) {
+            for (Artifact artifact : project.getAttachedArtifacts()) {
+                if (ReactorProject.SOURCE_ARTIFACT_CLASSIFIER.equalsIgnoreCase(artifact.getClassifier())
+                        && "java-source".equals(artifact.getType())) {
+                    File sourceFile = artifact.getFile();
+                    try (Jar hostBundle = new Jar(project.getArtifact().getFile());
+                            Jar sourceJar = new Jar(sourceFile)) {
+                        Attributes hostMain = hostBundle.getManifest().getMainAttributes();
+                        Attributes sourceMain = sourceJar.getManifest().getMainAttributes();
+                        String hostName = hostMain.getValue(BUNDLE_SYMBOLICNAME);
+                        String hostVersion = hostMain.getValue(BUNDLE_VERSION);
+                        sourceMain.putValue(BUNDLE_MANIFESTVERSION, "2");
+                        sourceMain.putValue(BUNDLE_SYMBOLICNAME, hostName + sourceBundleSuffix);
+                        sourceMain.putValue(BUNDLE_VERSION, hostVersion);
+                        sourceMain.putValue(OsgiSourceMojo.MANIFEST_HEADER_ECLIPSE_SOURCE_BUNDLE,
+                                hostName + ";version=\"" + hostVersion + "\";roots:=\".\"");
+                        String baseName = FilenameUtils.getBaseName(sourceFile.getName());
+                        File outputFile = new File(sourceFile.getParentFile(), baseName + "-pde.jar");
+                        sourceJar.write(outputFile);
+                        artifact.setFile(outputFile);
+                    } catch (Exception e) {
+                        throw new MojoFailureException("Update of manifest failed!", e);
+                    }
+                }
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
This is the very first working solution. We might want to improve later on the following things:

1. Check if we can hook into the `maven-source-plugin` to not need to explicitly configure `generate-pde-source-header` to run after the `maven-source-plugin`. e.g. we can call this automatic if the `plugin-source` is enabled
2. Check if we can call the necessary generation of P2 metadata automatically.