### PR TITLE
Fix #247: Using https instead of http for links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ and the minimal reproducer project to Tycho's [issue tracker](https://github.com
 
 Java 11 and Maven 3.6.3, or newer.
 
-If your Internet connection uses a proxy, make sure that you have the proxy configured in your [Maven settings.xml](http://maven.apache.org/settings.html).
+If your Internet connection uses a proxy, make sure that you have the proxy configured in your [Maven settings.xml](https://maven.apache.org/settings.html).
 
 ### Using the Eclipse Installer (Oomph)
 
@@ -75,7 +75,7 @@ _Background information on the Tycho integration tests_
 
 The integration tests trigger sample builds that use Tycho. These builds expect that Tycho has been installed to the local Maven repository. This is why you need to build Tycho through a `mvn install` before you can run the integration tests.
 
-Alternatively, e.g. if you are only interested in modifying an integration test and do not want to patch Tycho itself, you can configure the integration tests to download the current Tycho snapshot produced by the [Tycho CI builds](http://hudson.eclipse.org/tycho/view/CI). To do this, you need to edit the Maven settings stored in `tycho-its/settings.xml` and add the tycho-snapshots repository as described in [[Getting Tycho]]. (Advanced note: The integration tests can also be pointed to a different settings.xml with the system property `tycho.testSettings`.)
+Alternatively, e.g. if you are only interested in modifying an integration test and do not want to patch Tycho itself, you can configure the integration tests to download the current Tycho snapshot produced by the [Tycho CI builds](https://hudson.eclipse.org/tycho/view/CI). To do this, you need to edit the Maven settings stored in `tycho-its/settings.xml` and add the tycho-snapshots repository as described in [[Getting Tycho]]. (Advanced note: The integration tests can also be pointed to a different settings.xml with the system property `tycho.testSettings`.)
 
 ### Writing Tycho integration tests
 
@@ -122,7 +122,7 @@ To use a different Tycho snapshot repository use the system property `tycho-snap
 
 Tycho makes heavy use of p2 functionality. Therefore it may be useful to try out patches to p2 without waiting for a new p2 release, or even just the next nightly build. With the following steps it is possible to build Tycho against a locally built version of p2.
 
-1. Get the p2 sources (see [p2 project information](http://projects.eclipse.org/projects/rt.equinox.p2/developer))
+1. Get the p2 sources (see [p2 project information](https://projects.eclipse.org/projects/rt.equinox.p2/developer))
 2. Make changes in the p2 sources, **(!) don't forget to increase the version of that bundle otherwise your changes will be overwritten with the current release version (!)**
 3. Build the changed p2 bundles individually with <tt>mvn clean install -Pbuild-individual-bundles</tt> (see [Equinox/p2/Build](https://wiki.eclipse.org/Equinox/p2/Build) for more information)
 4. Build at least the Tycho module tycho-bundles-external with <tt>mvn clean install</tt> - you should see a warning that the locally built p2 bundles have been used.
@@ -156,7 +156,7 @@ To use the profiler, [set the system property](https://github.com/jcgay/maven-pr
 
 To get started with YouMonitor, you need to install and run the application. It will ask you for a repository, which is how you aggregate builds (e.g. use one repository per different project that you want to investigate). Afterwards select the [Monitoring in IDE or command line](https://www.yourkit.com/docs/youmonitor/help/ide_and_command_line.jsp) and use the button "Open Instructions". That will show you the project and machine specific argument which needs to be added to the Java command line. E.g. if you want to profile tests, you might want to add it to the [argLine configuration of Tycho Surefire](https://www.eclipse.org/tycho/sitedocs/tycho-surefire-plugin/test-mojo.html#argLine).
 
-## üèóÔ∏è Build & Test
+## ü?óÔ∏? Build & Test
 
 From the root directory of your local Tycho git-repository clone run the following Maven commands...
 * to check if compilation and all tests succeed:
@@ -235,7 +235,7 @@ Development Process and operates under the terms of the Eclipse IP Policy.
 ## Eclipse Contributor Agreement
 
 Before your contribution can be accepted by the project team contributors must
-electronically sign the Eclipse Contributor Agreement (ECA): http://www.eclipse.org/legal/ECA.php
+electronically sign the Eclipse Contributor Agreement (ECA): https://www.eclipse.org/legal/ECA.php
 
 For more information, please see the Eclipse Committer Handbook:
 https://www.eclipse.org/projects/handbook/#resources-commit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,7 @@ To use the profiler, [set the system property](https://github.com/jcgay/maven-pr
 
 To get started with YouMonitor, you need to install and run the application. It will ask you for a repository, which is how you aggregate builds (e.g. use one repository per different project that you want to investigate). Afterwards select the [Monitoring in IDE or command line](https://www.yourkit.com/docs/youmonitor/help/ide_and_command_line.jsp) and use the button "Open Instructions". That will show you the project and machine specific argument which needs to be added to the Java command line. E.g. if you want to profile tests, you might want to add it to the [argLine configuration of Tycho Surefire](https://www.eclipse.org/tycho/sitedocs/tycho-surefire-plugin/test-mojo.html#argLine).
 
-## 🏗️ Build & Test
+##🏗️ Build & Test
 
 From the root directory of your local Tycho git-repository clone run the following Maven commands...
 * to check if compilation and all tests succeed:
@@ -225,7 +225,7 @@ changing some configuration value in an existing mojo)
 
 If you require such a change, please note that in the issue and we will assign the next major release to it, those changes would not be merged until the next major release keep your changes small and local as it possible take some time and you probably have to catch up with minor changes in the meantime.
 
-## ð Process and Legal
+##👔 Process and Legal
 
 ## Eclipse Development Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,7 @@ To use the profiler, [set the system property](https://github.com/jcgay/maven-pr
 
 To get started with YouMonitor, you need to install and run the application. It will ask you for a repository, which is how you aggregate builds (e.g. use one repository per different project that you want to investigate). Afterwards select the [Monitoring in IDE or command line](https://www.yourkit.com/docs/youmonitor/help/ide_and_command_line.jsp) and use the button "Open Instructions". That will show you the project and machine specific argument which needs to be added to the Java command line. E.g. if you want to profile tests, you might want to add it to the [argLine configuration of Tycho Surefire](https://www.eclipse.org/tycho/sitedocs/tycho-surefire-plugin/test-mojo.html#argLine).
 
-## �?��? Build & Test
+## 🏗️ Build & Test
 
 From the root directory of your local Tycho git-repository clone run the following Maven commands...
 * to check if compilation and all tests succeed:
@@ -225,7 +225,7 @@ changing some configuration value in an existing mojo)
 
 If you require such a change, please note that in the issue and we will assign the next major release to it, those changes would not be merged until the next major release keep your changes small and local as it possible take some time and you probably have to catch up with minor changes in the meantime.
 
-## 👔 Process and Legal
+## ð Process and Legal
 
 ## Eclipse Development Process
 

--- a/NOTICE
+++ b/NOTICE
@@ -38,21 +38,21 @@ This project leverages the following third party content.
 Apache Commons Compress (1.7)
 
 * License: Apache License, 2.0
-* Project: http://commons.apache.org/proper/commons-compress/
+* Project: https://commons.apache.org/proper/commons-compress/
 * Source: https://github.com/apache/commons-compress/tree/COMPRESS-1.7
 
 Apache Commons Configuration (1.9)
 
 * License: Apache License, 2.0
-* Project: http://commons.apache.org/proper/commons-configuration/index.html
+* Project: https://commons.apache.org/proper/commons-configuration/index.html
 * Source:
-   http://svn.apache.org/repos/asf/commons/proper/configuration/tags/CONFIGURATION_1_9/
+   https://svn.apache.org/repos/asf/commons/proper/configuration/tags/CONFIGURATION_1_9/
 
 Apache Commons Exec (1.2)
 
 * License: Apache License 2.0
-* Project: http://commons.apache.org/proper/commons-exec/
-* Source: http://svn.apache.org/viewvc/commons/proper/exec/tags/1.2/
+* Project: https://commons.apache.org/proper/commons-exec/
+* Source: https://svn.apache.org/viewvc/commons/proper/exec/tags/1.2/
 
 Apache Commons Exec (1.3)
 
@@ -89,15 +89,15 @@ Apache HttpClient (3.1)
 asm (4.0)
 
 * License: New BSD License
-* Project: http://asm.ow2.org/
-* Source: http://websvn.ow2.org/listing.php?repname=asm&
+* Project: https://asm.ow2.org/
+* Source: https://websvn.ow2.org/listing.php?repname=asm&
 
 asm (5.0.3)
 
 * License: New BSD license
-* Project: http://asm.ow2.org/
+* Project: https://asm.ow2.org/
 * Source:
-   http://search.maven.org/remotecontent?filepath=org/ow2/asm/asm/5.0.3/asm-5.0.3-sources.jar
+   https://search.maven.org/remotecontent?filepath=org/ow2/asm/asm/5.0.3/asm-5.0.3-sources.jar
 
 ASM (6.1.1)
 
@@ -118,7 +118,7 @@ backport-util-concurrent (3.1)
 common-java5 (2.17)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/surefire/surefire-providers/common-java5/
+* Project: https://maven.apache.org/surefire/surefire-providers/common-java5/
 * Source:
    https://git-wip-us.apache.org/repos/asf?p=maven-surefire.git;a=tag;h=refs/tags/surefire-2.17
 
@@ -133,13 +133,13 @@ Commons IO (1.4)
 commons-compress (1.9)
 
 * License: Apache License, 2.0
-* Project: http://commons.apache.org/proper/commons-compress/
-* Source: http://svn.apache.org/repos/asf/commons/proper/compress/trunk
+* Project: https://commons.apache.org/proper/commons-compress/
+* Source: https://svn.apache.org/repos/asf/commons/proper/compress/trunk
 
 commons-compress (1.11)
 
 * License: Apache License, 2.0, BSD (one file), Public Domain (one file)
-* Project: http://commons.apache.org/proper/commons-compress/
+* Project: https://commons.apache.org/proper/commons-compress/
 * Source: https://git-wip-us.apache.org/repos/asf?p=commons-compress.git
 
 commons-compress (1.15)
@@ -153,14 +153,14 @@ commons-compress (1.19)
 commons-io (2.5)
 
 * License: Apache License, 2.0
-* Project: http://commons.apache.org/proper/commons-io/
-* Source: http://svn.apache.org/viewvc/commons/proper/io/tags/commons-io-2.5
+* Project: https://commons.apache.org/proper/commons-io/
+* Source: https://svn.apache.org/viewvc/commons/proper/io/tags/commons-io-2.5
 
 de.pdark.decentxml (1.3)
 
 * License: New BSD license
-* Project: http://code.google.com/p/decentxml/
-* Source: http://decentxml.googlecode.com/svn/tags/r1.3/
+* Project: https://code.google.com/p/decentxml/
+* Source: https://decentxml.googlecode.com/svn/tags/r1.3/
 
 de.pdark.decentxml (1.4)
 
@@ -169,9 +169,9 @@ de.pdark.decentxml (1.4)
 doxia-sink-api (1.0)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/doxia/doxia/doxia-sink-api/
+* Project: https://maven.apache.org/doxia/doxia/doxia-sink-api/
 * Source:
-   http://svn.apache.org/viewvc/maven/doxia/doxia/tags/doxia-1.0-alpha-7/doxia-sink-api/
+   https://svn.apache.org/viewvc/maven/doxia/doxia/tags/doxia-1.0-alpha-7/doxia-sink-api/
 
 hamcrest-core (1.3)
 
@@ -260,14 +260,14 @@ JUnit5 Jupiter Engine (5.4.1)
 maven-archiver (2.4)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/shared/maven-archiver/
-* Source: http://svn.apache.org/viewvc/maven/shared/tags/maven-archiver-2.4/
+* Project: https://maven.apache.org/shared/maven-archiver/
+* Source: https://svn.apache.org/viewvc/maven/shared/tags/maven-archiver-2.4/
 
 maven-archiver (2.5)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/shared/maven-archiver/
-* Source: http://svn.apache.org/viewvc/maven/shared/tags/maven-archiver-2.5/
+* Project: https://maven.apache.org/shared/maven-archiver/
+* Source: https://svn.apache.org/viewvc/maven/shared/tags/maven-archiver-2.5/
 
 maven-archiver (3.5.0)
 
@@ -286,49 +286,49 @@ maven-artifact-manager (2.0.9)
 * License: Apache License, 2.0
 * Project: https://maven.apache.org/
 * Source:
-   http://svn.apache.org/repos/asf/maven/components/tags/maven-2.0.9/maven-artifact-manager/
+   https://svn.apache.org/repos/asf/maven/components/tags/maven-2.0.9/maven-artifact-manager/
 
 maven-artifact-manager (2.2.1)
 
 * License: Apache-2.0
-* Project: http://maven.apache.org/ref/2.0.11/maven-artifact-manager/index.html
+* Project: https://maven.apache.org/ref/2.0.11/maven-artifact-manager/index.html
 * Source:
-   http://svn.apache.org/viewvc/maven/maven-2/tags/maven-2.2.1/maven-artifact-manager/
+   https://svn.apache.org/viewvc/maven/maven-2/tags/maven-2.2.1/maven-artifact-manager/
 
 maven-clean-plugin (2.4.1)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/plugins/maven-clean-plugin/
+* Project: https://maven.apache.org/plugins/maven-clean-plugin/
 * Source:
-   http://svn.apache.org/viewvc/maven/plugins/tags/maven-clean-plugin-2.4.1/
+   https://svn.apache.org/viewvc/maven/plugins/tags/maven-clean-plugin-2.4.1/
 
 maven-compiler-plugin (2.0.1)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/plugins/maven-compiler-plugin/
+* Project: https://maven.apache.org/plugins/maven-compiler-plugin/
 * Source:
-   http://svn.apache.org/viewvc/maven/plugins/tags/maven-compiler-plugin-2.0.1/
+   https://svn.apache.org/viewvc/maven/plugins/tags/maven-compiler-plugin-2.0.1/
 
 maven-deploy-plugin (2.5)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/plugins/maven-deploy-plugin/
+* Project: https://maven.apache.org/plugins/maven-deploy-plugin/
 * Source:
-   http://svn.apache.org/viewvc/maven/plugins/tags/maven-deploy-plugin-2.5/
+   https://svn.apache.org/viewvc/maven/plugins/tags/maven-deploy-plugin-2.5/
 
 maven-filtering (1.0)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/shared/maven-filtering/
+* Project: https://maven.apache.org/shared/maven-filtering/
 * Source:
-   http://svn.apache.org/viewvc/maven/shared/tags/maven-filtering-1.0-beta-4/
+   https://svn.apache.org/viewvc/maven/shared/tags/maven-filtering-1.0-beta-4/
 
 maven-install-plugin (2.3.1)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/plugins/maven-install-plugin/
+* Project: https://maven.apache.org/plugins/maven-install-plugin/
 * Source:
-   http://svn.apache.org/viewvc/maven/plugins/tags/maven-install-plugin-2.3.1/
+   https://svn.apache.org/viewvc/maven/plugins/tags/maven-install-plugin-2.3.1/
 
 maven-plugin-annotations (3.3)
 
@@ -339,7 +339,7 @@ maven-plugin-descriptor (2.0.9)
 * License: Apache License, 2.0
 * Project: https://maven.apache.org/index.html
 * Source:
-   http://svn.apache.org/repos/asf/maven/components/tags/maven-2.0.9/maven-plugin-descriptor/
+   https://svn.apache.org/repos/asf/maven/components/tags/maven-2.0.9/maven-plugin-descriptor/
 
 maven-plugin-descriptor (2.2.1)
 
@@ -351,7 +351,7 @@ maven-plugin-registry (2.0.9)
 * License: Apache License, 2.0
 * Project: https://maven.apache.org/
 * Source:
-   http://svn.apache.org/repos/asf/maven/components/tags/maven-2.0.9/maven-plugin-registry/
+   https://svn.apache.org/repos/asf/maven/components/tags/maven-2.0.9/maven-plugin-registry/
 
 maven-plugin-registry (2.2.1)
 
@@ -363,7 +363,7 @@ maven-profile (2.0.9)
 * License: Apache License, 2.0
 * Project: https://maven.apache.org/
 * Source:
-   http://svn.apache.org/repos/asf/maven/components/tags/maven-2.0.9/maven-profile/
+   https://svn.apache.org/repos/asf/maven/components/tags/maven-2.0.9/maven-profile/
 
 maven-profile (2.2.1)
 
@@ -382,37 +382,37 @@ maven-project (2.2.1)
 maven-reporting-api (2.0.6)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/shared/maven-reporting-api/
+* Project: https://maven.apache.org/shared/maven-reporting-api/
 * Source:
-   http://svn.apache.org/viewvc/maven/components/tags/maven-2.0.6/maven-reporting/maven-reporting-api/
+   https://svn.apache.org/viewvc/maven/components/tags/maven-2.0.6/maven-reporting/maven-reporting-api/
 
 maven-resources-plugin (2.4.3)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/plugins/maven-resources-plugin/
+* Project: https://maven.apache.org/plugins/maven-resources-plugin/
 * Source:
-   http://svn.apache.org/viewvc/maven/plugins/tags/maven-resources-plugin-2.4.3/
+   https://svn.apache.org/viewvc/maven/plugins/tags/maven-resources-plugin-2.4.3/
 
 maven-shared-utils (0.9)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/shared/maven-shared-utils/
+* Project: https://maven.apache.org/shared/maven-shared-utils/
 * Source:
-   http://svn.apache.org/viewvc/maven/shared/tags/maven-shared-utils-3.1.0
+   https://svn.apache.org/viewvc/maven/shared/tags/maven-shared-utils-3.1.0
 
 maven-source-plugin (2.1)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/plugins/maven-source-plugin/
+* Project: https://maven.apache.org/plugins/maven-source-plugin/
 * Source:
-   http://svn.apache.org/repos/asf/maven/plugins/tags/maven-source-plugin-2.1/
+   https://svn.apache.org/repos/asf/maven/plugins/tags/maven-source-plugin-2.1/
 
 maven-toolchain (2.0.9)
 
 * License: Apache License, 2.0
 * Project: https://maven.apache.org/
 * Source:
-   http://svn.apache.org/repos/asf/maven/components/tags/maven-2.0.9/maven-toolchain/
+   https://svn.apache.org/repos/asf/maven/components/tags/maven-2.0.9/maven-toolchain/
 
 maven-toolchain (2.2.1)
 
@@ -453,15 +453,15 @@ plexus-archiver (1.2)
 
 * License: Apache License, 2.0
 * Project:
-   http://plexus.codehaus.org/plexus-components/plexus-archiver/index.html
+   https://plexus.codehaus.org/plexus-components/plexus-archiver/index.html
 * Source:
-   http://svn.codehaus.org/plexus/plexus-components/tags/plexus-archiver-1.2/
+   https://svn.codehaus.org/plexus/plexus-components/tags/plexus-archiver-1.2/
 
 plexus-archiver (2.2)
 
 * License: Apache License, 2.0
 * Project:
-   http://plexus.codehaus.org/plexus-components/plexus-archiver/index.html
+   https://plexus.codehaus.org/plexus-components/plexus-archiver/index.html
 * Source: https://github.com/sonatype/plexus-archiver.git
 
 plexus-archiver (2.9.1)
@@ -474,7 +474,7 @@ plexus-archiver (2.10.1)
 
 * License: Apache License, 2.0
 * Project:
-   http://plexus.codehaus.org/plexus-components/plexus-archiver/index.html
+   https://plexus.codehaus.org/plexus-components/plexus-archiver/index.html
 * Source: https://github.com/sonatype/plexus-archiver
 
 plexus-archiver (3.4)
@@ -499,23 +499,23 @@ plexus-compiler-api (1.6)
 
 * License: MIT License, Apache License, 2.0
 * Project:
-   http://plexus.codehaus.org/plexus-components/plexus-compiler/index.html
+   https://plexus.codehaus.org/plexus-components/plexus-compiler/index.html
 * Source:
-   http://svn.codehaus.org/plexus/plexus-components/tags/plexus-compiler-1.6/plexus-compiler-api/
+   https://svn.codehaus.org/plexus/plexus-components/tags/plexus-compiler-1.6/plexus-compiler-api/
 
 plexus-compiler-api (1.8.1)
 
 * License: MIT License, Apache License 2.0
 * Project:
-   http://plexus.codehaus.org/plexus-components/plexus-compiler/index.html
+   https://plexus.codehaus.org/plexus-components/plexus-compiler/index.html
 * Source:
-   http://svn.codehaus.org/plexus/plexus-components/tags/1.8.1/plexus-compiler-api/
+   https://svn.codehaus.org/plexus/plexus-components/tags/1.8.1/plexus-compiler-api/
 
 plexus-compiler-api (2.2)
 
 * License: MIT License, Apache License 2.0
 * Project:
-   http://plexus.codehaus.org/plexus-components/plexus-compiler/index.html
+   https://plexus.codehaus.org/plexus-components/plexus-compiler/index.html
 * Source: https://github.com/sonatype/plexus-compiler/tree/plexus-compiler-2.2
 
 plexus-compiler-api (2.8.5)
@@ -526,23 +526,23 @@ plexus-compiler-manager (1.6)
 
 * License: MIT License
 * Project:
-   http://plexus.codehaus.org/plexus-components/plexus-compiler/plexus-compiler-manager/index.html
+   https://plexus.codehaus.org/plexus-components/plexus-compiler/plexus-compiler-manager/index.html
 * Source:
-   http://svn.codehaus.org/plexus/plexus-components/tags/plexus-compiler-1.6/plexus-compiler-manager/
+   https://svn.codehaus.org/plexus/plexus-components/tags/plexus-compiler-1.6/plexus-compiler-manager/
 
 plexus-compiler-manager (1.8.1)
 
 * License: MIT License
 * Project:
-   http://plexus.codehaus.org/plexus-components/plexus-compiler/plexus-compiler-manager/index.html
+   https://plexus.codehaus.org/plexus-components/plexus-compiler/plexus-compiler-manager/index.html
 * Source:
-   http://svn.codehaus.org/plexus/plexus-components/tags/1.8.1/plexus-compiler-manager/
+   https://svn.codehaus.org/plexus/plexus-components/tags/1.8.1/plexus-compiler-manager/
 
 plexus-compiler-manager (2.2)
 
 * License: MIT License
 * Project:
-   http://plexus.codehaus.org/plexus-components/plexus-compiler/plexus-compiler-manager/index.html
+   https://plexus.codehaus.org/plexus-components/plexus-compiler/plexus-compiler-manager/index.html
 * Source:
    https://github.com/sonatype/plexus-compiler/tree/plexus-compiler-2.2/plexus-compiler-manager
 
@@ -554,54 +554,54 @@ plexus-digest (1.0)
 
 * License: Apache License, 2.0
 * Project:
-   http://plexus.codehaus.org/plexus-components/plexus-digest/index.html
-* Source: http://svn.codehaus.org/plexus/tags/plexus-digest-1.0/
+   https://plexus.codehaus.org/plexus-components/plexus-digest/index.html
+* Source: https://svn.codehaus.org/plexus/tags/plexus-digest-1.0/
 
 plexus-interactivity-api (1.0)
 
 * License: MIT license
 * Project:
-   http://plexus.codehaus.org/plexus-components/plexus-interactivity/index.html
+   https://plexus.codehaus.org/plexus-components/plexus-interactivity/index.html
 * Source:
-   http://svn.codehaus.org/plexus/tags/plexus-interactivity-1.0-alpha-4/plexus-interactivity-api/
+   https://svn.codehaus.org/plexus/tags/plexus-interactivity-1.0-alpha-4/plexus-interactivity-api/
 
 plexus-interpolation (1.13)
 
 * License: Apache Software License 1.1, Apache License, 2.0, MIT license 
 * Project:
-   http://plexus.codehaus.org/plexus-components/plexus-interpolation/index.html
+   https://plexus.codehaus.org/plexus-components/plexus-interpolation/index.html
 * Source:
-   http://svn.codehaus.org/plexus/plexus-components/tags/plexus-interpolation-1.13/
+   https://svn.codehaus.org/plexus/plexus-components/tags/plexus-interpolation-1.13/
 
 plexus-io (1.0.1)
 
 * License: Apache License, 2.0
-* Project: http://plexus.codehaus.org/plexus-components/plexus-io/index.html
+* Project: https://plexus.codehaus.org/plexus-components/plexus-io/index.html
 * Source:
-   http://svn.codehaus.org/plexus/plexus-components/tags/plexus-io-1.0.1/
+   https://svn.codehaus.org/plexus/plexus-components/tags/plexus-io-1.0.1/
 
 plexus-io (2.0.5)
 
 * License: Apache License, 2.0
-* Project: http://plexus.codehaus.org/plexus-components/plexus-io/index.html
+* Project: https://plexus.codehaus.org/plexus-components/plexus-io/index.html
 * Source: https://github.com/sonatype/plexus-io.git
 
 plexus-io (2.4.1)
 
 * License: Apache License, 2.0
-* Project: http://plexus.codehaus.org/plexus-components/plexus-io/index.html
+* Project: https://plexus.codehaus.org/plexus-components/plexus-io/index.html
 * Source: https://github.com/sonatype/plexus-io.git
 
 plexus-io (2.6)
 
 * License: Apache License, 2.0
-* Project: http://plexus.codehaus.org/plexus-components/plexus-io/index.html
+* Project: https://plexus.codehaus.org/plexus-components/plexus-io/index.html
 * Source: https://github.com/sonatype/plexus-io.git
 
 plexus-io (2.7.1)
 
 * License: Apache-2.0
-* Project: http://plexus.codehaus.org/plexus-components/plexus-io/index.html
+* Project: https://plexus.codehaus.org/plexus-components/plexus-io/index.html
 * Source: https://github.com/sonatype/plexus-io.git
 
 plexus-io (3.2.0)
@@ -616,7 +616,7 @@ plexus-util (3.0.20)
 
 * License: Apache 2.0, Apache 1.1, BSD, Public Domain, Indiana University
    Extreme! Lab Software License V1.1.1 (Apache 1.1 styl
-* Project: http://plexus.codehaus.org/plexus-utils/
+* Project: https://plexus.codehaus.org/plexus-utils/
 * Source: https://github.com/sonatype/plexus-utils
 
 plexus-utils (1.5.6)
@@ -633,21 +633,21 @@ plexus-utils (2.0.5)
 
 * License:  Apache 2.0, Apache 1.1, BSD, Public Domain, Indiana University
    Extreme! Lab Software License V1.1.1 (Apache 1.1 style)
-* Project: http://plexus.codehaus.org/plexus-utils/
-* Source: http://svn.codehaus.org/plexus/plexus-utils/tags/plexus-utils-2.0.5/
+* Project: https://plexus.codehaus.org/plexus-utils/
+* Source: https://svn.codehaus.org/plexus/plexus-utils/tags/plexus-utils-2.0.5/
 
 plexus-utils (3.0.7)
 
 * License: Apache 2.0, Apache 1.1, BSD, Public Domain, Indiana University
    Extreme! Lab Software License V1.1.1 (Apache 1.1 style) 
-* Project: http://plexus.codehaus.org/plexus-utils/
+* Project: https://plexus.codehaus.org/plexus-utils/
 
 plexus-utils (3.0.24)
 
 * License: Apache 2.0, Apache 1.1, BSD, Public Domain, Indiana University
    Extreme! Lab Software License V1.1.1 (Apache 1.1 style)
 * Project: https://codehaus-plexus.github.io/plexus-utils/
-* Source: http://github.com/codehaus-plexus/plexus-utils
+* Source: https://github.com/codehaus-plexus/plexus-utils
 
 plexus-utils (3.3.0)
 
@@ -678,82 +678,82 @@ sat4j (2.2.0)
 Surefire common-java5 (2.19.1)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/surefire/surefire-providers/common-java5/
+* Project: https://maven.apache.org/surefire/surefire-providers/common-java5/
 * Source:
    https://github.com/apache/maven-surefire/tree/surefire-2.19.1_vote-2/surefire-providers/common-java5
 
 Surefire common-junit3 (2.19.1)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/surefire/surefire-providers/common-junit3/
+* Project: https://maven.apache.org/surefire/surefire-providers/common-junit3/
 * Source:
    https://github.com/apache/maven-surefire/tree/surefire-2.19.1_vote-2/surefire-providers/common-junit3
 
 Surefire common-junit4 (2.19.1)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/surefire/surefire-providers/common-junit4/
+* Project: https://maven.apache.org/surefire/surefire-providers/common-junit4/
 * Source:
    https://github.com/apache/maven-surefire/tree/surefire-2.19.1_vote-2/surefire-providers/common-junit4
 
 surefire-api (2.4.3)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/surefire/surefire-api/index.html
-* Source: http://svn.apache.org/viewvc/maven/surefire/tags/surefire-2.4.3/
+* Project: https://maven.apache.org/surefire/surefire-api/index.html
+* Source: https://svn.apache.org/viewvc/maven/surefire/tags/surefire-2.4.3/
 
 surefire-api (2.10)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/surefire/surefire-api/index.html
+* Project: https://maven.apache.org/surefire/surefire-api/index.html
 * Source:
-   http://svn.apache.org/viewvc/maven/surefire/tags/surefire-2.10/surefire-api/
+   https://svn.apache.org/viewvc/maven/surefire/tags/surefire-2.10/surefire-api/
 
 surefire-api (2.17)
 
 * License: Apache License 2.0
-* Project: http://maven.apache.org/surefire/maven-surefire-plugin/
+* Project: https://maven.apache.org/surefire/maven-surefire-plugin/
 * Source:
    https://git-wip-us.apache.org/repos/asf?p=maven-surefire.git;a=tag;h=refs/tags/surefire-2.17
 
 surefire-api (2.19.1)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/surefire/surefire-api/
+* Project: https://maven.apache.org/surefire/surefire-api/
 * Source:
    https://github.com/apache/maven-surefire/tree/surefire-2.19.1_vote-2/surefire-api
 
 surefire-api (2.22.0)
 
 * License: Apache-2.0
-* Project: http://maven.apache.org/surefire/surefire-api/
+* Project: https://maven.apache.org/surefire/surefire-api/
 * Source: https://maven.apache.org/surefire/surefire-api/source-repository.html
 
 surefire-booter (2.4.3)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/surefire/surefire-booter/index.html
+* Project: https://maven.apache.org/surefire/surefire-booter/index.html
 * Source:
-   http://svn.apache.org/viewvc/maven/surefire/tags/surefire-2.4.3/surefire-booter/
+   https://svn.apache.org/viewvc/maven/surefire/tags/surefire-2.4.3/surefire-booter/
 
 surefire-booter (2.10)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/surefire/surefire-booter/index.html
+* Project: https://maven.apache.org/surefire/surefire-booter/index.html
 * Source:
-   http://svn.apache.org/viewvc/maven/surefire/tags/surefire-2.10/surefire-booter/
+   https://svn.apache.org/viewvc/maven/surefire/tags/surefire-2.10/surefire-booter/
 
 surefire-booter (2.17)
 
 * License: Apache License 2.0
-* Project: http://maven.apache.org/surefire/maven-surefire-plugin/
+* Project: https://maven.apache.org/surefire/maven-surefire-plugin/
 * Source:
    https://git-wip-us.apache.org/repos/asf?p=maven-surefire.git;a=tag;h=refs/tags/surefire-2.17
 
 surefire-booter (2.19.1)
 
 * License: Apache-2.0
-* Project: http://maven.apache.org/surefire/
+* Project: https://maven.apache.org/surefire/
 * Source: https://github.com/apache/maven-surefire/tree/master/surefire-booter
 
 surefire-booter (2.22.0)
@@ -766,42 +766,42 @@ surefire-booter (2.22.0)
 surefire-common (2.17)
 
 * License: Apache License 2.0
-* Project: http://maven.apache.org/surefire/maven-surefire-plugin/
+* Project: https://maven.apache.org/surefire/maven-surefire-plugin/
 * Source:
    https://git-wip-us.apache.org/repos/asf?p=maven-surefire.git;a=tag;h=refs/tags/surefire-2.17
 
 surefire-common (2.22)
 
 * License: Apache-2.0
-* Project: http://maven.apache.org/surefire/maven-surefire-plugin/
+* Project: https://maven.apache.org/surefire/maven-surefire-plugin/
 * Source:
    https://maven.apache.org/surefire/maven-surefire-common/source-repository.html
 
 surefire-common-junit48 (2.17)
 
 * License: Apache License 2.0
-* Project: http://maven.apache.org/surefire/maven-surefire-plugin/
+* Project: https://maven.apache.org/surefire/maven-surefire-plugin/
 * Source:
    https://git-wip-us.apache.org/repos/asf?p=maven-surefire.git;a=tag;h=refs/tags/surefire-2.17
 
 surefire-common-junit48 (2.19.1)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/surefire/surefire-providers/common-junit48/
+* Project: https://maven.apache.org/surefire/surefire-providers/common-junit48/
 * Source:
    https://github.com/apache/maven-surefire/tree/surefire-2.19.1_vote-2/surefire-providers/common-junit48
 
 surefire-grouper (2.17)
 
 * License: Apache License 2.0
-* Project: http://maven.apache.org/surefire/maven-surefire-plugin/
+* Project: https://maven.apache.org/surefire/maven-surefire-plugin/
 * Source:
    https://git-wip-us.apache.org/repos/asf?p=maven-surefire.git;a=tag;h=refs/tags/surefire-2.17
 
 surefire-grouper (2.19.1)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/surefire/surefire-grouper/
+* Project: https://maven.apache.org/surefire/surefire-grouper/
 * Source:
    https://github.com/apache/maven-surefire/tree/surefire-2.19.1_vote-2/surefire-grouper
 
@@ -809,16 +809,16 @@ surefire-juni47 (2.19.1)
 
 * License: Apache License, 2.0
 * Project:
-   http://maven.apache.org/components/surefire/surefire-providers/surefire-junit47/
+   https://maven.apache.org/components/surefire/surefire-providers/surefire-junit47/
 * Source:
    https://github.com/apache/maven-surefire/tree/surefire-2.19.1_vote-2/surefire-providers/surefire-junit47
 
 surefire-junit (2.4.3)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/surefire/surefire-providers/index.html
+* Project: https://maven.apache.org/surefire/surefire-providers/index.html
 * Source:
-   http://svn.apache.org/viewvc/maven/surefire/tags/surefire-2.4.3/surefire-providers/surefire-junit/
+   https://svn.apache.org/viewvc/maven/surefire/tags/surefire-2.4.3/surefire-providers/surefire-junit/
 
 surefire-junit-platform (2.22.0)
 
@@ -831,35 +831,35 @@ surefire-junit-platform (2.22.0)
 surefire-junit3 (2.10)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/surefire/surefire-providers/index.html
+* Project: https://maven.apache.org/surefire/surefire-providers/index.html
 * Source:
-   http://svn.apache.org/viewvc/maven/surefire/tags/surefire-2.10/surefire-providers/surefire-junit3/
+   https://svn.apache.org/viewvc/maven/surefire/tags/surefire-2.10/surefire-providers/surefire-junit3/
 
 surefire-junit3 (2.17)
 
 * License: Apache License 2.0
-* Project: http://maven.apache.org/surefire/maven-surefire-plugin/
+* Project: https://maven.apache.org/surefire/maven-surefire-plugin/
 * Source:
    https://git-wip-us.apache.org/repos/asf?p=maven-surefire.git;a=tag;h=refs/tags/surefire-2.17
 
 surefire-junit4 (2.4.3)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/surefire/surefire-providers/index.html
+* Project: https://maven.apache.org/surefire/surefire-providers/index.html
 * Source:
-   http://svn.apache.org/viewvc/maven/surefire/tags/surefire-2.4.3/surefire-providers/surefire-junit4/
+   https://svn.apache.org/viewvc/maven/surefire/tags/surefire-2.4.3/surefire-providers/surefire-junit4/
 
 surefire-junit4 (2.10)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/surefire/surefire-providers/index.html
+* Project: https://maven.apache.org/surefire/surefire-providers/index.html
 * Source:
-   http://svn.apache.org/viewvc/maven/surefire/tags/surefire-2.10/surefire-providers/surefire-junit4/
+   https://svn.apache.org/viewvc/maven/surefire/tags/surefire-2.10/surefire-providers/surefire-junit4/
 
 surefire-junit4 (2.17)
 
 * License: Apache License 2.0
-* Project: http://maven.apache.org/surefire/maven-surefire-plugin/
+* Project: https://maven.apache.org/surefire/maven-surefire-plugin/
 * Source:
    https://git-wip-us.apache.org/repos/asf?p=maven-surefire.git;a=tag;h=refs/tags/surefire-2.17
 
@@ -870,14 +870,14 @@ surefire-junit4 (2.19.1)
 surefire-junit47 (2.10)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/surefire/surefire-providers/index.html
+* Project: https://maven.apache.org/surefire/surefire-providers/index.html
 * Source:
-   http://svn.apache.org/viewvc/maven/surefire/tags/surefire-2.10/surefire-providers/surefire-junit47/
+   https://svn.apache.org/viewvc/maven/surefire/tags/surefire-2.10/surefire-providers/surefire-junit47/
 
 surefire-junit47 (2.17)
 
 * License: Apache License 2.0
-* Project: http://maven.apache.org/surefire/maven-surefire-plugin/
+* Project: https://maven.apache.org/surefire/maven-surefire-plugin/
 * Source:
    https://git-wip-us.apache.org/repos/asf?p=maven-surefire.git;a=tag;h=refs/tags/surefire-2.17
 
@@ -899,7 +899,7 @@ surefire-testng (2.19.1)
 surefire-testng-util (2.17)
 
 * License: Apache License, 2.0
-* Project: http://maven.apache.org/surefire/maven-surefire-plugin/
+* Project: https://maven.apache.org/surefire/maven-surefire-plugin/
 * Source:
    https://git-wip-us.apache.org/repos/asf?p=maven-surefire.git;a=tag;h=refs/tags/surefire-2.17
 
@@ -916,8 +916,8 @@ testng (6.9.10)
 xz for java (1.5)
 
 * License: Public-Domain
-* Project: http://tukaani.org/xz/java.html
-* Source: http://git.tukaani.org/xz-java.git
+* Project: https://tukaani.org/xz/java.html
+* Source: https://git.tukaani.org/xz-java.git
 
 ## Cryptography
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -17,9 +17,9 @@ in the corresponding folder.
 About Tycho
 ===========
 
-  * [Project Homepage](http://www.eclipse.org/tycho/)
-  * [Documentation](http://eclipse.org/tycho/documentation.php)
-  * [Bug Tracker](https://bugs.eclipse.org/bugs/buglist.cgi?product=Tycho)
-  * [How to Contribute](http://wiki.eclipse.org/Tycho/Contributor_Guide)
+  * [Project Homepage](https://github.com/eclipse/tycho)
+  * [Documentation](https://www.eclipse.org/tycho/sitedocs/)
+  * [Bug Tracker](https://github.com/eclipse/tycho/issues)
+  * [How to Contribute](https://github.com/eclipse/tycho/blob/master/CONTRIBUTING.md)
   * [Contact Us](https://dev.eclipse.org/mailman/listinfo/tycho-user)
 

--- a/demo/itp01/pom.xml
+++ b/demo/itp01/pom.xml
@@ -19,7 +19,7 @@
    <repository>
      <id>helios</id>
      <layout>p2</layout>
-     <url>http://download.eclipse.org/releases/helios</url>
+     <url>https://download.eclipse.org/releases/helios</url>
    </repository>
   </repositories>
 

--- a/demo/itp02/build02/pom.xml
+++ b/demo/itp02/build02/pom.xml
@@ -37,7 +37,7 @@
    <repository>
      <id>helios</id>
      <layout>p2</layout>
-     <url>http://download.eclipse.org/releases/helios</url>
+     <url>https://download.eclipse.org/releases/helios</url>
    </repository>
   </repositories>
 

--- a/demo/itp03-crossplatform/org.tycho.demo.crossplatform.rcp/pom.xml
+++ b/demo/itp03-crossplatform/org.tycho.demo.crossplatform.rcp/pom.xml
@@ -7,6 +7,6 @@
     <version>1.0.0-SNAPSHOT</version>
   </parent>  
   <artifactId>org.tycho.demo.crossplatform.rcp</artifactId>
-  <!-- eclipse-application is deprecated. See http://wiki.eclipse.org/Tycho/Packaging_Types#eclipse-application -->
+  <!-- eclipse-application is deprecated. See https://wiki.eclipse.org/Tycho/Packaging_Types#eclipse-application -->
   <packaging>eclipse-application</packaging>
 </project>

--- a/demo/itp03-crossplatform/pom.xml
+++ b/demo/itp03-crossplatform/pom.xml
@@ -8,7 +8,7 @@
 
   <properties>
     <tycho-version>2.3.0</tycho-version>
-    <eclipse-repository-url>http://download.eclipse.org/eclipse/updates/3.6</eclipse-repository-url>
+    <eclipse-repository-url>https://download.eclipse.org/eclipse/updates/3.6</eclipse-repository-url>
   </properties>
 
   <modules>
@@ -20,7 +20,7 @@
     <profile>
       <id>e35</id>
       <properties>
-        <eclipse-repository-url>http://download.eclipse.org/eclipse/updates/3.5</eclipse-repository-url>
+        <eclipse-repository-url>https://download.eclipse.org/eclipse/updates/3.5</eclipse-repository-url>
       </properties>
     </profile>
   </profiles>

--- a/demo/itp04-rcp/README.txt
+++ b/demo/itp04-rcp/README.txt
@@ -1,6 +1,6 @@
 This demo project shows how Tycho supports p2-enabled RCP applications
 
 The demo application is documented in detail here 
-http://wiki.eclipse.org/Tycho/Demo_Projects/RCP_Application
+https://wiki.eclipse.org/Tycho/Demo_Projects/RCP_Application
 
 

--- a/demo/itp04-rcp/example-feature-2/feature.properties
+++ b/demo/itp04-rcp/example-feature-2/feature.properties
@@ -102,10 +102,10 @@ TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS.\n\
 SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
        - Common Public License Version 1.0 (available at https://www.eclipse.org/legal/cpl-v10.html)\n\
-       - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-       - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
-       - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
-       - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\
+       - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+       - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
+       - Metro Link Public License 1.00 (available at https://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
+       - Mozilla Public License Version 1.1 (available at https://www.mozilla.org/MPL/MPL-1.1.html)\n\
 \n\
 IT IS YOUR OBLIGATION TO READ AND ACCEPT ALL SUCH TERMS AND CONDITIONS PRIOR\n\
 TO USE OF THE CONTENT. If no About, Feature License, or Feature Update License\n\
@@ -120,7 +120,7 @@ the purpose of allowing users to install software, documentation, information an
 other materials (collectively "Installable Software"). This capability is provided with\n\
 the intent of allowing such users to install, extend and update Eclipse-based products.\n\
 Information about packaging Installable Software is available at\n\
-http://eclipse.org/equinox/p2/repository_packaging.html ("Specification").\n\
+https://eclipse.org/equinox/p2/repository_packaging.html ("Specification").\n\
 \n\
 You may use Provisioning Technology to allow other parties to install Installable Software.\n\
 You shall be responsible for enabling the applicable license agreements relating to the\n\

--- a/demo/itp04-rcp/example-feature-2/license.html
+++ b/demo/itp04-rcp/example-feature-2/license.html
@@ -59,10 +59,10 @@ OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):</p>
 
 <ul>
        <li>Common Public License Version 1.0 (available at <a href="https://www.eclipse.org/legal/cpl-v10.html">https://www.eclipse.org/legal/cpl-v10.html</a>)</li>
-       <li>Apache Software License 1.1 (available at <a href="http://www.apache.org/licenses/LICENSE">http://www.apache.org/licenses/LICENSE</a>)</li>
-       <li>Apache Software License 2.0 (available at <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>)</li>
-       <li>Metro Link Public License 1.00 (available at <a href="http://www.opengroup.org/openmotif/supporters/metrolink/license.html">http://www.opengroup.org/openmotif/supporters/metrolink/license.html</a>)</li>
-       <li>Mozilla Public License Version 1.1 (available at <a href="http://www.mozilla.org/MPL/MPL-1.1.html">http://www.mozilla.org/MPL/MPL-1.1.html</a>)</li>
+       <li>Apache Software License 1.1 (available at <a href="https://www.apache.org/licenses/LICENSE">https://www.apache.org/licenses/LICENSE</a>)</li>
+       <li>Apache Software License 2.0 (available at <a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a>)</li>
+       <li>Metro Link Public License 1.00 (available at <a href="https://www.opengroup.org/openmotif/supporters/metrolink/license.html">https://www.opengroup.org/openmotif/supporters/metrolink/license.html</a>)</li>
+       <li>Mozilla Public License Version 1.1 (available at <a href="https://www.mozilla.org/MPL/MPL-1.1.html">https://www.mozilla.org/MPL/MPL-1.1.html</a>)</li>
 </ul>
 
 <p>IT IS YOUR OBLIGATION TO READ AND ACCEPT ALL SUCH TERMS AND CONDITIONS PRIOR TO USE OF THE CONTENT.  If no About, Feature License, or Feature Update License is provided, please
@@ -75,7 +75,7 @@ contact the Eclipse Foundation to determine what terms and conditions govern tha
    Update Manager (&quot;Provisioning Technology&quot;) for the purpose of allowing users to install software, documentation, information and/or
    other materials (collectively &quot;Installable Software&quot;). This capability is provided with the intent of allowing such users to
    install, extend and update Eclipse-based products. Information about packaging Installable Software is available at <a
-       href="http://eclipse.org/equinox/p2/repository_packaging.html">http://eclipse.org/equinox/p2/repository_packaging.html</a>
+       href="https://eclipse.org/equinox/p2/repository_packaging.html">https://eclipse.org/equinox/p2/repository_packaging.html</a>
    (&quot;Specification&quot;).</p>
 
 <p>You may use Provisioning Technology to allow other parties to install Installable Software. You shall be responsible for enabling the

--- a/demo/itp04-rcp/example-feature/feature.properties
+++ b/demo/itp04-rcp/example-feature/feature.properties
@@ -102,10 +102,10 @@ TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS.\n\
 SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
        - Common Public License Version 1.0 (available at https://www.eclipse.org/legal/cpl-v10.html)\n\
-       - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-       - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
-       - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
-       - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\
+       - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+       - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
+       - Metro Link Public License 1.00 (available at https://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
+       - Mozilla Public License Version 1.1 (available at https://www.mozilla.org/MPL/MPL-1.1.html)\n\
 \n\
 IT IS YOUR OBLIGATION TO READ AND ACCEPT ALL SUCH TERMS AND CONDITIONS PRIOR\n\
 TO USE OF THE CONTENT. If no About, Feature License, or Feature Update License\n\
@@ -120,7 +120,7 @@ the purpose of allowing users to install software, documentation, information an
 other materials (collectively "Installable Software"). This capability is provided with\n\
 the intent of allowing such users to install, extend and update Eclipse-based products.\n\
 Information about packaging Installable Software is available at\n\
-http://eclipse.org/equinox/p2/repository_packaging.html ("Specification").\n\
+https://eclipse.org/equinox/p2/repository_packaging.html ("Specification").\n\
 \n\
 You may use Provisioning Technology to allow other parties to install Installable Software.\n\
 You shall be responsible for enabling the applicable license agreements relating to the\n\

--- a/demo/itp04-rcp/example-feature/license.html
+++ b/demo/itp04-rcp/example-feature/license.html
@@ -59,10 +59,10 @@ OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):</p>
 
 <ul>
        <li>Common Public License Version 1.0 (available at <a href="https://www.eclipse.org/legal/cpl-v10.html">https://www.eclipse.org/legal/cpl-v10.html</a>)</li>
-       <li>Apache Software License 1.1 (available at <a href="http://www.apache.org/licenses/LICENSE">http://www.apache.org/licenses/LICENSE</a>)</li>
-       <li>Apache Software License 2.0 (available at <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>)</li>
-       <li>Metro Link Public License 1.00 (available at <a href="http://www.opengroup.org/openmotif/supporters/metrolink/license.html">http://www.opengroup.org/openmotif/supporters/metrolink/license.html</a>)</li>
-       <li>Mozilla Public License Version 1.1 (available at <a href="http://www.mozilla.org/MPL/MPL-1.1.html">http://www.mozilla.org/MPL/MPL-1.1.html</a>)</li>
+       <li>Apache Software License 1.1 (available at <a href="https://www.apache.org/licenses/LICENSE">https://www.apache.org/licenses/LICENSE</a>)</li>
+       <li>Apache Software License 2.0 (available at <a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a>)</li>
+       <li>Metro Link Public License 1.00 (available at <a href="https://www.opengroup.org/openmotif/supporters/metrolink/license.html">https://www.opengroup.org/openmotif/supporters/metrolink/license.html</a>)</li>
+       <li>Mozilla Public License Version 1.1 (available at <a href="https://www.mozilla.org/MPL/MPL-1.1.html">https://www.mozilla.org/MPL/MPL-1.1.html</a>)</li>
 </ul>
 
 <p>IT IS YOUR OBLIGATION TO READ AND ACCEPT ALL SUCH TERMS AND CONDITIONS PRIOR TO USE OF THE CONTENT.  If no About, Feature License, or Feature Update License is provided, please
@@ -75,7 +75,7 @@ contact the Eclipse Foundation to determine what terms and conditions govern tha
    Update Manager (&quot;Provisioning Technology&quot;) for the purpose of allowing users to install software, documentation, information and/or
    other materials (collectively &quot;Installable Software&quot;). This capability is provided with the intent of allowing such users to
    install, extend and update Eclipse-based products. Information about packaging Installable Software is available at <a
-       href="http://eclipse.org/equinox/p2/repository_packaging.html">http://eclipse.org/equinox/p2/repository_packaging.html</a>
+       href="https://eclipse.org/equinox/p2/repository_packaging.html">https://eclipse.org/equinox/p2/repository_packaging.html</a>
    (&quot;Specification&quot;).</p>
 
 <p>You may use Provisioning Technology to allow other parties to install Installable Software. You shall be responsible for enabling the

--- a/demo/itp04-rcp/mars/mars.target
+++ b/demo/itp04-rcp/mars/mars.target
@@ -7,7 +7,7 @@
 <unit id="org.eclipse.rcp.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/releases/mars/"/>
+<repository location="https://download.eclipse.org/releases/mars/"/>
 </location>
 </locations>
 </target>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<inceptionYear>2008</inceptionYear>
-	<url>http://www.eclipse.org/tycho/</url>
+	<url>https://www.eclipse.org/tycho/</url>
 	<ciManagement>
 		<system>jenkins</system>
 		<url>https://ci.eclipse.org/tycho</url>
@@ -23,13 +23,13 @@
 	<licenses>
 		<license>
 			<name>Eclipse Public License</name>
-			<url>http://www.eclipse.org/legal/epl-v20.html</url>
+			<url>https://www.eclipse.org/legal/epl-v20.html</url>
 			<distribution>repo</distribution>
 		</license>
 	</licenses>
 	<organization>
 		<name>Eclipse Foundation</name>
-		<url>http://www.eclipse.org/</url>
+		<url>https://www.eclipse.org/</url>
 	</organization>
 	<issueManagement>
 		<system>GitHub</system>
@@ -44,17 +44,17 @@
 		<developer>
 			<name>Igor Fedorenko</name>
 			<organization>Sonatype</organization>
-			<organizationUrl>http://www.sonatype.com</organizationUrl>
+			<organizationUrl>https://www.sonatype.com</organizationUrl>
 		</developer>
 		<developer>
 			<name>Tobias Oberlies</name>
 			<organization>SAP</organization>
-			<organizationUrl>http://www.sap.com</organizationUrl>
+			<organizationUrl>https://www.sap.com</organizationUrl>
 		</developer>
 		<developer>
 			<name>Jan Sievers</name>
 			<organization>SAP</organization>
-			<organizationUrl>http://www.sap.com</organizationUrl>
+			<organizationUrl>https://www.sap.com</organizationUrl>
 		</developer>
 	</developers>
 	<prerequisites>
@@ -321,7 +321,7 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-plugin-plugin</artifactId>
 					<version>${pluginToolsVersion}</version>
-					<!-- workaround for http://jira.codehaus.org/browse/MNG-5346 -->
+					<!-- workaround for https://jira.codehaus.org/browse/MNG-5346 -->
 					<configuration>
 						<skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
 						<extractors>
@@ -580,7 +580,7 @@
 		<site>
 			<id>tycho.site</id>
 			<name>Tycho Site</name>
-			<!-- >workaround for http://jira.codehaus.org/browse/MSITE-671 -->
+			<!-- >workaround for https://jira.codehaus.org/browse/MSITE-671 -->
 			<url>http://staging</url>
 		</site>
 		<repository>

--- a/src/site/markdown/BuildProperties.md
+++ b/src/site/markdown/BuildProperties.md
@@ -1,6 +1,6 @@
 ## Build Properties
 
-Tycho uses the `build.properties` file [as defined by PDE](http://help.eclipse.org/luna/index.jsp?topic=/org.eclipse.pde.doc.user/reference/pde_feature_generating_build.htm) to configure various aspects of the build.
+Tycho uses the `build.properties` file [as defined by PDE](https://help.eclipse.org/luna/index.jsp?topic=/org.eclipse.pde.doc.user/reference/pde_feature_generating_build.htm) to configure various aspects of the build.
 
 Note that Tycho only supports a subset of keys defined by PDE. If a key is not supported, this may be because
 

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/impl/publisher/rootfiles/FileSet.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/impl/publisher/rootfiles/FileSet.java
@@ -20,7 +20,7 @@ import org.eclipse.core.runtime.Path;
 
 /**
  * Ant-like file set. Wildcards *, ** and ? are implemented as described on <br/>
- * {@link http://en.wikibooks.org/wiki/Apache_Ant/Fileset }. This is not a complete equivalent
+ * {@link https://en.wikibooks.org/wiki/Apache_Ant/Fileset }. This is not a complete equivalent
  * implementation of the ant fileset. Only the subset needed for PDE root files is supported.
  */
 public class FileSet extends AbstractFileSet {

--- a/tycho-compiler-jdt/src/main/java/org/eclipse/tycho/compiler/jdt/JdkLibraryInfoProvider.java
+++ b/tycho-compiler-jdt/src/main/java/org/eclipse/tycho/compiler/jdt/JdkLibraryInfoProvider.java
@@ -140,7 +140,7 @@ public class JdkLibraryInfoProvider {
         String[] bootclasspath = splitPath(parts[1]);
         String[] extDirs = splitPath(parts[2]);
         String[] endorsedDirs = splitPath(parts[3]);
-        // workaround for missing bootclasspath in Java 9 - see JDT bug http://eclip.se/489207  
+        // workaround for missing bootclasspath in Java 9 - see JDT bug https://eclip.se/489207  
         if (bootclasspath.length == 0) {
             File jrtFsJar = new File(javaHome, "lib/jrt-fs.jar");
             if (!jrtFsJar.isFile()) {

--- a/tycho-compiler-plugin/src/main/java/copied/org/apache/maven/plugin/AbstractCompilerMojo.java
+++ b/tycho-compiler-plugin/src/main/java/copied/org/apache/maven/plugin/AbstractCompilerMojo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * 	http://www.apache.org/licenses/LICENSE-2.0
+ * 	https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -195,7 +195,7 @@ public abstract class AbstractCompilerMojo extends AbstractMojo {
 
     /**
      * Qualified class names of annotation processors to run. If specified, the
-     * <a href="http://java.sun.com/javase/6/docs/api/javax/annotation/processing/Processor.html" >
+     * <a href="https://java.sun.com/javase/6/docs/api/javax/annotation/processing/Processor.html" >
      * normal processor discovery process</a> will be skipped. This parameter requires a 1.6 VM or
      * above and is used only if the compliance is 1.6
      * 

--- a/tycho-compiler-plugin/src/main/java/copied/org/apache/maven/plugin/CompilationFailureException.java
+++ b/tycho-compiler-plugin/src/main/java/copied/org/apache/maven/plugin/CompilationFailureException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * 	http://www.apache.org/licenses/LICENSE-2.0
+ * 	https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
+++ b/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/AbstractOsgiCompilerMojo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * 	http://www.apache.org/licenses/LICENSE-2.0
+ * 	https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -136,7 +136,7 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo
      * Which JDK to use for compilation. Default value is SYSTEM which means the currently running
      * JDK. If BREE is specified, MANIFEST header <code>Bundle-RequiredExecutionEnvironment</code>
      * is used to define the JDK to compile against. In this case, you need to provide a
-     * <a href="http://maven.apache.org/guides/mini/guide-using-toolchains.html">toolchains.xml</a>
+     * <a href="https://maven.apache.org/guides/mini/guide-using-toolchains.html">toolchains.xml</a>
      * configuration file. The value of BREE will be matched against the id of the toolchain
      * elements in toolchains.xml. Example:
      * 
@@ -257,9 +257,9 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo
      * 
      * Set this to <code>false</code> in case you want to keep resources separate from java files in
      * <code>src/main/resources</code> and handle them using
-     * <a href="http://maven.apache.org/plugins/maven-resources-plugin/"> maven-resources-plugin</a>
+     * <a href="https://maven.apache.org/plugins/maven-resources-plugin/"> maven-resources-plugin</a>
      * (e.g. for <a href=
-     * "http://maven.apache.org/plugins/maven-resources-plugin/examples/filter.html">resource
+     * "https://maven.apache.org/plugins/maven-resources-plugin/examples/filter.html">resource
      * filtering<a/>.
      * 
      */
@@ -677,7 +677,7 @@ public abstract class AbstractOsgiCompilerMojo extends AbstractCompilerMojo
         DefaultJavaToolChain toolChain = toolchainProvider.findMatchingJavaToolChain(session, toolchainId);
         if (toolChain == null) {
             throw new MojoExecutionException("useJDK = BREE configured, but no toolchain of type 'jdk' with id '"
-                    + toolchainId + "' found. See http://maven.apache.org/guides/mini/guide-using-toolchains.html");
+                    + toolchainId + "' found. See https://maven.apache.org/guides/mini/guide-using-toolchains.html");
         }
         compilerConfiguration.addCompilerCustomArgument("use.java.home", toolChain.getJavaHome());
         configureBootClassPath(compilerConfiguration, toolChain);

--- a/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/OsgiCompilerMojo.java
+++ b/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/OsgiCompilerMojo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * 	http://www.apache.org/licenses/LICENSE-2.0
+ * 	https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/OsgiTestCompilerMojo.java
+++ b/tycho-compiler-plugin/src/main/java/org/eclipse/tycho/compiler/OsgiTestCompilerMojo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * 	http://www.apache.org/licenses/LICENSE-2.0
+ * 	https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/utils/MavenCompatiblityHelper.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/utils/MavenCompatiblityHelper.java
@@ -57,7 +57,7 @@ public class MavenCompatiblityHelper {
      * 
      * The types RemoteRepository and RepositorySystemSession from aether are changed incompatibly
      * in maven 3.1 so we invoke MavenPluginManager#getPluginDescriptor reflectively. See maven
-     * issue <a href="http://jira.codehaus.org/browse/MNG-5354">MNG-5354</a>.
+     * issue <a href="https://jira.codehaus.org/browse/MNG-5354">MNG-5354</a>.
      * 
      */
     public PluginDescriptor getPluginDescriptor(Plugin plugin, MavenProject project, MavenSession session)
@@ -93,7 +93,7 @@ public class MavenCompatiblityHelper {
      * 
      * The types RemoteRepository and RepositorySystemSession from aether are changed incompatibly
      * in maven 3.1 so we invoke PluginDescriptorCache#createKey reflectively. See maven issue <a
-     * href="http://jira.codehaus.org/browse/MNG-5354">MNG-5354</a>.
+     * href="https://jira.codehaus.org/browse/MNG-5354">MNG-5354</a>.
      */
     public PluginDescriptorCache.Key createKey(Plugin plugin, MavenProject project, MavenSession session) {
         try {

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/AbstractArtifactDependencyWalker.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/AbstractArtifactDependencyWalker.java
@@ -141,7 +141,7 @@ public abstract class AbstractArtifactDependencyWalker implements ArtifactDepend
 
                 // for Mac OS X there is no org.eclipse.equinox.launcher.carbon.macosx.x86 or org.eclipse.equinox.launcher.carbon.macosx.ppc folder,
                 // only a org.eclipse.equinox.launcher.carbon.macosx folder.
-                // see http://jira.codehaus.org/browse/MNGECLIPSE-1075
+                // see https://jira.codehaus.org/browse/MNGECLIPSE-1075
                 if (PlatformPropertiesUtils.OS_MACOSX.equals(os) && (PlatformPropertiesUtils.ARCH_X86.equals(arch)
                         || PlatformPropertiesUtils.ARCH_PPC.equals(arch))) {
                     id = "org.eclipse.equinox.launcher." + ws + "." + os;

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DependencyComputer.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DependencyComputer.java
@@ -386,7 +386,7 @@ public class DependencyComputer {
      * bundle are supposed to come from JRE and which from the bundle itself, so returned classpath
      * access rules include all packages exported by the framework extension bundles.
      * 
-     * [1] http://blog.meschberger.ch/2008/10/osgi-bundles-require-classes-from.html
+     * [1] https://blog.meschberger.ch/2008/10/osgi-bundles-require-classes-from.html
      */
 
     public List<AccessRule> computeBootClasspathExtraAccessRules(ModuleContainer container) {

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/EquinoxResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/EquinoxResolver.java
@@ -440,7 +440,7 @@ public class EquinoxResolver {
     private boolean isFrameworkImplementation(OsgiManifest mf) {
         // starting with OSGi R4.2, /META-INF/services/org.osgi.framework.launch.FrameworkFactory
         // can be used to detect framework implementation
-        // See http://www.osgi.org/javadoc/r4v42/org/osgi/framework/launch/FrameworkFactory.html
+        // See https://www.osgi.org/javadoc/r4v42/org/osgi/framework/launch/FrameworkFactory.html
 
         // Assume only framework implementation export org.osgi.framework package
         String value = mf.getHeaders().get(Constants.EXPORT_PACKAGE);

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiManifest.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/OsgiManifest.java
@@ -142,7 +142,7 @@ public class OsgiManifest {
      * https://help.eclipse.org/galileo/index.jsp?topic=/org.eclipse.platform.doc.isv/reference/misc/
      * bundle_manifest.html
      * 
-     * http://eclipsesource.com/blogs/2009/01/20/tip-eclipse-bundleshape/
+     * https://eclipsesource.com/blogs/2009/01/20/tip-eclipse-bundleshape/
      */
     public boolean isDirectoryShape() {
         return isDirectoryShape;

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/targetplatform/EclipseInstallationLayout.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/targetplatform/EclipseInstallationLayout.java
@@ -36,7 +36,7 @@ import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
  * Finds bundles in Eclipse installation.
  * 
  * See https://wiki.eclipse.org/Equinox_p2_Getting_Started See
- * http://mea-bloga.blogspot.com/2008/04/new-target-platform-preference.html
+ * https://mea-bloga.blogspot.com/2008/04/new-target-platform-preference.html
  * 
  * @author igor
  * @deprecated only required for {@link LocalDependencyResolver}

--- a/tycho-extras/README.md
+++ b/tycho-extras/README.md
@@ -3,9 +3,9 @@ About Tycho Extras
 
 Additional tools for Tycho.
 
-  * [Project Homepage](http://www.eclipse.org/tycho/)
-  * [Documentation](http://eclipse.org/tycho/documentation.php)
-  * [Bug Tracker](https://bugs.eclipse.org/bugs/buglist.cgi?product=Tycho)
-  * [How to Contribute](https://wiki.eclipse.org/Tycho/Contributor_Guide)
+  * [Project Homepage](https://github.com/eclipse/tycho)
+  * [Documentation](https://www.eclipse.org/tycho/sitedocs/)
+  * [Bug Tracker](https://github.com/eclipse/tycho/issues)
+  * [How to Contribute](https://github.com/eclipse/tycho/blob/master/CONTRIBUTING.md)
   * [Contact Us](https://dev.eclipse.org/mailman/listinfo/tycho-user)
 

--- a/tycho-its/projects/resolver.split/org.eclipse.equinox.security/schema/loginModule.exsd
+++ b/tycho-its/projects/resolver.split/org.eclipse.equinox.security/schema/loginModule.exsd
@@ -51,7 +51,7 @@
       <annotation>
          <documentation>
             An entry defining a single LoginModule that can be used for authenticating users. See
-&lt;A HREF=&quot;http://java.sun.com/j2se/1.4.2/docs/api/javax/security/auth/spi/LoginModule.html&quot;&gt;javax.security.auth.spi.LoginModule&lt;/A&gt; for more information.
+&lt;A HREF=&quot;https://java.sun.com/j2se/1.4.2/docs/api/javax/security/auth/spi/LoginModule.html&quot;&gt;javax.security.auth.spi.LoginModule&lt;/A&gt; for more information.
          </documentation>
       </annotation>
       <complexType>

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackageFeatureMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackageFeatureMojo.java
@@ -53,7 +53,7 @@ public class PackageFeatureMojo extends AbstractTychoPackagingMojo {
     private static final String FEATURE_PROPERTIES = "feature.properties";
 
     /**
-     * The <a href="http://maven.apache.org/shared/maven-archiver/">maven archiver</a> to use. One
+     * The <a href="https://maven.apache.org/shared/maven-archiver/">maven archiver</a> to use. One
      * of the archiver properties is the <code>addMavenDescriptor</code> flag, which indicates
      * whether the generated archive will contain the pom.xml and pom.properties file. If no archive
      * configuration is specified, the default value is <code>false</code>. If the maven descriptor

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackagePluginMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/PackagePluginMojo.java
@@ -97,7 +97,7 @@ public class PackagePluginMojo extends AbstractTychoPackagingMojo {
     protected String finalName;
 
     /**
-     * The <a href="http://maven.apache.org/shared/maven-archiver/">maven archiver</a> to use. One
+     * The <a href="https://maven.apache.org/shared/maven-archiver/">maven archiver</a> to use. One
      * of the archiver properties is the <code>addMavenDescriptor</code> flag, which indicates
      * whether the generated archive will contain the pom.xml and pom.properties file. If no archive
      * configuration is specified, the default value is <code>true</code>. If the maven descriptor
@@ -123,7 +123,7 @@ public class PackagePluginMojo extends AbstractTychoPackagingMojo {
      * Whether to generate an
      * <a href="https://wiki.eclipse.org/PDE/UI/SourceReferences">Eclipse-SourceReferences</a>
      * MANIFEST header. When using this parameter, property ${tycho.scmUrl} must be set and be a
-     * valid <a href="http://maven.apache.org/scm/scm-url-format.html">maven SCM URL</a>.
+     * valid <a href="https://maven.apache.org/scm/scm-url-format.html">maven SCM URL</a>.
      * 
      * Example configuration:
      * 

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/ProductExportMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/ProductExportMojo.java
@@ -572,7 +572,7 @@ public class ProductExportMojo extends AbstractTychoPackagingMojo {
                 // the launcher is renamed to "eclipse", because
                 // this is the value of the CFBundleExecutable
                 // property within the Info.plist file.
-                // see http://jira.codehaus.org/browse/MNGECLIPSE-1087
+                // see https://jira.codehaus.org/browse/MNGECLIPSE-1087
                 newName = "eclipse";
             }
 
@@ -585,7 +585,7 @@ public class ProductExportMojo extends AbstractTychoPackagingMojo {
 
             // macosx: the *.app directory is renamed to the
             // product configuration launcher name
-            // see http://jira.codehaus.org/browse/MNGECLIPSE-1087
+            // see https://jira.codehaus.org/browse/MNGECLIPSE-1087
             if (PlatformPropertiesUtils.OS_MACOSX.equals(os)) {
                 newName = launcherName + ".app";
                 getLog().debug("Renaming Eclipse.app to " + newName);

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/sourceref/ScmUrl.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/sourceref/ScmUrl.java
@@ -18,7 +18,7 @@ import java.util.Properties;
 import org.apache.maven.plugin.MojoExecutionException;
 
 /**
- * Maven SCM URL as specified by {@linkplain http://maven.apache.org/scm/scm-url-format.html}
+ * Maven SCM URL as specified by {@linkplain https://maven.apache.org/scm/scm-url-format.html}
  */
 public class ScmUrl {
 
@@ -34,7 +34,7 @@ public class ScmUrl {
         }
         if (!url.startsWith("scm:")) {
             throw new MojoExecutionException("Invalid SCM URL: '" + url
-                    + "'. See http://maven.apache.org/scm/scm-url-format.html");
+                    + "'. See https://maven.apache.org/scm/scm-url-format.html");
         }
         int delimiterIndex = -1;
         int pipeIndex = url.indexOf('|', 4);
@@ -50,7 +50,7 @@ public class ScmUrl {
         }
         if (delimiterIndex == -1) {
             throw new MojoExecutionException("Invalid SCM URL: '" + url
-                    + "'. See http://maven.apache.org/scm/scm-url-format.html");
+                    + "'. See https://maven.apache.org/scm/scm-url-format.html");
         }
         this.type = url.substring(4, delimiterIndex);
     }

--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/sourceref/SourceReferencesProvider.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/sourceref/SourceReferencesProvider.java
@@ -24,7 +24,7 @@ import org.eclipse.osgi.util.ManifestElement;
  * 
  * [1] {@linkplain https://wiki.eclipse.org/PDE/UI/SourceReferences}
  * 
- * [2] {@linkplain http://maven.apache.org/scm/scm-url-format.html}
+ * [2] {@linkplain https://maven.apache.org/scm/scm-url-format.html}
  */
 public interface SourceReferencesProvider {
 

--- a/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/AbstractSourceJarMojo.java
+++ b/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/AbstractSourceJarMojo.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -108,7 +108,7 @@ public abstract class AbstractSourceJarMojo extends AbstractMojo {
 
     /**
      * The archive configuration to use. See
-     * <a href="http://maven.apache.org/shared/maven-archiver/index.html">Maven Archiver
+     * <a href="https://maven.apache.org/shared/maven-archiver/index.html">Maven Archiver
      * Reference</a>.
      *
      * @since 2.1

--- a/tycho-surefire/org.eclipse.tycho.surefire.junit/src/main/resources/about_files/NOTICE
+++ b/tycho-surefire/org.eclipse.tycho.surefire.junit/src/main/resources/about_files/NOTICE
@@ -3,6 +3,6 @@ SureFire JUnit Runner
 Copyright 2004-2015 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 
 

--- a/tycho-surefire/org.eclipse.tycho.surefire.junit4/src/main/resources/about_files/NOTICE
+++ b/tycho-surefire/org.eclipse.tycho.surefire.junit4/src/main/resources/about_files/NOTICE
@@ -3,6 +3,6 @@ SureFire JUnit4 Runner
 Copyright 2004-2015 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 
 

--- a/tycho-surefire/org.eclipse.tycho.surefire.junit47/src/main/resources/about_files/NOTICE
+++ b/tycho-surefire/org.eclipse.tycho.surefire.junit47/src/main/resources/about_files/NOTICE
@@ -2,6 +2,6 @@ SureFire JUnitCore Runner
 Copyright 2004-2011 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 
 

--- a/tycho-surefire/org.eclipse.tycho.surefire.junit5/src/main/resources/about_files/NOTICE
+++ b/tycho-surefire/org.eclipse.tycho.surefire.junit5/src/main/resources/about_files/NOTICE
@@ -3,6 +3,6 @@ Shared Java 5 Provider Base
 Copyright 2004-2015 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 
 

--- a/tycho-surefire/org.eclipse.tycho.surefire.junit54/src/main/resources/about_files/NOTICE
+++ b/tycho-surefire/org.eclipse.tycho.surefire.junit54/src/main/resources/about_files/NOTICE
@@ -3,6 +3,6 @@ Shared Java 5 Provider Base
 Copyright 2004-2015 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 
 

--- a/tycho-surefire/org.eclipse.tycho.surefire.junit55/src/main/resources/about_files/NOTICE
+++ b/tycho-surefire/org.eclipse.tycho.surefire.junit55/src/main/resources/about_files/NOTICE
@@ -3,6 +3,6 @@ Shared Java 5 Provider Base
 Copyright 2004-2015 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 
 

--- a/tycho-surefire/org.eclipse.tycho.surefire.junit56/src/main/resources/about_files/NOTICE
+++ b/tycho-surefire/org.eclipse.tycho.surefire.junit56/src/main/resources/about_files/NOTICE
@@ -3,6 +3,6 @@ Shared Java 5 Provider Base
 Copyright 2004-2015 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 
 

--- a/tycho-surefire/org.eclipse.tycho.surefire.junit57/src/main/resources/about_files/NOTICE
+++ b/tycho-surefire/org.eclipse.tycho.surefire.junit57/src/main/resources/about_files/NOTICE
@@ -3,6 +3,6 @@ Shared Java 5 Provider Base
 Copyright 2004-2015 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 
 

--- a/tycho-surefire/org.eclipse.tycho.surefire.junit57withvintage/src/main/resources/about_files/NOTICE
+++ b/tycho-surefire/org.eclipse.tycho.surefire.junit57withvintage/src/main/resources/about_files/NOTICE
@@ -3,6 +3,6 @@ Shared Java 5 Provider Base
 Copyright 2004-2015 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 
 

--- a/tycho-surefire/org.eclipse.tycho.surefire.junit58/src/main/resources/about.html
+++ b/tycho-surefire/org.eclipse.tycho.surefire.junit58/src/main/resources/about.html
@@ -22,7 +22,7 @@ being redistributed by another party (&quot;Redistributor&quot;) and different t
 apply to your use of any object code in the Content.  Check the Redistributor's license that was 
 provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
 indicated below, the terms and conditions of the EPL still apply to any source code in the Content
-and such source code may be obtained at <a href="http://www.eclipse.org">http://www.eclipse.org</a>.</p>
+and such source code may be obtained at <a href="https://www.eclipse.org">https://www.eclipse.org</a>.</p>
 		
 <h3>Third Party Content</h3>
 <p>The Content includes items that have been sourced from third parties as set out below. If you 
@@ -34,7 +34,7 @@ terms and conditions of use.</p>
 <p>The plug-in includes Surefire Shared Java 5 Provider Base ${surefire-version} developed by the Apache Software Foundation.  Therefore:</p>
 
 <blockquote>
-This product includes software developed by the Apache Software Foundation (<a href="http://www.apache.org/">http://www.apache.org/</a>).
+This product includes software developed by the Apache Software Foundation (<a href="https://www.apache.org/">https://www.apache.org/</a>).
 </blockquote>
 
 <p>Surefire Shared Java 5 Provider Base is:</p>
@@ -42,28 +42,28 @@ This product includes software developed by the Apache Software Foundation (<a h
 <blockquote>Copyright 2004-2015 The Apache Software Foundation.</blockquote>
 
 <p>Your use of the Surefire Shared Java 5 Provider Base code is subject to the terms and conditions of the Apache Software License 2.0.  A copy of the license is contained
-in the file <a href="about_files/LICENSE">LICENSE</a> and is also available at <a href="http://www.apache.org/licenses/LICENSE-2.0.html">http://www.apache.org/licenses/LICENSE-2.0.html</a>.
+in the file <a href="about_files/LICENSE">LICENSE</a> and is also available at <a href="https://www.apache.org/licenses/LICENSE-2.0.html">https://www.apache.org/licenses/LICENSE-2.0.html</a>.
 
 <p>The Apache attribution <a href="about_files/NOTICE">NOTICE</a> file is included with the Content in accordance with 4d of the Apache License, Version 2.0.</p>
 
-<p>Examples and documentation as well as updated source code for Surefire Shared Java 5 Provider Base is available at <a href="http://maven.apache.org/surefire/">http://maven.apache.org/surefire/</a>.</p>
+<p>Examples and documentation as well as updated source code for Surefire Shared Java 5 Provider Base is available at <a href="https://maven.apache.org/surefire/">https://maven.apache.org/surefire/</a>.</p>
 
 <h4>opentest4j</h4>
 <p>The plug-in includes opentest4j 1.0.0.
 <p>Your use of the opentest4j code is subject to the terms and conditions of the Apache Software License 2.0.  A copy of the license is contained
-in the file <a href="about_files/LICENSE">LICENSE</a> and is also available at <a href="http://www.apache.org/licenses/LICENSE-2.0.html">http://www.apache.org/licenses/LICENSE-2.0.html</a>.
+in the file <a href="about_files/LICENSE">LICENSE</a> and is also available at <a href="https://www.apache.org/licenses/LICENSE-2.0.html">https://www.apache.org/licenses/LICENSE-2.0.html</a>.
 <p>Examples and documentation as well as updated source code for opentest4j is available at <a href="https://github.com/ota4j-team/opentest4j/">https://github.com/ota4j-team/opentest4j/</a>.</p>
 
 <h4>API Guardian</h4>
 <p>The plug-in includes API Guardian 1.0.0.
 <p>Your use of the API Guardian code is subject to the terms and conditions of the Apache Software License 2.0.  A copy of the license is contained
-in the file <a href="about_files/LICENSE">LICENSE</a> and is also available at <a href="http://www.apache.org/licenses/LICENSE-2.0.html">http://www.apache.org/licenses/LICENSE-2.0.html</a>.
+in the file <a href="about_files/LICENSE">LICENSE</a> and is also available at <a href="https://www.apache.org/licenses/LICENSE-2.0.html">https://www.apache.org/licenses/LICENSE-2.0.html</a>.
 <p>Examples and documentation as well as updated source code for opentest4j is available at <a href="https://github.com/apiguardian-team/apiguardian/">https://github.com/apiguardian-team/apiguardian/</a>.</p>
 
 <h4>junit-platform-surefire-provider</h4>
 <p>The plug-in includes junit-platform-surefire-provider ${junit-platform-version}.
 <p>Your use of the junit-platform-surefire-provider code is subject to the terms and conditions of the Apache Software License 2.0.  A copy of the license is contained
-in the file <a href="about_files/LICENSE">LICENSE</a> and is also available at <a href="http://www.apache.org/licenses/LICENSE-2.0.html">http://www.apache.org/licenses/LICENSE-2.0.html</a>.
+in the file <a href="about_files/LICENSE">LICENSE</a> and is also available at <a href="https://www.apache.org/licenses/LICENSE-2.0.html">https://www.apache.org/licenses/LICENSE-2.0.html</a>.
 <p>Examples and documentation as well as updated source code for junit-platform-surefire-provider is available at <a href="https://github.com/junit-team/junit5/">https://github.com/junit-team/junit5/</a>.</p>
 
 <h4>junit-jupiter-engine, junit-vintage-engine, junit-platform-commons, junit-platform-engine, junit-platform-launcher</h4>

--- a/tycho-surefire/org.eclipse.tycho.surefire.junit58/src/main/resources/about_files/NOTICE
+++ b/tycho-surefire/org.eclipse.tycho.surefire.junit58/src/main/resources/about_files/NOTICE
@@ -3,6 +3,6 @@ Shared Java 5 Provider Base
 Copyright 2004-2015 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 
 

--- a/tycho-surefire/org.eclipse.tycho.surefire.junit58withvintage/src/main/resources/about_files/NOTICE
+++ b/tycho-surefire/org.eclipse.tycho.surefire.junit58withvintage/src/main/resources/about_files/NOTICE
@@ -3,6 +3,6 @@ Shared Java 5 Provider Base
 Copyright 2004-2015 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 
 

--- a/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/src/main/resources/about.html
+++ b/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/src/main/resources/about.html
@@ -22,7 +22,7 @@ being redistributed by another party (&quot;Redistributor&quot;) and different t
 apply to your use of any object code in the Content.  Check the Redistributor's license that was 
 provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
 indicated below, the terms and conditions of the EPL still apply to any source code in the Content
-and such source code may be obtained at <a href="http://www.eclipse.org">http://www.eclipse.org</a>.</p>
+and such source code may be obtained at <a href="https://www.eclipse.org">https://www.eclipse.org</a>.</p>
 		
 <h3>Third Party Content</h3>
 <p>The Content includes items that have been sourced from third parties as set out below. If you 
@@ -34,7 +34,7 @@ terms and conditions of use.</p>
 <p>The plug-in includes Maven Surefire Common, SureFire Booter, SureFire API ${surefire-version} developed by the Apache Software Foundation.  Therefore:</p>
 
 <blockquote>
-This product includes software developed by the Apache Software Foundation (<a href="http://www.apache.org/">http://www.apache.org/</a>).
+This product includes software developed by the Apache Software Foundation (<a href="https://www.apache.org/">https://www.apache.org/</a>).
 </blockquote>
 
 <p>Maven Surefire Common, SureFire Booter, SureFire API are:</p>
@@ -42,11 +42,11 @@ This product includes software developed by the Apache Software Foundation (<a h
 <blockquote>Copyright 2004-2015 The Apache Software Foundation.</blockquote>
 
 <p>Your use of the Maven Surefire Common, SureFire Booter, SureFire API code is subject to the terms and conditions of the Apache Software License 2.0.  A copy of the license is contained
-in the file <a href="about_files/LICENSE">LICENSE</a> and is also available at <a href="http://www.apache.org/licenses/LICENSE-2.0.html">http://www.apache.org/licenses/LICENSE-2.0.html</a>.
+in the file <a href="about_files/LICENSE">LICENSE</a> and is also available at <a href="https://www.apache.org/licenses/LICENSE-2.0.html">https://www.apache.org/licenses/LICENSE-2.0.html</a>.
 
 <p>The Apache attribution <a href="about_files/NOTICE">NOTICE</a> file is included with the Content in accordance with 4d of the Apache License, Version 2.0.</p>
 
-<p>Examples and documentation as well as updated source code for Maven Surefire Common, SureFire Booter, SureFire API is available at <a href="http://maven.apache.org/surefire/">http://maven.apache.org/surefire/</a>.</p>
+<p>Examples and documentation as well as updated source code for Maven Surefire Common, SureFire Booter, SureFire API is available at <a href="https://maven.apache.org/surefire/">https://maven.apache.org/surefire/</a>.</p>
 
 </body>
 </html>

--- a/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/src/main/resources/about_files/NOTICE
+++ b/tycho-surefire/org.eclipse.tycho.surefire.osgibooter/src/main/resources/about_files/NOTICE
@@ -8,7 +8,7 @@ SureFire API
 Copyright 2004-2015 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 
 This product includes software developed by the Spring Framework
-Project (http://www.springframework.org).
+Project (https://www.springframework.org).

--- a/tycho-surefire/org.eclipse.tycho.surefire.testng/src/main/resources/about.html
+++ b/tycho-surefire/org.eclipse.tycho.surefire.testng/src/main/resources/about.html
@@ -22,7 +22,7 @@ being redistributed by another party (&quot;Redistributor&quot;) and different t
 apply to your use of any object code in the Content.  Check the Redistributor's license that was 
 provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
 indicated below, the terms and conditions of the EPL still apply to any source code in the Content
-and such source code may be obtained at <a href="http://www.eclipse.org">http://www.eclipse.org</a>.</p>
+and such source code may be obtained at <a href="https://www.eclipse.org">https://www.eclipse.org</a>.</p>
 		
 <h3>Third Party Content</h3>
 <p>The Content includes items that have been sourced from third parties as set out below. If you 
@@ -34,7 +34,7 @@ terms and conditions of use.</p>
 <p>The plug-in includes SureFire TestNG ${surefire-version}, SureFire TestNG Utils ${surefire-version} and Common Java5 ${surefire-version} developed by the Apache Software Foundation.  Therefore:</p>
 
 <blockquote>
-This product includes software developed by the Apache Software Foundation (<a href="http://www.apache.org/">http://www.apache.org/</a>).
+This product includes software developed by the Apache Software Foundation (<a href="https://www.apache.org/">https://www.apache.org/</a>).
 </blockquote>
 
 <p>SureFire TestNG is:</p>
@@ -42,11 +42,11 @@ This product includes software developed by the Apache Software Foundation (<a h
 <blockquote>Copyright (c) 2004-2011 The Apache Software Foundation. All rights reserved.</blockquote>
 
 <p>Your use of the SureFire TestNG, SureFire TestNG Utils and Common Java5 code is subject to the terms and conditions of the Apache Software License 2.0.  A copy of the license is contained
-in the file <a href="about_files/LICENSE">LICENSE</a> and is also available at <a href="http://www.apache.org/licenses/LICENSE-2.0.html">http://www.apache.org/licenses/LICENSE-2.0.html</a>.
+in the file <a href="about_files/LICENSE">LICENSE</a> and is also available at <a href="https://www.apache.org/licenses/LICENSE-2.0.html">https://www.apache.org/licenses/LICENSE-2.0.html</a>.
 
 <p>The Apache attribution <a href="about_files/NOTICE">NOTICE</a> file is included with the Content in accordance with 4d of the Apache License, Version 2.0.</p>
 
-<p>Examples and documentation as well as updated source code for SureFire JUnitCore Runner is available at <a href="http://maven.apache.org/surefire/">http://maven.apache.org/surefire/</a>.</p>
+<p>Examples and documentation as well as updated source code for SureFire JUnitCore Runner is available at <a href="https://maven.apache.org/surefire/">https://maven.apache.org/surefire/</a>.</p>
 
 </body>
 </html>

--- a/tycho-surefire/org.eclipse.tycho.surefire.testng/src/main/resources/about_files/NOTICE
+++ b/tycho-surefire/org.eclipse.tycho.surefire.testng/src/main/resources/about_files/NOTICE
@@ -2,6 +2,6 @@ SureFire TestNG Runner
 Copyright 2004-2011 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 
 

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/AbstractTestMojo.java
@@ -637,11 +637,11 @@ public abstract class AbstractTestMojo extends AbstractMojo {
      * <p/>
      * <ul>
      * <li>SYSTEM: Use the currently running JVM (or from
-     * <a href="http://maven.apache.org/guides/mini/guide-using-toolchains.html">toolchain</a> if
+     * <a href="https://maven.apache.org/guides/mini/guide-using-toolchains.html">toolchain</a> if
      * configured in pom.xml)</li>
      * <li>BREE: use MANIFEST header <code>Bundle-RequiredExecutionEnvironment</code> to lookup the
      * JDK from
-     * <a href="http://maven.apache.org/guides/mini/guide-using-toolchains.html">toolchains.xml</a>.
+     * <a href="https://maven.apache.org/guides/mini/guide-using-toolchains.html">toolchains.xml</a>.
      * The value of BREE will be matched against the id of the toolchain elements in
      * toolchains.xml.</li>
      * </ul>
@@ -1168,7 +1168,7 @@ public abstract class AbstractTestMojo extends AbstractMojo {
         Toolchain toolChain = toolchainProvider.findMatchingJavaToolChain(session, profileName);
         if (toolChain == null) {
             throw new MojoExecutionException("useJDK = BREE configured, but no toolchain of type 'jdk' with id '"
-                    + profileName + "' found. See http://maven.apache.org/guides/mini/guide-using-toolchains.html");
+                    + profileName + "' found. See https://maven.apache.org/guides/mini/guide-using-toolchains.html");
         }
         return toolChain;
     }

--- a/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/spi/TestFrameworkProvider.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/java/org/eclipse/tycho/surefire/provider/spi/TestFrameworkProvider.java
@@ -41,7 +41,7 @@ public interface TestFrameworkProvider {
 
     /**
      * Fully qualified class name of the surefire provider (must implement contract
-     * http://maven.apache.org/plugins/maven-surefire-plugin/api.html ).
+     * https://maven.apache.org/plugins/maven-surefire-plugin/api.html ).
      */
     public String getSurefireProviderClassName();
 

--- a/tycho-surefire/tycho-surefire-plugin/src/test/resources/org.junit4_4.7.0.v20100104/about.html
+++ b/tycho-surefire/tycho-surefire-plugin/src/test/resources/org.junit4_4.7.0.v20100104/about.html
@@ -22,7 +22,7 @@ being redistributed by another party (&quot;Redistributor&quot;) and different t
 apply to your use of any object code in the Content.  Check the Redistributor's license that was 
 provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
 indicated below, the terms and conditions of the EPL still apply to any source code in the Content
-and such source code may be obtained at <a href="http://www.eclipse.org">http://www.eclipse.org</a>.</p>
+and such source code may be obtained at <a href="https://www.eclipse.org">https://www.eclipse.org</a>.</p>
 
 </body>
 </html>

--- a/tycho-surefire/tycho-surefire-plugin/src/test/resources/org.junit_3.8.2.v20090203-1005/about.html
+++ b/tycho-surefire/tycho-surefire-plugin/src/test/resources/org.junit_3.8.2.v20090203-1005/about.html
@@ -22,7 +22,7 @@ being redistributed by another party (&quot;Redistributor&quot;) and different t
 apply to your use of any object code in the Content.  Check the Redistributor's license that was 
 provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
 indicated below, the terms and conditions of the EPL still apply to any source code in the Content
-and such source code may be obtained at <a href="http://www.eclipse.org">http://www.eclipse.org</a>.</p>
+and such source code may be obtained at <a href="https://www.eclipse.org">https://www.eclipse.org</a>.</p>
 
 <h3>Third Party Content</h3>
 
@@ -40,7 +40,7 @@ Your use of JUnit 3.8.2 in both source and binary code form contained in the plu
 Common Public License Version 1.0 (&quot;CPL&quot;).  A copy of the CPL is available at <a href="https://www.eclipse.org/legal/cpl-v10.html">https://www.eclipse.org/legal/cpl-v10.html</a>.
 (a local copy can be found <a href="about_files/cpl-v10.html">here</a>)</p>
 
-<p>The original binaries and source are available at the <a href="http://junit.org">JUnit web site</a>.
+<p>The original binaries and source are available at the <a href="https://junit.org">JUnit web site</a>.
 
 </body>
 </html>

--- a/tycho-surefire/tycho-surefire-plugin/src/test/resources/org.junit_4.8.1.v4_8_1_v20100114-1600/about.html
+++ b/tycho-surefire/tycho-surefire-plugin/src/test/resources/org.junit_4.8.1.v4_8_1_v20100114-1600/about.html
@@ -22,7 +22,7 @@ being redistributed by another party (&quot;Redistributor&quot;) and different t
 apply to your use of any object code in the Content.  Check the Redistributor's license that was 
 provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
 indicated below, the terms and conditions of the EPL still apply to any source code in the Content
-and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+and such source code may be obtained at <a href="https://www.eclipse.org/">https://www.eclipse.org</a>.</p>
 
 
 <h3>Third Party Content</h3>
@@ -36,19 +36,19 @@ terms and conditions of use.</p>
 
 <h4>JUnit 4.8.1</h4>
 
-<p>The plug-in is accompanied by software developed by <a href="http://www.junit.org/">JUnit.org</a>.  The JUnit 4.8.1 code included with the plug-in includes no modifications.
+<p>The plug-in is accompanied by software developed by <a href="https://www.junit.org/">JUnit.org</a>.  The JUnit 4.8.1 code included with the plug-in includes no modifications.
 Your use of JUnit 4.8.1 in both source and binary code form contained in the plug-in is subject to the terms and conditions of the 
 Common Public License Version 1.0 (&quot;CPL&quot;).  A copy of the CPL is available at <a href="https://www.eclipse.org/legal/cpl-v10.html">https://www.eclipse.org/legal/cpl-v10.html</a>.
 The binary code is located in junit.jar and the source code is located in source-bundle or in the org.junit.source bundle.
-<br/>The original source and binaries are available from <a href="http://sourceforge.net/projects/junit/files/">http://sourceforge.net/projects/junit/files/</a>, namely:
-<br/><a href="http://sourceforge.net/projects/junit/files/junit/4.8.1/junit-4.8.1-src.jar/download">http://sourceforge.net/projects/junit/files/junit/4.8.1/junit-4.8.1-src.jar/download</a>
-<br/><a href="http://sourceforge.net/projects/junit/files/junit/4.8.1/junit-dep-4.8.1.jar/download">http://sourceforge.net/projects/junit/files/junit/4.8.1/junit-dep-4.8.1.jar/download</a>
+<br/>The original source and binaries are available from <a href="https://sourceforge.net/projects/junit/files/">https://sourceforge.net/projects/junit/files/</a>, namely:
+<br/><a href="https://sourceforge.net/projects/junit/files/junit/4.8.1/junit-4.8.1-src.jar/download">https://sourceforge.net/projects/junit/files/junit/4.8.1/junit-4.8.1-src.jar/download</a>
+<br/><a href="https://sourceforge.net/projects/junit/files/junit/4.8.1/junit-dep-4.8.1.jar/download">https://sourceforge.net/projects/junit/files/junit/4.8.1/junit-dep-4.8.1.jar/download</a>
 </p>
 
 
 <h4>Hamcrest Library 1.1</h4>
 
-<p>The plug-in is accompanied by software developed by Hamcrest (<a href="http://code.google.com/p/hamcrest/">http://code.google.com/p/hamcrest/</a>).
+<p>The plug-in is accompanied by software developed by Hamcrest (<a href="https://code.google.com/p/hamcrest/">https://code.google.com/p/hamcrest/</a>).
 The hamcrest-library 1.1 code included within the JUnit 4.8.1 Jar includes no modifications.
 Your use of hamcrest-library 1.1 in both source and binary code form contained in the plug-in is subject to the terms and conditions of the 
 New BSD License.

--- a/tycho-testing-harness/src/main/java/org/eclipse/tycho/testing/AbstractTychoMojoTestCase.java
+++ b/tycho-testing-harness/src/main/java/org/eclipse/tycho/testing/AbstractTychoMojoTestCase.java
@@ -173,7 +173,7 @@ public class AbstractTychoMojoTestCase extends AbstractMojoTestCase {
     /**
      * Returns a mojo configured with the mojo's default configuration.
      */
-    // workaround for MPLUGINTESTING-46 - see http://jira.codehaus.org/browse/MPLUGINTESTING-46
+    // workaround for MPLUGINTESTING-46 - see https://jira.codehaus.org/browse/MPLUGINTESTING-46
     protected Mojo lookupMojoWithDefaultConfiguration(MavenProject project, MavenSession session, String goal)
             throws Exception {
         Mojo mojo = lookupEmptyMojo(goal, project.getFile());


### PR DESCRIPTION
Using https for links within code comments and links to license
informations.