### PR TITLE
Support Eclipse features via m2 repositories

### DIFF
--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/resolver/MavenTargetDefinitionContent.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/resolver/MavenTargetDefinitionContent.java
@@ -40,6 +40,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 
 import org.apache.commons.io.FilenameUtils;
+import org.eclipse.equinox.internal.p2.publisher.eclipse.FeatureParser;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.metadata.IArtifactKey;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
@@ -162,6 +163,14 @@ public class MavenTargetDefinitionContent implements TargetDefinitionContent {
                         continue;
                     }
                     logger.debug("Resolved " + mavenArtifact + "...");
+
+                    Feature feature = new FeatureParser().parse(mavenArtifact.getLocation());
+                    if (feature != null) {
+                        feature.setLocation(mavenArtifact.getLocation().getAbsolutePath());
+                        features.add(feature);
+                        continue;
+                    }
+
                     String symbolicName;
                     String bundleVersion;
                     try {

--- a/tycho-its/projects/target.maven.eclipse-feature/feature/build.properties
+++ b/tycho-its/projects/target.maven.eclipse-feature/feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/tycho-its/projects/target.maven.eclipse-feature/feature/feature.xml
+++ b/tycho-its/projects/target.maven.eclipse-feature/feature/feature.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="feature"
+      label="Feature"
+      version="0.0.1.qualifier">
+
+   <description url="http://www.example.com/description">
+      [Enter Feature Description here.]
+   </description>
+
+   <copyright url="http://www.example.com/copyright">
+      [Enter Copyright Description here.]
+   </copyright>
+
+   <license url="http://www.example.com/license">
+      [Enter License Description here.]
+   </license>
+
+   <includes
+         id="org.eclipse.jgit"
+         version="0.0.0"/>
+
+</feature>

--- a/tycho-its/projects/target.maven.eclipse-feature/feature/pom.xml
+++ b/tycho-its/projects/target.maven.eclipse-feature/feature/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>tycho-its-project</groupId>
+    <artifactId>target.maven.eclipse-feature</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>feature</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>eclipse-feature</packaging>
+</project>

--- a/tycho-its/projects/target.maven.eclipse-feature/pom.xml
+++ b/tycho-its/projects/target.maven.eclipse-feature/pom.xml
@@ -1,0 +1,42 @@
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>tycho-its-project</groupId>
+	<artifactId>target.maven.eclipse-feature</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	
+	<modules>
+		<module>target-platform</module>
+		<module>feature</module>
+	</modules>
+	
+	<properties>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
+	</properties>
+	
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<target>
+						<artifact> 
+							<groupId>tycho-its-project</groupId> 
+							<artifactId>target-platform</artifactId> 
+							<version>0.0.1-SNAPSHOT</version>
+						</artifact> 
+					</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/projects/target.maven.eclipse-feature/target-platform/pom.xml
+++ b/tycho-its/projects/target.maven.eclipse-feature/target-platform/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>tycho-its-project</groupId>
+    <artifactId>target.maven.eclipse-feature</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>target-platform</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>eclipse-target-definition</packaging>
+</project>

--- a/tycho-its/projects/target.maven.eclipse-feature/target-platform/target-platform.target
+++ b/tycho-its/projects/target.maven.eclipse-feature/target-platform/target-platform.target
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="tp">
+	<locations>
+		<location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
+			<dependencies>
+				<dependency>
+					<groupId>org.eclipse.jgit.feature</groupId>
+					<artifactId>org.eclipse.jgit</artifactId>
+					<version>6.1.0.202203080745-r</version>
+					<type>jar</type>
+				</dependency>
+			</dependencies>
+			<repositories>
+				<repository>
+					<id>jgit</id>
+					<url>https://repo.eclipse.org/content/groups/jgit/</url>
+				</repository>
+			</repositories>
+		</location>
+	</locations>
+</target>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetPlatformLocationsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/target/TargetPlatformLocationsTest.java
@@ -122,4 +122,10 @@ public class TargetPlatformLocationsTest extends AbstractTychoIntegrationTest {
 		verifier.verifyErrorFreeLog();
 	}
 
+	@Test
+	public void testMavenLocationEclipseFeature() throws Exception {
+		Verifier verifier = getVerifier("target.maven.eclipse-feature", false, true);
+		verifier.executeGoal("verify");
+		verifier.verifyErrorFreeLog();
+	}
 }


### PR DESCRIPTION
Currently all Maven artifacts are treated as OSGi bundles.

If one wants to assemble a product or build features including other features, those have to either be part of the same reactor build or be contributed via a p2 repository.

This commit checks whether an artifact contains a 'feature.xml'. If so, it is treated as a feature, otherwise as a bundle.