### PR TITLE
Fix #885 - 'includePackedArtifacts' must be automatically disabled when running with an incompatible vm

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@ This page describes the noteworthy improvements provided by each release of Ecli
 ## 2.7.2
 Fixes:
 - [2.7.1][regression] Neither raw version nor format was specified #876 
+- [2.7.1] 'includePackedArtifacts' must be automatically disabled when running with an incompatible vm #885 
 
 ## 2.7.1
 

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReader.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTargetPlatformConfigurationReader.java
@@ -9,6 +9,7 @@
  *    Sonatype Inc. - initial API and implementation
  *    Christoph Läubrich -  [Bug 461284] - Improve discovery and attach of .target files in eclipse-target-definition
  *                          [Bug 567098] - pomDependencies=consider should wrap non-osgi jars
+ *                          [Issue #885] - 'includePackedArtifacts' must be automatically disabled when running with an incompatible vm
  *******************************************************************************/
 package org.eclipse.tycho.core.resolver;
 
@@ -167,7 +168,12 @@ public class DefaultTargetPlatformConfigurationReader {
         if (value == null) {
             return;
         }
-        result.setIncludePackedArtifacts(Boolean.parseBoolean(value));
+        boolean include = Boolean.parseBoolean(value);
+        if (include && Runtime.version().feature() >= 14) {
+            logger.warn("Pack200 is not supported when running on Java 14 and higher");
+            return;
+        }
+        result.setIncludePackedArtifacts(include);
     }
 
     private void setTargetDefinitionIncludeSources(TargetPlatformConfiguration result, Xpp3Dom configuration)


### PR DESCRIPTION
This ignores the setting and emits a warning when running on JDK >= 14.