### PR TITLE
Issue #797 - add a custom transport based on URL#openStream() with caching of 404 responses

### DIFF
--- a/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/core/resolver/shared/MavenRepositoryLocation.java
+++ b/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/core/resolver/shared/MavenRepositoryLocation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 SAP AG and others.
+ * Copyright (c) 2012, 2022 SAP AG and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *    SAP AG - initial API and implementation
+ *    Christoph Läubrich - Issue #797 - Implement a caching P2 transport  
  *******************************************************************************/
 package org.eclipse.tycho.core.resolver.shared;
 

--- a/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/core/resolver/shared/MavenRepositorySettings.java
+++ b/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/core/resolver/shared/MavenRepositorySettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2013 SAP AG and others.
+ * Copyright (c) 2012, 2022 SAP AG and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,8 +9,11 @@
  *
  * Contributors:
  *    SAP AG - initial API and implementation
+ *    Christoph Läubrich - Issue #797 - Implement a caching P2 transport  
  *******************************************************************************/
 package org.eclipse.tycho.core.resolver.shared;
+
+import java.net.URI;
 
 /**
  * Provides the mirror configuration and credentials from the Maven settings for loading remote p2
@@ -21,10 +24,12 @@ public interface MavenRepositorySettings {
     public final class Credentials {
         private final String userName;
         private final String password;
+        private final URI url;
 
-        public Credentials(String userName, String password) {
+        public Credentials(String userName, String password, URI uri) {
             this.userName = userName;
             this.password = password;
+            this.url = uri;
         }
 
         public String getUserName() {
@@ -33,6 +38,10 @@ public interface MavenRepositorySettings {
 
         public String getPassword() {
             return password;
+        }
+
+        public URI getURI() {
+            return url;
         }
     }
 

--- a/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/core/shared/MavenContext.java
+++ b/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/core/shared/MavenContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 SAP AG and others.
+ * Copyright (c) 2011, 2022 SAP AG and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -16,8 +16,10 @@ package org.eclipse.tycho.core.shared;
 import java.io.File;
 import java.util.Collection;
 import java.util.Properties;
+import java.util.stream.Stream;
 
 import org.eclipse.tycho.ReactorProject;
+import org.eclipse.tycho.core.resolver.shared.MavenRepositoryLocation;
 
 /**
  * Makes maven information which is constant for the whole maven session available as a service to
@@ -33,6 +35,11 @@ public interface MavenContext {
      * whether maven was started in offline mode (CLI option "-o")
      */
     public boolean isOffline();
+
+    /**
+     * whether maven was started with the update-snapshots mode (CLI option "-U")
+     */
+    boolean isUpdateSnapshots();
 
     /**
      * Session-global properties merged from (in order of precedence)
@@ -58,5 +65,11 @@ public interface MavenContext {
      * @return the extension for the given type
      */
     public String getExtension(String artifactType);
+
+    /**
+     * 
+     * @return a collection of all {@link MavenRepositoryLocation}s know to the maven context
+     */
+    Stream<MavenRepositoryLocation> getMavenRepositoryLocations();
 
 }

--- a/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/core/shared/MockMavenContext.java
+++ b/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/core/shared/MockMavenContext.java
@@ -14,9 +14,11 @@ package org.eclipse.tycho.core.shared;
 
 import java.io.File;
 import java.util.Properties;
+import java.util.stream.Stream;
 
 import org.eclipse.tycho.ArtifactType;
 import org.eclipse.tycho.PackagingType;
+import org.eclipse.tycho.core.resolver.shared.MavenRepositoryLocation;
 
 public class MockMavenContext extends MavenContextImpl {
 
@@ -57,6 +59,16 @@ public class MockMavenContext extends MavenContextImpl {
         default:
             return "jar";
         }
+    }
+
+    @Override
+    public boolean isUpdateSnapshots() {
+        return false;
+    }
+
+    @Override
+    public Stream<MavenRepositoryLocation> getMavenRepositoryLocations() {
+        return Stream.empty();
     }
 
 }

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/local/GAVArtifactDescriptorTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/local/GAVArtifactDescriptorTest.java
@@ -21,7 +21,7 @@ import org.eclipse.equinox.internal.p2.metadata.ArtifactKey;
 import org.eclipse.equinox.p2.metadata.IArtifactKey;
 import org.eclipse.equinox.p2.metadata.Version;
 import org.eclipse.equinox.p2.repository.artifact.spi.ArtifactDescriptor;
-import org.eclipse.tycho.core.shared.MavenContextImpl;
+import org.eclipse.tycho.core.shared.MockMavenContext;
 import org.eclipse.tycho.p2.repository.GAV;
 import org.eclipse.tycho.p2.repository.MavenRepositoryCoordinates;
 import org.junit.Test;
@@ -170,7 +170,7 @@ public class GAVArtifactDescriptorTest {
                 OTHER_EXTENSION);
         subject = new GAVArtifactDescriptor(createP2Descriptor(), coordinates);
 
