### PR TITLE
issue #697 reproducer

### DIFF
--- a/tycho-its/projects/issue697/bundle1/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/issue697/bundle1/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: bundle
+Bundle-SymbolicName: bundle
+Bundle-Version: 1.0.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Automatic-Module-Name: bundle
+Require-Bundle: wrapped.de.monticore.monticore-runtime;bundle-version="7.2.0"

--- a/tycho-its/projects/issue697/bundle1/build.properties
+++ b/tycho-its/projects/issue697/bundle1/build.properties
@@ -1,0 +1,3 @@
+source.. = src/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/issue697/bundle1/pom.xml
+++ b/tycho-its/projects/issue697/bundle1/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>tycho-its-project</groupId>
+    <artifactId>issue697</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>bundle</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>eclipse-plugin</packaging>
+</project>

--- a/tycho-its/projects/issue697/bundle2/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/issue697/bundle2/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: bundle2
+Bundle-SymbolicName: bundle2
+Bundle-Version: 1.0.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Automatic-Module-Name: bundle2
+Require-Bundle: dsltool-api;bundle-version="0.0.1"

--- a/tycho-its/projects/issue697/bundle2/build.properties
+++ b/tycho-its/projects/issue697/bundle2/build.properties
@@ -1,0 +1,3 @@
+source.. = src/
+bin.includes = META-INF/,\
+               .

--- a/tycho-its/projects/issue697/bundle2/pom.xml
+++ b/tycho-its/projects/issue697/bundle2/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>tycho-its-project</groupId>
+    <artifactId>issue697</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>bundle2</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>eclipse-plugin</packaging>
+</project>

--- a/tycho-its/projects/issue697/pom.xml
+++ b/tycho-its/projects/issue697/pom.xml
@@ -1,0 +1,58 @@
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>tycho-its-project</groupId>
+	<artifactId>issue697</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	
+	<modules>
+		<module>target-platform</module>
+		<module>bundle1</module>
+		<module>bundle2</module>
+	</modules>
+	
+	<properties>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
+	</properties>
+	
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-versions-plugin</artifactId>
+				<version>${tycho-version}</version>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-compiler-plugin</artifactId>
+				<version>${tycho-version}</version>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-packaging-plugin</artifactId>
+				<version>${tycho-version}</version>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<target>
+						<artifact> 
+							<groupId>tycho-its-project</groupId> 
+							<artifactId>target-platform</artifactId> 
+							<version>0.0.1-SNAPSHOT</version>
+						</artifact> 
+					</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/projects/issue697/target-platform/pom.xml
+++ b/tycho-its/projects/issue697/target-platform/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>tycho-its-project</groupId>
+    <artifactId>issue697</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>target-platform</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>eclipse-target-definition</packaging>
+</project>

--- a/tycho-its/projects/issue697/target-platform/target-platform.target
+++ b/tycho-its/projects/issue697/target-platform/target-platform.target
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="tp">
+	<locations>
+		<location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
+			<dependencies>
+				<dependency>
+					<groupId>de.monticore</groupId>
+					<artifactId>dsltool-api</artifactId>
+					<version>0.0.1</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>de.monticore</groupId>
+					<artifactId>monticore-runtime</artifactId>
+					<version>7.2.0</version>
+					<type>jar</type>
+				</dependency>
+			</dependencies>
+			<repositories>
+				<repository>
+					<id>rwth</id>
+					<url>https://nexus.se.rwth-aachen.de/repository/monticore/</url>
+				</repository>
+			</repositories>
+		</location>
+	</locations>
+</target>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/issue697/Issue697Test.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/issue697/Issue697Test.java
@@ -1,0 +1,18 @@
+package org.eclipse.tycho.test.issue697;
+
+import java.util.List;
+
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.Test;
+
+public class Issue697Test extends AbstractTychoIntegrationTest {
+
+	@Test
+	public void test() throws Exception {
+		Verifier verifier = getVerifier("issue697");
+
+		verifier.executeGoals(List.of("clean", "verify"));
+		verifier.verifyErrorFreeLog();
+	}
+}


### PR DESCRIPTION
The test case attempts to build two plugins with dependencies from an external (Nexus) repository.

The first plugin depends on a Maven artifact which is rebundled and builds successfully.
The second plugin depends on an OSGi bundle which can't be resolved during the build.

The issue has been introduced with Tycho 2.7.0.