### PR TITLE
Fix IT tests to run with Java 17

### DIFF
--- a/tycho-its/projects/TYCHO0404pomDependencyConsiderExtraClasspath/extra/pom.xml
+++ b/tycho-its/projects/TYCHO0404pomDependencyConsiderExtraClasspath/extra/pom.xml
@@ -27,7 +27,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
+				<version>3.10.1</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/tycho-its/projects/TYCHO309pomDependencyConsider/artifact/pom.xml
+++ b/tycho-its/projects/TYCHO309pomDependencyConsider/artifact/pom.xml
@@ -18,7 +18,7 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>2.5.4</version>
+				<version>5.1.4</version>
 				<executions>
 					<execution>
 						<id>bundle-manifest</id>
@@ -31,7 +31,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
+				<version>3.10.1</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/tycho-its/projects/TYCHO309pomDependencyConsider/pom.xml
+++ b/tycho-its/projects/TYCHO309pomDependencyConsider/pom.xml
@@ -43,7 +43,7 @@
 			<plugins>
 				<plugin>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.8.1</version>
+					<version>3.10.1</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/tycho-its/projects/TYCHO418pomDependencyConsider/artifact/pom.xml
+++ b/tycho-its/projects/TYCHO418pomDependencyConsider/artifact/pom.xml
@@ -18,7 +18,7 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>2.5.4</version>
+				<version>5.1.4</version>
 				<executions>
 					<execution>
 						<id>bundle-manifest</id>
@@ -31,7 +31,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
+				<version>3.10.1</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/tycho-its/projects/TYCHO418pomDependencyConsider/pom.xml
+++ b/tycho-its/projects/TYCHO418pomDependencyConsider/pom.xml
@@ -46,7 +46,7 @@
 			<plugins>
 				<plugin>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.8.1</version>
+					<version>3.10.1</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/tycho-its/projects/TYCHO590annotationProcessing/annotated-project/pom.xml
+++ b/tycho-its/projects/TYCHO590annotationProcessing/annotated-project/pom.xml
@@ -15,10 +15,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
+				<version>3.10.1</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 					<fork>false</fork>
 					<compilerId>jdt</compilerId>
 					<annotationProcessors>

--- a/tycho-its/projects/TYCHO590annotationProcessing/pom.xml
+++ b/tycho-its/projects/TYCHO590annotationProcessing/pom.xml
@@ -16,10 +16,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
+				<version>3.10.1</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 					<fork>false</fork>
 					<compilerId>jdt</compilerId>
 				</configuration>

--- a/tycho-its/projects/compiler.mavenCompilerPlugin/pom.xml
+++ b/tycho-its/projects/compiler.mavenCompilerPlugin/pom.xml
@@ -23,7 +23,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
+				<version>3.10.1</version>
 				<configuration>
 					<compilerId>jdt</compilerId>
 					<compilerArgument>-err:unused</compilerArgument> 

--- a/tycho-its/projects/eeProfile.custom/repository/content.xml
+++ b/tycho-its/projects/eeProfile.custom/repository/content.xml
@@ -208,6 +208,9 @@
         <provided namespace='osgi.ee' name='JavaSE' version='1.4.0'/>
         <provided namespace='osgi.ee' name='JavaSE' version='1.5.0'/>
         <provided namespace='osgi.ee' name='JavaSE' version='1.6.0'/>
+        <provided namespace='osgi.ee' name='JavaSE' version='1.7.0'/>
+        <provided namespace='osgi.ee' name='JavaSE' version='1.8.0'/>
+        <provided namespace='osgi.ee' name='JavaSE' version='11'/>
       </provides>
       <touchpoint id='org.eclipse.equinox.p2.native' version='1.0.0'/>
     </unit>

--- a/tycho-its/projects/tycho.xtend/pom.xml
+++ b/tycho-its/projects/tycho.xtend/pom.xml
@@ -16,7 +16,7 @@
 	<repositories>
 		<repository>
 			<id>xtext</id>
-			<url>https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.25.0/</url>
+			<url>https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.26.0/</url>
 			<layout>p2</layout>
 		</repository>
 	</repositories>
@@ -26,7 +26,7 @@
 			<plugin>
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
-				<version>2.25.0</version>
+				<version>2.26.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/eeProfile/CustomProfileIntegrationTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/eeProfile/CustomProfileIntegrationTest.java
@@ -24,22 +24,24 @@ import org.junit.Test;
 
 public class CustomProfileIntegrationTest extends AbstractTychoIntegrationTest {
 
-    @Test
-    public void testBuildWithCustomProfile() throws Exception {
-        // reactor with a test bundle importing javax.activation;version="1.1.0"
-        Verifier verifier = getVerifier("eeProfile.custom/build", false);
+	@Test
+	public void testBuildWithCustomProfile() throws Exception {
+		// reactor with a test bundle importing javax.activation;version="1.1.0"
+		Verifier verifier = getVerifier("eeProfile.custom/build", false);
 
-        // repository where the custom EE is the only provider of javax.activation;version="1.1.0"
-        verifier.setSystemProperty("custom-profile-repo",
-                ResourceUtil.resolveTestResource("projects/eeProfile.custom/repository").toURI().toString());
+		// repository where the custom EE is the only provider of
+		// javax.activation;version="1.1.0"
+		verifier.setSystemProperty("custom-profile-repo",
+				ResourceUtil.resolveTestResource("projects/eeProfile.custom/repository").toURI().toString());
 
-        verifier.setSystemProperty("test-runtime-repo", ResourceUtil.P2Repositories.ECLIPSE_342.toString());
-        verifier.executeGoal("verify");
-        verifier.verifyErrorFreeLog();
+		verifier.setSystemProperty("test-runtime-repo", ResourceUtil.P2Repositories.ECLIPSE_LATEST.toString());
+		verifier.executeGoal("verify");
+		verifier.verifyErrorFreeLog();
 
-        // custom EE is in build result (because there is a dependency from the product via the bundle and includeAllDependencies=true)
-        P2RepositoryTool repo = P2RepositoryTool.forEclipseRepositoryModule(new File(verifier.getBasedir(), "product"));
-        P2RepositoryTool.IU customProfileIU = repo.getUniqueIU("a.jre.customprofile");
-        assertEquals("1.6.0", customProfileIU.getVersion());
-    }
+		// custom EE is in build result (because there is a dependency from the product
+		// via the bundle and includeAllDependencies=true)
+		P2RepositoryTool repo = P2RepositoryTool.forEclipseRepositoryModule(new File(verifier.getBasedir(), "product"));
+		P2RepositoryTool.IU customProfileIU = repo.getUniqueIU("a.jre.customprofile");
+		assertEquals("1.6.0", customProfileIU.getVersion());
+	}
 }


### PR DESCRIPTION
Java 17 no longer supports 1.6 bytecode target so have to update to
newer maven-compiler-plugin and change source/target values where set.
XTend 2.25 also has issues with Java 17 which are fixed by moving to
2.26.
Custom profile IT test had to provide newer JavaSE osgi.ee capability as
the old 3.4.2 eclipse is no longer starting with Java 17.