-        assertThat(subject.getMavenCoordinates().getLocalRepositoryPath(new MavenContextImpl(null, false, null, null) {
+        assertThat(subject.getMavenCoordinates().getLocalRepositoryPath(new MockMavenContext(null, false, null, null) {
 
             @Override
             public String getExtension(String artifactType) {
@@ -185,7 +185,7 @@ public class GAVArtifactDescriptorTest {
                 DEFAULT_EXTENSION);
         subject = new GAVArtifactDescriptor(createP2Descriptor(), coordinates);
 
-        assertThat(subject.getMavenCoordinates().getLocalRepositoryPath(new MavenContextImpl(null, false, null, null) {
+        assertThat(subject.getMavenCoordinates().getLocalRepositoryPath(new MockMavenContext(null, false, null, null) {
 
             @Override
             public String getExtension(String artifactType) {

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/manager/ReactorRepositoryManagerTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/manager/ReactorRepositoryManagerTest.java
@@ -77,7 +77,7 @@ public class ReactorRepositoryManagerTest extends MavenServiceStubbingTestBase {
     @Test
     public void testTargetPlatformComputationInIntegration() throws Exception {
         subject = getService(ReactorRepositoryManagerFacade.class);
-
+        assertThat(subject, is(notNullValue()));
         ReactorProject currentProject = new ReactorProjectStub("reactor-artifact");
 
         TargetPlatformConfigurationStub tpConfig = new TargetPlatformConfigurationStub();

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/remote/RemoteAgentMavenMirrorsTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/remote/RemoteAgentMavenMirrorsTest.java
@@ -54,10 +54,15 @@ public class RemoteAgentMavenMirrorsTest {
     public void initSubject() throws Exception {
         File localRepository = tempManager.newFolder("localRepo");
         MavenContext mavenContext = new MockMavenContext(localRepository, OFFLINE, logVerifier.getLogger(),
-                new Properties());
+                new Properties()) {
+            @Override
+            public boolean isUpdateSnapshots() {
+                return true;
+            }
+        };
 
         mavenRepositorySettings = new MavenRepositorySettingsStub();
-        subject = new RemoteAgent(mavenContext, mavenRepositorySettings, OFFLINE);
+        subject = new RemoteAgent(mavenContext, null, mavenRepositorySettings, OFFLINE);
     }
 
     @Test

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/META-INF/MANIFEST.MF
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/META-INF/MANIFEST.MF
@@ -33,6 +33,7 @@ Export-Package: org.eclipse.tycho.p2.impl;x-friends:="org.eclipse.tycho.p2.impl.
  org.eclipse.tycho.p2.target.ee;x-friends:="org.eclipse.tycho.p2.tools.impl",
  org.eclipse.tycho.p2.util.resolution
 Import-Package: org.apache.commons.io;version="2.8.0",
+ org.eclipse.ecf.provider.filetransfer.util;version="3.2.0",
  org.eclipse.tycho,
  org.eclipse.tycho.artifacts,
  org.eclipse.tycho.core.ee.shared,

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/OSGI-INF/remoteAgentManager.xml
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/OSGI-INF/remoteAgentManager.xml
@@ -6,4 +6,5 @@
    </service>
    <reference bind="setMavenContext" cardinality="1..1" interface="org.eclipse.tycho.core.shared.MavenContext" name="MavenContext" policy="static"/>
    <reference bind="setMavenRepositorySettings" cardinality="1..1" interface="org.eclipse.tycho.core.resolver.shared.MavenRepositorySettings" name="MavenRepositorySettings" policy="static"/>
+   <reference bind="setProxyService" cardinality="1..1" interface="org.eclipse.core.net.proxy.IProxyService" name="IProxyService" policy="static"/>
 </scr:component>

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/remote/CacheEntry.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/remote/CacheEntry.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.p2.remote;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.function.Function;
+
+import org.eclipse.core.net.proxy.IProxyService;
+import org.eclipse.tycho.core.resolver.shared.MavenRepositorySettings.Credentials;
+
+public interface CacheEntry {
+
+    long getLastModified(IProxyService proxyService, Function<URI, Credentials> credentialsProvider) throws IOException;
+
+    File getCacheFile(IProxyService proxyService, Function<URI, Credentials> credentialsProvider) throws IOException;
+}

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/remote/RemoteAgentManager.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/remote/RemoteAgentManager.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2.remote;
 
+import org.eclipse.core.net.proxy.IProxyService;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.core.ProvisionException;
 import org.eclipse.tycho.core.resolver.shared.MavenRepositorySettings;
@@ -33,6 +34,8 @@ public class RemoteAgentManager {
     // TODO stop when this service is stopped?
     private IProvisioningAgent cachedAgent;
 
+    private IProxyService proxyService;
+
     public RemoteAgentManager(MavenContext mavenContext) {
         this.mavenContext = mavenContext;
     }
@@ -44,7 +47,7 @@ public class RemoteAgentManager {
     public synchronized IProvisioningAgent getProvisioningAgent() throws ProvisionException {
         if (cachedAgent == null) {
             boolean disableP2Mirrors = getDisableP2MirrorsConfiguration();
-            cachedAgent = new RemoteAgent(mavenContext, mavenRepositorySettings, disableP2Mirrors);
+            cachedAgent = new RemoteAgent(mavenContext, proxyService, mavenRepositorySettings, disableP2Mirrors);
         }
         return cachedAgent;
     }
@@ -68,6 +71,10 @@ public class RemoteAgentManager {
 
     public void setMavenRepositorySettings(MavenRepositorySettings mavenRepositorySettings) {
         this.mavenRepositorySettings = mavenRepositorySettings;
+    }
+
+    public void setProxyService(IProxyService proxyService) {
+        this.proxyService = proxyService;
     }
 
 }

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/remote/RemoteRepositoryLoadingHelper.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/remote/RemoteRepositoryLoadingHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 SAP AG and others.
+ * Copyright (c) 2012, 2022 SAP AG and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,13 +9,15 @@
  *
  * Contributors:
  *    SAP AG - initial API and implementation
+ *    Christoph Läubrich - Issue #797 - Implement a caching P2 transport  
  *******************************************************************************/
 package org.eclipse.tycho.p2.remote;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
 
 import org.eclipse.equinox.p2.core.ProvisionException;
 import org.eclipse.tycho.core.resolver.shared.MavenRepositoryLocation;
@@ -31,7 +33,7 @@ class RemoteRepositoryLoadingHelper implements IRepositoryIdManager {
     private final MavenRepositorySettings settings;
     private final MavenLogger logger;
 
-    private Map<URI, String> knownMavenRepositoryIds = new HashMap<>();
+    private Map<URI, String> knownMavenRepositoryIds = new ConcurrentHashMap<>();
 
     public RemoteRepositoryLoadingHelper(MavenRepositorySettings settings, MavenLogger logger) {
         this.settings = settings;
@@ -132,6 +134,11 @@ class RemoteRepositoryLoadingHelper implements IRepositoryIdManager {
     private static boolean certainlyNoRemoteURL(URI location) {
         // e.g. in-memory composite artifact repositories; see see org.eclipse.equinox.internal.p2.artifact.repository.CompositeArtifactRepository.createMemoryComposite(IProvisioningAgent)
         return location.isOpaque() || !location.isAbsolute();
+    }
+
+    public Stream<MavenRepositoryLocation> getKnownMavenRepositoryLocations() {
+        return knownMavenRepositoryIds.entrySet().stream()
+                .map(e -> new MavenRepositoryLocation(e.getValue(), e.getKey()));
     }
 
 }

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/remote/SharedHttpCacheStorage.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/remote/SharedHttpCacheStorage.java
@@ -1,0 +1,592 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.p2.remote;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Authenticator;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.PasswordAuthentication;
+import java.net.Proxy;
+import java.net.Proxy.Type;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Base64;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.FileUtils;
+import org.eclipse.core.net.proxy.IProxyData;
+import org.eclipse.core.net.proxy.IProxyService;
+import org.eclipse.ecf.provider.filetransfer.util.ProxySetupHelper;
+import org.eclipse.equinox.internal.p2.repository.AuthenticationFailedException;
+import org.eclipse.tycho.core.resolver.shared.MavenRepositorySettings.Credentials;
+import org.eclipse.tycho.core.shared.MavenLogger;
+
+public class SharedHttpCacheStorage {
+
+    /**
+     * Assumes the following minimum caching period for remote files in minutes
+     */
+    //TODO can we sync this with the time where maven updates snapshots?
+    public static final long MIN_CACHE_PERIOD = Long.getLong("tycho.p2.transport.min-cache-minutes",
+            TimeUnit.HOURS.toMinutes(1));
+    private static final String PROXY_AUTHORIZATION_HEADER = "Proxy-Authorization";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String LAST_MODIFIED_HEADER = "Last-Modified";
+    private static final String EXPIRES_HEADER = "Expires";
+    private static final String CACHE_CONTROL_HEADER = "Cache-Control";
+    private static final String MAX_AGE_DIRECTIVE = "max-age";
+    private static final String MUST_REVALIDATE_DIRECTIVE = "must-revalidate";
+
+    private static final String ETAG_HEADER = "ETag";
+
+    private static final Map<CacheConfig, SharedHttpCacheStorage> storageMap = new HashMap<>();
+
+    private static final int MAX_IN_MEMORY = 1000;
+
+    private final Map<File, CacheLine> entryCache;
+
+    private CacheConfig cacheConfig;
+
+    private SharedHttpCacheStorage(CacheConfig cacheConfig) {
+
+        this.cacheConfig = cacheConfig;
+        entryCache = new LinkedHashMap<File, CacheLine>(100, 0.75f, true) {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            protected boolean removeEldestEntry(final Map.Entry<File, CacheLine> eldest) {
+                return (size() > MAX_IN_MEMORY);
+            }
+
+        };
+    }
+
+    /**
+     * Fetches the cache entry for this URI
+     * 
+     * @param uri
+     * @return
+     * @throws FileNotFoundException
+     *             if the URI is know to be not found
+     */
+    public CacheEntry getCacheEntry(URI uri, MavenLogger logger) throws FileNotFoundException {
+        CacheLine cacheLine = getCacheLine(uri);
+        if (!cacheConfig.update) { //if not updates are forced ...
+            int code = cacheLine.getResponseCode();
+            if (code == HttpURLConnection.HTTP_NOT_FOUND) {
+                throw new FileNotFoundException(uri.toASCIIString());
+            }
+            if (code == HttpURLConnection.HTTP_MOVED_PERM) {
+                return getCacheEntry(cacheLine.getRedirect(uri), logger);
+            }
+        }
+        return new CacheEntry() {
+
+            @Override
+            public long getLastModified(IProxyService proxyService, Function<URI, Credentials> credentialsProvider)
+                    throws IOException {
+                if (cacheConfig.offline) {
+                    return cacheLine.getLastModified(uri, proxyService, credentialsProvider,
+                            SharedHttpCacheStorage::mavenIsOffline, logger);
+                }
+                try {
+                    return cacheLine.fetchLastModified(uri, proxyService, credentialsProvider, logger);
+                } catch (FileNotFoundException | AuthenticationFailedException e) {
+                    //for not found and failed authentication we can't do anything useful
+                    throw e;
+                } catch (IOException e) {
+                    if (!cacheConfig.update && cacheLine.getResponseCode() > 0) {
+                        //if we have something cached, use that ...
+                        logger.warn("Request to " + uri + " failed, trying cache instead...");
+                        return cacheLine.getLastModified(uri, proxyService, credentialsProvider, nil -> e, logger);
+                    }
+                    throw e;
+                }
+            }
+
+            @Override
+            public File getCacheFile(IProxyService proxyService, Function<URI, Credentials> credentialsProvider)
+                    throws IOException {
+                if (cacheConfig.offline) {
+                    return cacheLine.getFile(uri, proxyService, credentialsProvider,
+                            SharedHttpCacheStorage::mavenIsOffline, logger);
+                }
+                try {
+                    return cacheLine.fetchFile(uri, proxyService, credentialsProvider, logger);
+                } catch (FileNotFoundException | AuthenticationFailedException e) {
+                    //for not found and failed authentication we can't do anything useful
+                    throw e;
+                } catch (IOException e) {
+                    if (!cacheConfig.update && cacheLine.getResponseCode() > 0) {
+                        //if we have something cached, use that ...
+                        logger.warn("Request to " + uri + " failed, trying cache instead...");
+                        return cacheLine.getFile(uri, proxyService, credentialsProvider, nil -> e, logger);
+                    }
+                    throw e;
+                }
+            }
+
+        };
+    }
+
+    private synchronized CacheLine getCacheLine(URI uri) {
+        File file = new File(cacheConfig.location,
+                uri.normalize().toASCIIString().replace(':', '/').replaceAll("/+", "/"));
+        File location;
+        try {
+            location = file.getCanonicalFile();
+        } catch (IOException e) {
+            location = file.getAbsoluteFile();
+        }
+        return entryCache.computeIfAbsent(location, CacheLine::new);
+
+    }
+
+    private final class CacheLine {
+
+        private static final String RESPONSE_CODE = "HTTP_RESPONSE_CODE";
+        private static final String LAST_UPDATED = "FILE-LAST_UPDATED";
+        private static final String STATUS_LINE = "HTTP_STATUS_LINE";
+        private final File file;
+        private final File headerFile;
+        private Properties header;
+        private final DateFormat httpDateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.US);
+
+        public CacheLine(File file) {
+            this.file = file;
+            this.headerFile = new File(file.getParent(), file.getName() + ".headers");
+            httpDateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+        }
+
+        public synchronized long fetchLastModified(URI uri, IProxyService proxyService,
+                Function<URI, Credentials> credentialsProvider, MavenLogger logger) throws IOException {
+            //TODO its very likely that the file is downloaded here if it has changed... so probably just download it right now?
+            RepositoryAuthenticator authenticator = new RepositoryAuthenticator(getProxyData(proxyService, uri),
+                    credentialsProvider.apply(uri));
+            HttpURLConnection connection = (HttpURLConnection) uri.toURL().openConnection(authenticator.getProxy());
+            connection.setAuthenticator(authenticator);
+            connection.setRequestMethod("HEAD");
+            authenticator.preemtiveAuth(connection);
+            connection.connect();
+            try {
+                int code = connection.getResponseCode();
+                if (isAuthFailure(code)) {
+                    throw new AuthenticationFailedException(); //FIXME why is there no constructor to give a cause?
+                }
+                if (isNotFound(code)) {
+                    updateHeader(connection, code);
+                    throw new FileNotFoundException(uri.toString());
+                }
+                if (isRedirected(code)) {
+                    updateHeader(connection, code);
+                    return SharedHttpCacheStorage.this.getCacheEntry(uri, logger).getLastModified(proxyService,
+                            credentialsProvider);
+                }
+                return connection.getLastModified();
+            } finally {
+                closeConnection(connection);
+            }
+        }
+
+        public synchronized long getLastModified(URI uri, IProxyService proxyService,
+                Function<URI, Credentials> credentialsProvider, Function<URI, IOException> notAviableExceptionSupplier,
+                MavenLogger logger) throws IOException {
+            int code = getResponseCode();
+            if (code > 0) {
+                if (isAuthFailure(code)) {
+                    throw new AuthenticationFailedException(); //FIXME why is there no constructor to give a cause?
+                }
+                if (isNotFound(code)) {
+                    throw new FileNotFoundException(uri.toString());
+                }
+                if (isRedirected(code)) {
+                    return SharedHttpCacheStorage.this.getCacheEntry(uri, logger).getLastModified(proxyService,
+                            credentialsProvider);
+                }
+                Properties offlineHeader = getHeader();
+                Date lastModified = pareHttpDate(offlineHeader.getProperty(LAST_MODIFIED_HEADER.toLowerCase()));
+                if (lastModified != null) {
+                    return lastModified.getTime();
+                }
+                return -1;
+            } else {
+                throw notAviableExceptionSupplier.apply(uri);
+            }
+        }
+
+        public synchronized File fetchFile(URI uri, IProxyService proxyService,
+                Function<URI, Credentials> credentialsProvider, MavenLogger logger) throws IOException {
+            boolean exits = file.isFile();
+            if (exits && !mustValidate()) {
+                return file;
+            }
+            RepositoryAuthenticator authenticator = new RepositoryAuthenticator(getProxyData(proxyService, uri),
+                    credentialsProvider.apply(uri));
+            HttpURLConnection connection = (HttpURLConnection) uri.toURL().openConnection(authenticator.getProxy());
+            connection.setAuthenticator(authenticator);
+            authenticator.preemtiveAuth(connection);
+            Properties lastHeader = getHeader();
+            if (exits) {
+                if (lastHeader.containsKey(ETAG_HEADER.toLowerCase())) {
+                    connection.setRequestProperty("If-None-Match", lastHeader.getProperty(ETAG_HEADER.toLowerCase()));
+                }
+                if (lastHeader.contains(LAST_MODIFIED_HEADER.toLowerCase())) {
+                    connection.setRequestProperty("If-Modified-Since",
+                            lastHeader.getProperty(LAST_MODIFIED_HEADER.toLowerCase()));
+                }
+            }
+            connection.setInstanceFollowRedirects(false);
+            connection.connect();
+            int code = connection.getResponseCode();
+            if (exits && code == HttpURLConnection.HTTP_NOT_MODIFIED) {
+                updateHeader(connection, getResponseCode());
+                return file;
+            }
+            if (isAuthFailure(code)) {
+                throw new AuthenticationFailedException(); //FIXME why is there no constructor to give a cause?
+            }
+            updateHeader(connection, code);
+            if (isRedirected(code)) {
+                closeConnection(connection);
+                return SharedHttpCacheStorage.this.getCacheEntry(getRedirect(uri), logger).getCacheFile(proxyService,
+                        credentialsProvider);
+            }
+            if (exits) {
+                FileUtils.forceDelete(file);
+            }
+            File tempFile = File.createTempFile("download", ".tmp", file.getParentFile());
+            try (InputStream inputStream = connection.getInputStream();
+                    FileOutputStream os = new FileOutputStream(tempFile)) {
+                inputStream.transferTo(os);
+            } catch (IOException e) {
+                tempFile.delete();
+                throw e;
+            }
+            FileUtils.moveFile(tempFile, file);
+            return file;
+        }
+
+        public synchronized File getFile(URI uri, IProxyService proxyService,
+                Function<URI, Credentials> credentialsProvider, Function<URI, IOException> notAviableExceptionSupplier,
+                MavenLogger logger) throws IOException {
+            int code = getResponseCode();
+            if (code > 0) {
+                if (isAuthFailure(code)) {
+                    throw new AuthenticationFailedException(); //FIXME why is there no constructor to give a cause?
+                }
+                if (isNotFound(code)) {
+                    throw new FileNotFoundException(uri.toString());
+                }
+                if (isRedirected(code)) {
+                    return SharedHttpCacheStorage.this.getCacheEntry(getRedirect(uri), logger)
+                            .getCacheFile(proxyService, credentialsProvider);
+                }
+                if (file.isFile()) {
+                    return file;
+                }
+            }
+            throw notAviableExceptionSupplier.apply(uri);
+        }
+
+        private boolean mustValidate() {
+            if (cacheConfig.update) {
+                //user enforced validation
+                return true;
+            }
+            String[] cacheControls = getCacheControl();
+            for (String directive : cacheControls) {
+                if (MUST_REVALIDATE_DIRECTIVE.equals(directive)) {
+                    //server enforced validation
+                    return true;
+                }
+            }
+            Properties properties = getHeader();
+            long lastUpdated = parseLong(properties.getProperty(LAST_UPDATED));
+            if (lastUpdated + TimeUnit.MINUTES.toMillis(MIN_CACHE_PERIOD) > System.currentTimeMillis()) {
+                return false;
+            }
+            //Cache-Control header with "max-age" directive takes precedence over Expires Header.
+            for (String directive : cacheControls) {
+                if (directive.toLowerCase().startsWith(MAX_AGE_DIRECTIVE)) {
+                    long maxAge = parseLong(directive.substring(MAX_AGE_DIRECTIVE.length() + 1));
+                    if (maxAge <= 0) {
+                        return true;
+                    }
+                    return (lastUpdated + TimeUnit.SECONDS.toMillis(maxAge)) < System.currentTimeMillis();
+                }
+            }
+            Date expiresDate = pareHttpDate(properties.getProperty(EXPIRES_HEADER.toLowerCase()));
+            if (expiresDate != null) {
+                return expiresDate.after(new Date());
+            }
+            return true;
+        }
+
+        protected long parseLong(String value) {
+            if (value != null) {
+                try {
+                    return Long.parseLong(value);
+                } catch (NumberFormatException e) {
+                    //ignore...
+                }
+            }
+            return 0;
+        }
+
+        private String[] getCacheControl() {
+            String property = getHeader().getProperty(CACHE_CONTROL_HEADER);
+            if (property != null) {
+                return property.split(",\\s*");
+            }
+            return new String[0];
+        }
+
+        protected boolean isAuthFailure(int code) {
+            return code == HttpURLConnection.HTTP_PROXY_AUTH || code == HttpURLConnection.HTTP_UNAUTHORIZED;
+        }
+
+        protected void updateHeader(HttpURLConnection connection, int code) throws IOException, FileNotFoundException {
+            header = new Properties();
+            header.setProperty(RESPONSE_CODE, String.valueOf(code));
+            header.setProperty(LAST_UPDATED, String.valueOf(System.currentTimeMillis()));
+            Map<String, List<String>> headerFields = connection.getHeaderFields();
+            for (var entry : headerFields.entrySet()) {
+                String key = entry.getKey();
+                if (key == null) {
+                    key = STATUS_LINE;
+                }
+                key = key.toLowerCase();
+                if (AUTHORIZATION_HEADER.equalsIgnoreCase(key) || PROXY_AUTHORIZATION_HEADER.equalsIgnoreCase(key)) {
+                    //Don't store sensitive information here...
+                    continue;
+                }
+                if (key.toLowerCase().startsWith("x-")) {
+                    //don't store non default header...
+                    continue;
+                }
+                List<String> value = entry.getValue();
+                if (value.size() == 1) {
+                    header.put(key, value.get(0));
+                } else {
+                    header.put(key, value.stream().collect(Collectors.joining(",")));
+                }
+            }
+            FileUtils.forceMkdir(file.getParentFile());
+            try (FileOutputStream out = new FileOutputStream(headerFile)) {
+                //we store the header here, this might be a 404 response or (permanent) redirect we probably need to work with later on
+                header.store(out, null);
+            }
+        }
+
+        private synchronized Date pareHttpDate(String input) {
+            if (input != null) {
+                try {
+                    return httpDateFormat.parse(input);
+                } catch (ParseException e) {
+                    //can't use it then..
+                }
+            }
+            return null;
+        }
+
+        private void closeConnection(HttpURLConnection connection) {
+            try {
+                connection.getInputStream().close();
+            } catch (IOException e) {
+                //we just wan't to signal that we are done with this connection...
+            }
+        }
+
+        public int getResponseCode() {
+            return Integer.parseInt(getHeader().getProperty(RESPONSE_CODE, "-1"));
+        }
+
+        public URI getRedirect(URI base) throws FileNotFoundException {
+            String location = getHeader().getProperty("location");
+            if (location == null) {
+                throw new FileNotFoundException(base.toASCIIString());
+            }
+            return base.resolve(location);
+        }
+
+        public Properties getHeader() {
+            if (header == null) {
+                header = new Properties();
+                if (headerFile.isFile()) {
+                    try {
+                        header.load(new FileInputStream(headerFile));
+                    } catch (IOException e) {
+                        //can't use the headers then...
+                    }
+                }
+            }
+            return header;
+        }
+    }
+
+    private static IProxyData getProxyData(IProxyService proxyService, URI uri) throws IOException {
+        if (proxyService != null) {
+            IProxyData[] selected = proxyService.select(uri);
+            IProxyData proxyData = ProxySetupHelper.selectProxyFromProxies(uri.getScheme(), selected);
+            if (proxyData != null) {
+                return proxyData;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isRedirected(int code) {
+        return code == HttpURLConnection.HTTP_MOVED_PERM || code == HttpURLConnection.HTTP_MOVED_TEMP;
+    }
+
+    private static boolean isNotFound(int code) {
+        return code == HttpURLConnection.HTTP_NOT_FOUND;
+    }
+
+    public static SharedHttpCacheStorage getStorage(File location, boolean offline, boolean update) {
+        return storageMap.computeIfAbsent(new CacheConfig(location, offline, update), SharedHttpCacheStorage::new);
+    }
+
+    private static IOException mavenIsOffline(URI uri) {
+        return new IOException("maven is currently in offline mode requested URL " + uri + " does not exist locally!");
+    }
+
+    private static final class CacheConfig {
+        public CacheConfig(File location, boolean offline, boolean update) {
+            this.location = location;
+            this.offline = offline;
+            this.update = update;
+        }
+
+        private final File location;
+        private final boolean offline;
+        private final boolean update;
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(location, offline, update);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            CacheConfig other = (CacheConfig) obj;
+            return Objects.equals(location, other.location) && offline == other.offline && update == other.update;
+        }
+    }
+
+    private static final class RepositoryAuthenticator extends Authenticator {
+
+        private IProxyData proxyData;
+        private Credentials credentials;
+
+        public RepositoryAuthenticator(IProxyData proxyData, Credentials credentials) {
+            this.proxyData = proxyData;
+            this.credentials = credentials;
+        }
+
+        public void preemtiveAuth(HttpURLConnection connection) {
+            // as everything is known and we can't ask the user anyways, preemtive auth is a good choice here to prevent successive requests
+            addAuthHeader(connection, getPasswordAuthentication(RequestorType.PROXY), PROXY_AUTHORIZATION_HEADER);
+            addAuthHeader(connection, getPasswordAuthentication(RequestorType.SERVER), AUTHORIZATION_HEADER);
+        }
+
+        private void addAuthHeader(HttpURLConnection connection, PasswordAuthentication authentication, String header) {
+            if (authentication == null) {
+                return;
+            }
+            String encoding = Base64.getEncoder().encodeToString(
+                    (authentication.getUserName() + ":" + new String(authentication.getPassword())).getBytes());
+            connection.setRequestProperty(header, "Basic " + encoding);
+
+        }
+
+        @Override
+        protected PasswordAuthentication getPasswordAuthentication() {
+            return getPasswordAuthentication(getRequestorType());
+        }
+
+        protected PasswordAuthentication getPasswordAuthentication(RequestorType type) {
+            if (type == RequestorType.PROXY) {
+                if (proxyData != null) {
+                    String userId = proxyData.getUserId();
+                    if (userId != null) {
+                        String password = proxyData.getPassword();
+                        return new PasswordAuthentication(userId,
+                                password == null ? new char[0] : password.toCharArray());
+                    }
+                }
+            } else if (type == RequestorType.SERVER) {
+                if (credentials != null) {
+                    String userName = credentials.getUserName();
+                    if (userName != null) {
+                        String password = credentials.getPassword();
+                        return new PasswordAuthentication(userName,
+                                password == null ? new char[0] : password.toCharArray());
+                    }
+                }
+            }
+            return null;
+        }
+
+        public Proxy getProxy() {
+            if (proxyData == null) {
+                return Proxy.NO_PROXY;
+            }
+            return new Proxy(convertType(proxyData), convertAddress(proxyData));
+        }
+
+        private static SocketAddress convertAddress(IProxyData data) {
+            return new InetSocketAddress(data.getHost(), data.getPort());
+        }
+
+        private static Type convertType(IProxyData data) {
+            switch (data.getType()) {
+            case IProxyData.HTTPS_PROXY_TYPE:
+            case IProxyData.HTTP_PROXY_TYPE:
+                return Type.HTTP;
+            case IProxyData.SOCKS_PROXY_TYPE:
+                return Type.SOCKS;
+            default:
+                return Type.DIRECT;
+            }
+        }
+    }
+
+}

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/remote/TychoRepositoryTransport.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/remote/TychoRepositoryTransport.java
@@ -1,0 +1,194 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.p2.remote;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URLConnection;
+import java.text.NumberFormat;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Function;
+
+import org.apache.commons.io.IOUtils;
+import org.eclipse.core.net.proxy.IProxyService;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.equinox.internal.p2.repository.AuthenticationFailedException;
+import org.eclipse.equinox.internal.provisional.p2.repository.IStateful;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.eclipse.equinox.p2.core.spi.IAgentServiceFactory;
+import org.eclipse.tycho.core.resolver.shared.MavenRepositorySettings.Credentials;
+import org.eclipse.tycho.core.shared.MavenContext;
+import org.eclipse.tycho.core.shared.MavenLogger;
+
+@SuppressWarnings("restriction")
+public class TychoRepositoryTransport extends org.eclipse.equinox.internal.p2.repository.Transport
+        implements IAgentServiceFactory {
+
+    private NumberFormat numberFormat = NumberFormat.getNumberInstance();
+
+    private MavenContext mavenContext;
+    private SharedHttpCacheStorage httpCache;
+    private LongAdder requests = new LongAdder();
+    private LongAdder indexRequests = new LongAdder();
+
+    private IProxyService proxyService;
+
+    private Function<URI, Credentials> credentialsProvider;
+
+    public TychoRepositoryTransport(MavenContext mavenContext, IProxyService proxyService,
+            Function<URI, Credentials> credentialsProvider) {
+        this.mavenContext = mavenContext;
+        this.proxyService = proxyService;
+        this.credentialsProvider = credentialsProvider;
+        File cacheLocation = new File(mavenContext.getLocalRepositoryRoot(), ".cache/tycho");
+        cacheLocation.mkdirs();
+        MavenLogger logger = mavenContext.getLogger();
+        logger.info(
+                "### Using TychoRepositoryTransport for remote P2 access (You can disable this with -Dtycho.p2.transport=ecf) ###");
+        logger.info("    Cache location:         " + cacheLocation);
+        logger.info("    Transport mode:         " + (mavenContext.isOffline() ? "offline" : "online"));
+        logger.info("    Update mode:            " + (mavenContext.isUpdateSnapshots() ? "forced" : "cache first"));
+        logger.info("    Minimum cache duration: " + SharedHttpCacheStorage.MIN_CACHE_PERIOD + " minutes");
+        logger.info(
+                "      (you can configure this with -Dtycho.p2.transport.min-cache-minutes=<desired minimum cache duration>)");
+
+        numberFormat.setMaximumFractionDigits(2);
+        httpCache = SharedHttpCacheStorage.getStorage(cacheLocation, mavenContext.isOffline(),
+                mavenContext.isUpdateSnapshots());
+    }
+
+    @Override
+    public IStatus download(URI toDownload, OutputStream target, long startPos, IProgressMonitor monitor) {
+        if (startPos > 0) {
+            return new Status(IStatus.ERROR, TychoRepositoryTransport.class.getName(),
+                    "range downloads are not implemented");
+        }
+        return download(toDownload, target, monitor);
+    }
+
+    @Override
+    public IStatus download(URI toDownload, OutputStream target, IProgressMonitor monitor) {
+        try {
+            IOUtils.copy(stream(toDownload, monitor), target);
+            return reportStatus(Status.OK_STATUS, target);
+        } catch (AuthenticationFailedException e) {
+            return new Status(IStatus.ERROR, TychoRepositoryTransport.class.getName(),
+                    "authentication failed for " + toDownload, e);
+        } catch (IOException e) {
+            return reportStatus(new Status(IStatus.ERROR, TychoRepositoryTransport.class.getName(),
+                    "download from " + toDownload + " failed", e), target);
+        } catch (CoreException e) {
+            return reportStatus(e.getStatus(), target);
+        }
+    }
+
+    private IStatus reportStatus(IStatus status, OutputStream target) {
+        if (target instanceof IStateful) {
+            IStateful stateful = (IStateful) target;
+            stateful.setStatus(status);
+        }
+        return status;
+    }
+
+    @Override
+    public synchronized InputStream stream(URI toDownload, IProgressMonitor monitor)
+            throws FileNotFoundException, CoreException, AuthenticationFailedException {
+        MavenLogger logger = mavenContext.getLogger();
+        if (logger.isExtendedDebugEnabled()) {
+            logger.debug("Request stream for " + toDownload + "...");
+        }
+        requests.increment();
+        if (toDownload.toASCIIString().endsWith("p2.index")) {
+            indexRequests.increment();
+        }
+        try {
+            File cachedFile = getCachedFile(toDownload);
+            if (cachedFile != null) {
+                if (logger.isExtendedDebugEnabled()) {
+                    logger.debug(" --> routed through http-cache ...");
+                }
+                return new FileInputStream(cachedFile);
+            }
+            return toDownload.toURL().openStream();
+        } catch (FileNotFoundException e) {
+            if (logger.isExtendedDebugEnabled()) {
+                logger.debug(" --> not found!");
+            }
+            throw e;
+        } catch (IOException e) {
+            if (logger.isExtendedDebugEnabled()) {
+                logger.debug(" --> generic error: " + e);
+            }
+            throw new CoreException(new Status(IStatus.ERROR, TychoRepositoryTransport.class.getName(),
+                    "download from " + toDownload + " failed", e));
+        } finally {
+            if (logger.isExtendedDebugEnabled()) {
+                logger.debug("Total number of requests: " + requests.longValue() + " (" + indexRequests.longValue()
+                        + " for p2.index)");
+            }
+        }
+    }
+
+    @Override
+    public long getLastModified(URI toDownload, IProgressMonitor monitor)
+            throws CoreException, FileNotFoundException, AuthenticationFailedException {
+        //TODO P2 cache manager relies on this method to throw an exception to work correctly
+        try {
+            if (isHttp(toDownload)) {
+                return httpCache.getCacheEntry(toDownload, mavenContext.getLogger()).getLastModified(proxyService,
+                        credentialsProvider);
+            }
+            URLConnection connection = toDownload.toURL().openConnection();
+            long lastModified = connection.getLastModified();
+            connection.getInputStream().close();
+            return lastModified;
+        } catch (FileNotFoundException e) {
+            throw e;
+        } catch (IOException e) {
+            throw new CoreException(new Status(IStatus.ERROR, TychoRepositoryTransport.class.getName(),
+                    "download from " + toDownload + " failed", e));
+        }
+    }
+
+    @Override
+    public Object createService(IProvisioningAgent agent) {
+        return this;
+    }
+
+    public SharedHttpCacheStorage getHttpCache() {
+        return httpCache;
+    }
+
+    public File getCachedFile(URI remoteFile) throws IOException {
+
+        if (isHttp(remoteFile)) {
+            return httpCache.getCacheEntry(remoteFile, mavenContext.getLogger()).getCacheFile(proxyService,
+                    credentialsProvider);
+        }
+        return null;
+    }
+
+    public static boolean isHttp(URI remoteFile) {
+        String scheme = remoteFile.getScheme();
+        return scheme != null && scheme.toLowerCase().startsWith("http");
+    }
+
+}

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/remote/TychoRepositoryTransportCacheManager.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/remote/TychoRepositoryTransportCacheManager.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.p2.remote;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.URIUtil;
+import org.eclipse.equinox.internal.p2.repository.CacheManager;
+import org.eclipse.equinox.p2.core.ProvisionException;
+import org.eclipse.tycho.core.shared.MavenContext;
+
+@SuppressWarnings("restriction")
+public class TychoRepositoryTransportCacheManager extends CacheManager {
+
+    private static final List<String> EXTENSIONS = List.of(".jar", ".xml");
+
+    private MavenContext mavenContext;
+    private TychoRepositoryTransport transport;
+
+    public TychoRepositoryTransportCacheManager(TychoRepositoryTransport transport, MavenContext mavenContext) {
+        super(null, transport);
+        this.transport = transport;
+        this.mavenContext = mavenContext;
+    }
+
+    @Override
+    public File createCache(URI repositoryLocation, String prefix, IProgressMonitor monitor)
+            throws IOException, ProvisionException {
+        if (TychoRepositoryTransport.isHttp(repositoryLocation)) {
+            for (String extension : EXTENSIONS) {
+                URI fileLocation = URIUtil.append(repositoryLocation, prefix + extension);
+                try {
+                    File cachedFile = transport.getCachedFile(fileLocation);
+                    if (cachedFile != null) {
+                        return cachedFile;
+                    }
+                } catch (FileNotFoundException e) {
+                    continue;
+                }
+            }
+            throw new FileNotFoundException(
+                    "Not found any of " + EXTENSIONS + " for " + repositoryLocation + " with prefix " + prefix);
+        }
+        return super.createCache(repositoryLocation, prefix, monitor);
+    }
+
+    @Override
+    public File createCacheFromFile(URI remoteFile, IProgressMonitor monitor) throws ProvisionException, IOException {
+        File cachedFile = transport.getCachedFile(remoteFile);
+        if (cachedFile != null) {
+            //no need to cache this twice ...
+            return cachedFile;
+        }
+        return super.createCacheFromFile(remoteFile, monitor);
+    }
+
+    @Override
+    protected File getCacheDirectory() {
+        return new File(mavenContext.getLocalRepositoryRoot(), RemoteRepositoryCacheManager.CACHE_RELPATH);
+    }
+
+}

--- a/tycho-bundles/org.eclipse.tycho.test.utils/META-INF/MANIFEST.MF
+++ b/tycho-bundles/org.eclipse.tycho.test.utils/META-INF/MANIFEST.MF
@@ -15,7 +15,8 @@ Require-Bundle: org.junit;bundle-version="[4.8.1,5.0.0)",
  org.eclipse.jetty.security,
  org.eclipse.jetty.servlet,
  org.eclipse.equinox.common;bundle-version="3.6.100",
- org.apache.felix.scr;bundle-version="2.1.16"
+ org.apache.felix.scr;bundle-version="2.1.16",
+ org.eclipse.core.net
 Bundle-Vendor: %providerName
 Export-Package: org.eclipse.tycho.p2.remote.testutil,
  org.eclipse.tycho.p2.testutil,

--- a/tycho-bundles/org.eclipse.tycho.test.utils/src/main/java/org/eclipse/tycho/test/util/MavenServiceStubbingTestBase.java
+++ b/tycho-bundles/org.eclipse.tycho.test.utils/src/main/java/org/eclipse/tycho/test/util/MavenServiceStubbingTestBase.java
@@ -12,9 +12,11 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.util;
 
+import org.eclipse.core.internal.net.ProxyManager;
+import org.eclipse.core.net.proxy.IProxyService;
 import org.eclipse.tycho.core.resolver.shared.MavenRepositorySettings;
 import org.eclipse.tycho.core.shared.MavenContext;
-import org.eclipse.tycho.core.shared.MavenContextImpl;
+import org.eclipse.tycho.core.shared.MockMavenContext;
 import org.eclipse.tycho.locking.facade.FileLockService;
 import org.eclipse.tycho.p2.remote.testutil.MavenRepositorySettingsStub;
 import org.junit.Before;
@@ -43,13 +45,17 @@ public class MavenServiceStubbingTestBase {
     public StubServiceRegistration<FileLockService> fileLockServiceRegistration = new StubServiceRegistration<>(
             FileLockService.class, new NoopFileLockService());
 
+    @Rule
+    public StubServiceRegistration<IProxyService> proxyServiceRegistration = new StubServiceRegistration<>(
+            IProxyService.class, ProxyManager.getProxyManager());
+
     @Before
     public void initServiceInstances() throws Exception {
         mavenContextRegistration.registerService(createMavenContext());
     }
 
     private MavenContext createMavenContext() throws Exception {
-        MavenContext mavenContext = new MavenContextImpl(temporaryFolder.newFolder("target"), logVerifier.getLogger()) {
+        MavenContext mavenContext = new MockMavenContext(temporaryFolder.newFolder("target"), logVerifier.getLogger()) {
 
             @Override
             public String getExtension(String artifactType) {

--- a/tycho-core/src/main/java/org/eclipse/tycho/osgi/configuration/RepositorySettingsConfigurator.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/osgi/configuration/RepositorySettingsConfigurator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 SAP AG and others.
+ * Copyright (c) 2012, 2022 SAP AG and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *    SAP AG - initial API and implementation
+ *    Christoph Läubrich - Issue #797 - Implement a caching P2 transport  
  *******************************************************************************/
 package org.eclipse.tycho.osgi.configuration;
 
@@ -88,7 +89,7 @@ public class RepositorySettingsConfigurator extends EquinoxLifecycleListener {
                 SettingsDecryptionResult result = decrypter.decryptAndLogProblems(serverSettings);
                 Server decryptedServer = result.getServer();
                 return new MavenRepositorySettings.Credentials(decryptedServer.getUsername(),
-                        decryptedServer.getPassword());
+                        decryptedServer.getPassword(), location.getURL());
             }
             return null;
         }


### PR DESCRIPTION
This is a draft on how Tycho could use a custom transport. This also is a showcase on how an alternate P2 transport might work, to investigate what is required and give a bigger picture for possible P2 enhancements.