### PR TITLE
Replace Hamcrest usage with plain JUnit

### DIFF
--- a/sisu-equinox/sisu-equinox-launching/pom.xml
+++ b/sisu-equinox/sisu-equinox-launching/pom.xml
@@ -53,12 +53,6 @@
 			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest</artifactId>
-			<version>2.2</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/sisu-equinox/sisu-equinox-launching/src/test/java/org/eclipse/sisu/equinox/launching/internal/DefaultEquinoxInstallationFactoryTest.java
+++ b/sisu-equinox/sisu-equinox-launching/src/test/java/org/eclipse/sisu/equinox/launching/internal/DefaultEquinoxInstallationFactoryTest.java
@@ -12,8 +12,7 @@
  ******************************************************************************/
 package org.eclipse.sisu.equinox.launching.internal;
 
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -60,7 +59,7 @@ public class DefaultEquinoxInstallationFactoryTest {
 
         List<String> config = splitAtComma(
                 subject.toOsgiBundles(bundles, instDesc.getBundleStartLevel(), defaultLevel));
-        assertThat(config, hasItem("reference:file:absolute/path/to/bundle1@6"));
+        assertTrue(config.contains("reference:file:absolute/path/to/bundle1@6"));
     }
 
     @Test
@@ -69,14 +68,14 @@ public class DefaultEquinoxInstallationFactoryTest {
 
         List<String> config = splitAtComma(
                 subject.toOsgiBundles(bundles, instDesc.getBundleStartLevel(), defaultLevel));
-        assertThat(config, hasItem("reference:file:absolute/path/to/bundle1@6:start"));
+        assertTrue(config.contains("reference:file:absolute/path/to/bundle1@6:start"));
     }
 
     @Test
     public void testDefaultStartLevelIsNotSet() throws Exception {
         List<String> config = splitAtComma(
                 subject.toOsgiBundles(bundles, instDesc.getBundleStartLevel(), defaultLevel));
-        assertThat(config, hasItem("reference:file:absolute/path/to/bundle2")); // don't need @n here because this would be redundant
+        assertTrue(config.contains("reference:file:absolute/path/to/bundle2")); // don't need @n here because this would be redundant
     }
 
     @Test
@@ -85,7 +84,7 @@ public class DefaultEquinoxInstallationFactoryTest {
 
         List<String> config = splitAtComma(
                 subject.toOsgiBundles(bundles, instDesc.getBundleStartLevel(), defaultLevel));
-        assertThat(config, hasItem("reference:file:absolute/path/to/bundle2@start"));
+        assertTrue(config.contains("reference:file:absolute/path/to/bundle2@start"));
     }
 
     @Test
@@ -94,7 +93,7 @@ public class DefaultEquinoxInstallationFactoryTest {
 
         List<String> config = splitAtComma(
                 subject.toOsgiBundles(bundles, instDesc.getBundleStartLevel(), defaultLevel));
-        assertThat(config, hasItem("reference:file:absolute/path/to/bundle1@start")); // implicitly use default start level
+        assertTrue(config.contains("reference:file:absolute/path/to/bundle1@start")); // implicitly use default start level
     }
 
     private static File mockFile(String absolutePath) {

--- a/sisu-equinox/sisu-equinox-launching/src/test/java/org/eclipse/sisu/equinox/launching/internal/EquinoxLaunchConfigurationTest.java
+++ b/sisu-equinox/sisu-equinox-launching/src/test/java/org/eclipse/sisu/equinox/launching/internal/EquinoxLaunchConfigurationTest.java
@@ -12,18 +12,17 @@
  ******************************************************************************/
 package org.eclipse.sisu.equinox.launching.internal;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
-public class EquinoxLaunchConfigurationTest {
+class EquinoxLaunchConfigurationTest {
 
     @Test
-    public void testAddEnvironmentVariables() {
+    void testAddEnvironmentVariables() {
         EquinoxLaunchConfiguration config = new EquinoxLaunchConfiguration(null);
         Map<String, String> envVariables = new HashMap<>();
         envVariables.put("key1", "value1");
@@ -31,9 +30,9 @@ public class EquinoxLaunchConfigurationTest {
         config.addEnvironmentVariables(envVariables);
 
         Map<String, String> environment = config.getEnvironment();
-        assertThat(environment.size(), equalTo(2));
-        assertThat(environment.get("key1"), equalTo("value1"));
-        assertThat(environment.get("key2"), equalTo(""));
+        assertEquals(2, environment.size());
+        assertEquals("value1", environment.get("key1"));
+        assertEquals("", environment.get("key2"));
     }
 
 }

--- a/tycho-bundles/org.eclipse.tycho.core.shared.tests/META-INF/MANIFEST.MF
+++ b/tycho-bundles/org.eclipse.tycho.core.shared.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,6 @@ Bundle-SymbolicName: org.eclipse.tycho.core.shared.tests
 Bundle-Version: 3.0.0.qualifier
 Fragment-Host: org.eclipse.tycho.core.shared
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.junit;bundle-version="4.8.2",
- org.hamcrest.core
+Require-Bundle: org.junit;bundle-version="4.8.2"
 Bundle-Vendor: %providerName
 Automatic-Module-Name: org.eclipse.tycho.core.shared.tests

--- a/tycho-bundles/org.eclipse.tycho.core.shared.tests/src/test/java/org/eclipse/tycho/core/shared/TargetEnvironmentTest.java
+++ b/tycho-bundles/org.eclipse.tycho.core.shared.tests/src/test/java/org/eclipse/tycho/core/shared/TargetEnvironmentTest.java
@@ -12,10 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.core.shared;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 import java.util.Map;
 
@@ -58,19 +56,19 @@ public class TargetEnvironmentTest {
 
     @Test
     public void testToFilterExpression() throws Exception {
-        assertThat(subject.toFilterExpression(), is("(& (osgi.os=macosx) (osgi.ws=cocoa) (osgi.arch=ppc) )"));
+        assertEquals("(& (osgi.os=macosx) (osgi.ws=cocoa) (osgi.arch=ppc) )", subject.toFilterExpression());
     }
 
     @Test
     public void testToFilterExpressionWithUnsetAttribute() throws Exception {
         subject = new TargetEnvironment(OS, null, ARCH);
-        assertThat(subject.toFilterExpression(), is("(& (osgi.os=macosx) (osgi.arch=ppc) )"));
+        assertEquals("(& (osgi.os=macosx) (osgi.arch=ppc) )", subject.toFilterExpression());
     }
 
     @Test
     public void testToFilterExpressionWithOnlyOneAttribute() throws Exception {
         subject = new TargetEnvironment(OS, null, null);
-        assertThat(subject.toFilterExpression(), is("(osgi.os=macosx)"));
+        assertEquals("(osgi.os=macosx)", subject.toFilterExpression());
     }
 
     @Test
@@ -88,9 +86,9 @@ public class TargetEnvironmentTest {
     }
 
     private static void asserNotEqual(TargetEnvironment left, TargetEnvironment right) {
-        assertThat(left, not(right));
+        assertNotEquals(left, right);
 
         // should also not lead to hash code collisions
-        assertThat(left.hashCode(), not(right.hashCode()));
+        assertNotEquals(left.hashCode(), right.hashCode());
     }
 }

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/local/LocalArtifactRepositoryP2APITest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/local/LocalArtifactRepositoryP2APITest.java
@@ -20,10 +20,11 @@ import static org.eclipse.tycho.test.util.StatusMatchers.okStatus;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -156,15 +157,15 @@ public class LocalArtifactRepositoryP2APITest {
 
         assertThat(result, hasItem(ARTIFACT_A_DESCRIPTOR_1));
         assertThat(result, hasItem(ARTIFACT_A_DESCRIPTOR_2));
-        assertThat(result.size(), is(2));
+        assertEquals(2, result.size());
     }
 
     @Test
     public void testGetDescriptorsOfNonContainedKey() {
         List<IArtifactDescriptor> result = Arrays.asList(subject.getArtifactDescriptors(OTHER_KEY));
 
-        assertThat(result, notNullValue());
-        assertThat(result.size(), is(0));
+        assertNotNull(result);
+        assertEquals(0, result.size());
     }
 
     @Test
@@ -281,7 +282,7 @@ public class LocalArtifactRepositoryP2APITest {
     public void testGetArtifactFileOfNonContainedKey() {
         File result = subject.getArtifactFile(OTHER_KEY);
 
-        assertThat(result, is(nullValue()));
+        assertNull(result);
     }
 
     @Test
@@ -290,7 +291,7 @@ public class LocalArtifactRepositoryP2APITest {
 
         File result = subject.getArtifactFile(ARTIFACT_B_KEY);
 
-        assertThat(result, is(nullValue()));
+        assertNull(result);
     }
 
     @Test
@@ -304,7 +305,7 @@ public class LocalArtifactRepositoryP2APITest {
     public void testGetRawArtifactFileOfNonContainedFormat() {
         File result = subject.getArtifactFile(ARTIFACT_B_CANONICAL);
 
-        assertThat(result, is(nullValue()));
+        assertNull(result);
     }
 
     @Test

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/local/MirroringArtifactProviderTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/local/MirroringArtifactProviderTest.java
@@ -20,9 +20,9 @@ import static org.eclipse.tycho.test.util.StatusMatchers.errorStatus;
 import static org.eclipse.tycho.test.util.StatusMatchers.okStatus;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -190,7 +190,7 @@ public class MirroringArtifactProviderTest {
 
     @Test
     public void testGetUnavailableArtifactFile() {
-        assertThat(subject.getArtifactFile(OTHER_KEY), is(nullValue()));
+        assertNull(subject.getArtifactFile(OTHER_KEY));
     }
 
     @Test
@@ -221,7 +221,7 @@ public class MirroringArtifactProviderTest {
 
     @Test
     public void testGetRawArtifactFileOfUnavailableFile() {
-        assertThat(subject.getArtifactFile(canonicalDescriptorFor(OTHER_KEY)), is(nullValue()));
+        assertNull(subject.getArtifactFile(canonicalDescriptorFor(OTHER_KEY)));
     }
 
     @Test

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/p2base/artifact/provider/formats/LocalArtifactTransferPolicyTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/p2base/artifact/provider/formats/LocalArtifactTransferPolicyTest.java
@@ -13,8 +13,9 @@
 package org.eclipse.tycho.repository.p2base.artifact.provider.formats;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.io.File;
 import java.util.Arrays;
@@ -49,9 +50,9 @@ public class LocalArtifactTransferPolicyTest {
 
         List<IArtifactDescriptor> result = subject.sortFormatsByPreference(descriptors);
 
-        assertThat(result.get(0).getProperty(IArtifactDescriptor.FORMAT), is(nullValue()));
+        assertNull(result.get(0).getProperty(IArtifactDescriptor.FORMAT));
         assertThat(formatsOf(result.get(1), result.get(2)), is(asSet("customFormat", "anotherFormat")));
-        assertThat(result.size(), is(3));
+        assertEquals(3, result.size());
     }
 
     static Set<String> formatsOf(IArtifactDescriptor... descriptors) {

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/util/StatusToolTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/util/StatusToolTest.java
@@ -14,9 +14,9 @@ package org.eclipse.tycho.repository.util;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNull;
 
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
@@ -32,7 +32,7 @@ public class StatusToolTest {
 
         assertThat(StatusTool.toLogMessage(status), is("Simple error"));
         assertThat(StatusTool.collectProblems(status), is("Simple error"));
-        assertThat(StatusTool.findException(status), is(nullValue()));
+        assertNull(StatusTool.findException(status));
     }
 
     @Test

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/manager/ReactorRepositoryManagerTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/manager/ReactorRepositoryManagerTest.java
@@ -15,9 +15,8 @@ package org.eclipse.tycho.p2.manager;
 
 import static org.eclipse.tycho.p2.testutil.InstallableUnitMatchers.unitWithId;
 import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -64,20 +63,20 @@ public class ReactorRepositoryManagerTest extends MavenServiceStubbingTestBase {
     public void testReactorRepositoryManagerServiceAvailability() throws Exception {
         subject = getService(ReactorRepositoryManager.class);
 
-        assertThat(subject, is(notNullValue()));
+        assertNotNull(subject);
     }
 
     @Test
     public void testReactorRepositoryManagerFacadeServiceAvailability() throws Exception {
         subject = getService(ReactorRepositoryManagerFacade.class);
 
-        assertThat(subject, is(notNullValue()));
+        assertNotNull(subject);
     }
 
     @Test
     public void testTargetPlatformComputationInIntegration() throws Exception {
         subject = getService(ReactorRepositoryManagerFacade.class);
-        assertThat(subject, is(notNullValue()));
+        assertNotNull(subject);
         ReactorProject currentProject = new ReactorProjectStub("reactor-artifact");
 
         TargetPlatformConfigurationStub tpConfig = new TargetPlatformConfigurationStub();

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/remote/RemoteAgentCompositeLoadingTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/remote/RemoteAgentCompositeLoadingTest.java
@@ -12,10 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2.remote;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
 import java.io.IOException;
@@ -61,8 +59,8 @@ public class RemoteAgentCompositeLoadingTest {
             expectedException = e;
         }
 
-        assertThat(expectedException, not(nullValue()));
-        assertThat(expectedException.getStatus().getCode(), is(ProvisionException.REPOSITORY_FAILED_READ));
+        assertNotNull(expectedException);
+        assertEquals(ProvisionException.REPOSITORY_FAILED_READ, expectedException.getStatus().getCode());
     }
 
 }

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/remote/RemoteAgentDisableP2MirrorsTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/remote/RemoteAgentDisableP2MirrorsTest.java
@@ -12,9 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2.remote;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.io.File;
 import java.net.URI;
@@ -48,7 +47,7 @@ public class RemoteAgentDisableP2MirrorsTest {
         IProvisioningAgent agent = createRemoteAgent(true);
         IArtifactRepository repo = loadRepository(agent, ResourceUtil.resourceFile("p2-mirrors-disable").toURI());
 
-        assertThat(repo.getProperty(IRepository.PROP_MIRRORS_URL), is(nullValue()));
+        assertNull(repo.getProperty(IRepository.PROP_MIRRORS_URL));
     }
 
     @Test
@@ -56,7 +55,7 @@ public class RemoteAgentDisableP2MirrorsTest {
         IProvisioningAgent agent = createRemoteAgent(false);
         IArtifactRepository repo = loadRepository(agent, ResourceUtil.resourceFile("p2-mirrors-disable").toURI());
 
-        assertThat(repo.getProperty(IRepository.PROP_MIRRORS_URL), is("file://dummy/"));
+        assertEquals("file://dummy/", repo.getProperty(IRepository.PROP_MIRRORS_URL));
     }
 
     private IProvisioningAgent createRemoteAgent(boolean disableMirrors) throws Exception {

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/remote/RemoteAgentMavenMirrorsTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/remote/RemoteAgentMavenMirrorsTest.java
@@ -12,9 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2.remote;
 
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
 import java.net.URI;
@@ -72,8 +71,8 @@ public class RemoteAgentMavenMirrorsTest {
 
         Repositories repos = loadRepositories(repositoryId, url);
 
-        assertThat(repos.getMetadataRepository(), notNullValue());
-        assertThat(repos.getArtifactRepository(), notNullValue());
+        assertNotNull(repos.getMetadataRepository());
+        assertNotNull(repos.getArtifactRepository());
     }
 
     @Test
@@ -86,8 +85,8 @@ public class RemoteAgentMavenMirrorsTest {
 
         Repositories repos = loadRepositories(repositoryId, originalUrl);
 
-        assertThat(repos.getMetadataRepository(), notNullValue());
-        assertThat(repos.getArtifactRepository(), notNullValue());
+        assertNotNull(repos.getMetadataRepository());
+        assertNotNull(repos.getArtifactRepository());
     }
 
     @Test
@@ -101,8 +100,8 @@ public class RemoteAgentMavenMirrorsTest {
 
         Repositories repos = loadRepositories(null, originalUrl);
 
-        assertThat(repos.getMetadataRepository(), notNullValue());
-        assertThat(repos.getArtifactRepository(), notNullValue());
+        assertNotNull(repos.getMetadataRepository());
+        assertNotNull(repos.getArtifactRepository());
     }
 
     private void prepareMavenMirrorConfiguration(String id, URI mirrorUrl) {

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/remote/RemoteAgentMetadataRepositoryCacheTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/remote/RemoteAgentMetadataRepositoryCacheTest.java
@@ -12,14 +12,12 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2.remote;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.net.URI;
-import java.util.Collections;
 import java.util.Properties;
 
 import org.eclipse.equinox.p2.core.ProvisionException;
@@ -66,7 +64,7 @@ public class RemoteAgentMetadataRepositoryCacheTest {
     public void testOnlineLoading() throws Exception {
         RemoteAgent onlineAgent = newOnlineAgent();
         IMetadataRepository repo = loadHttpRepository(onlineAgent);
-        assertThat(repo, is(notNullValue()));
+        assertNotNull(repo);
     }
 
     @Test
@@ -74,14 +72,14 @@ public class RemoteAgentMetadataRepositoryCacheTest {
         RemoteAgent onlineAgent = newOnlineAgent();
         loadHttpRepository(onlineAgent);
 
-        assertThat(localServer.getAccessedUrls(HTTP_REPO_PATH), not(is(Collections.<String> emptyList()))); // self-test
+        assertFalse(localServer.getAccessedUrls(HTTP_REPO_PATH).isEmpty()); // self-test
         localServer.clearAccessedUrls(HTTP_REPO_PATH);
 
         RemoteAgent offlineAgent = newOfflineAgent();
         IMetadataRepository repo = loadHttpRepository(offlineAgent);
-        assertThat(repo, is(notNullValue()));
+        assertNotNull(repo);
 
-        assertThat(localServer.getAccessedUrls(HTTP_REPO_PATH), is(Collections.<String> emptyList()));
+        assertTrue(localServer.getAccessedUrls(HTTP_REPO_PATH).isEmpty());
     }
 
     @Test(expected = ProvisionException.class)
@@ -100,7 +98,7 @@ public class RemoteAgentMetadataRepositoryCacheTest {
 
         RemoteAgent onlineAgent2 = newOnlineAgent();
         IMetadataRepository repo = loadHttpRepository(onlineAgent2);
-        assertThat(repo, is(notNullValue()));
+        assertNotNull(repo);
     }
 
     @Test(expected = ProvisionException.class)
@@ -117,13 +115,13 @@ public class RemoteAgentMetadataRepositoryCacheTest {
         RemoteAgent onlineAgent = newOnlineAgent();
         loadHttpRepository(onlineAgent);
 
-        assertThat(localServer.getAccessedUrls(HTTP_REPO_PATH), not(is(Collections.<String> emptyList()))); // self-test
+        assertFalse(localServer.getAccessedUrls(HTTP_REPO_PATH).isEmpty()); // self-test
         localServer.clearAccessedUrls(HTTP_REPO_PATH);
 
         IMetadataRepository repo = loadHttpRepository(onlineAgent);
-        assertThat(repo, is(notNullValue()));
+        assertNotNull(repo);
 
-        assertThat(localServer.getAccessedUrls(HTTP_REPO_PATH), is(Collections.<String> emptyList()));
+        assertTrue(localServer.getAccessedUrls(HTTP_REPO_PATH).isEmpty());
     }
 
     private RemoteAgent newOnlineAgent() throws Exception {

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/ee/CustomEEResolutionHandlerTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/ee/CustomEEResolutionHandlerTest.java
@@ -14,10 +14,9 @@
 package org.eclipse.tycho.p2.target.ee;
 
 import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -67,13 +66,13 @@ public class CustomEEResolutionHandlerTest {
 
         List<SystemCapability> result = eeConfigurationCapture.capturedSystemCapabilities;
 
-        assertThat(result, not(nullValue()));
+        assertNotNull(result);
         assertThat(result, hasItem(new SystemCapability(Type.JAVA_PACKAGE, "javax.activation", "0.0.0")));
         assertThat(result, hasItem(new SystemCapability(Type.JAVA_PACKAGE, "javax.activation", "1.1.1")));
         assertThat(result, hasItem(new SystemCapability(Type.OSGI_EE, "OSGi/Minimum", "1.0.0")));
         assertThat(result, hasItem(new SystemCapability(Type.OSGI_EE, "JavaSE", "1.4.0")));
         assertThat(result, hasItem(new SystemCapability(Type.OSGI_EE, "JavaSE", "1.5.0")));
-        assertThat(result.size(), is(5));
+        assertEquals(5, result.size());
     }
 
     @Test

--- a/tycho-bundles/org.eclipse.tycho.p2.tools.tests/META-INF/MANIFEST.MF
+++ b/tycho-bundles/org.eclipse.tycho.p2.tools.tests/META-INF/MANIFEST.MF
@@ -6,7 +6,6 @@ Bundle-Version: 3.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Fragment-Host: org.eclipse.tycho.p2.tools.impl
 Require-Bundle: org.junit;bundle-version="[4.8.1,5.0.0)",
- org.hamcrest.core,
  org.eclipse.tycho.p2.resolver.impl,
  net.bytebuddy.byte-buddy
 Bundle-Vendor: %providerName

--- a/tycho-bundles/org.eclipse.tycho.p2.tools.tests/src/test/java/org/eclipse/tycho/p2/tools/publisher/PublisherServiceFactoryTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.tools.tests/src/test/java/org/eclipse/tycho/p2/tools/publisher/PublisherServiceFactoryTest.java
@@ -12,9 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.p2.tools.publisher;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
 
 import org.eclipse.tycho.p2.tools.impl.Activator;
 import org.eclipse.tycho.p2.tools.publisher.facade.PublisherServiceFactory;
@@ -32,7 +30,7 @@ public class PublisherServiceFactoryTest extends MavenServiceStubbingTestBase {
         try {
             PublisherServiceFactory publisherServiceFactory = tracker.waitForService(2000);
             // factory service is only available if all required services are available
-            assertThat(publisherServiceFactory, is(notNullValue()));
+            assertNotNull(publisherServiceFactory);
         } finally {
             tracker.close();
         }

--- a/tycho-bundles/org.eclipse.tycho.p2.tools.tests/src/test/java/org/eclipse/tycho/p2/tools/publisher/PublisherServiceTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.tools.tests/src/test/java/org/eclipse/tycho/p2/tools/publisher/PublisherServiceTest.java
@@ -13,11 +13,8 @@
 package org.eclipse.tycho.p2.tools.publisher;
 
 import static org.eclipse.tycho.p2.tools.test.util.ResourceUtil.resourceFile;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -89,20 +86,20 @@ public class PublisherServiceTest {
 
         Collection<DependencySeed> seeds = subject.publishCategories(categoryDefinition);
 
-        assertThat(seeds.size(), is(1));
+        assertEquals(1, seeds.size());
         DependencySeed seed = seeds.iterator().next();
 
         Set<Object> publishedUnits = outputRepository.getInstallableUnits();
-        assertThat(publishedUnits, hasItem(seed.getInstallableUnit()));
+        assertTrue(publishedUnits.contains(seed.getInstallableUnit()));
     }
 
     @Test
     public void testProfilePublishing() throws Exception {
         File customProfile = resourceFile("publishers/virgo-1.6.profile");
         Collection<DependencySeed> seeds = subject.publishEEProfile(customProfile);
-        assertThat(seeds.size(), is(2));
+        assertEquals(2, seeds.size());
         IInstallableUnit virgoProfileIU = unitsById(seeds).get("a.jre.virgo");
-        assertThat(virgoProfileIU, not(nullValue()));
+        assertNotNull(virgoProfileIU);
         Collection<IProvidedCapability> provided = virgoProfileIU.getProvidedCapabilities();
         boolean customJavaxActivationVersionFound = false;
         Version version_1_1_1 = Version.create("1.1.1");
@@ -118,7 +115,7 @@ public class PublisherServiceTest {
         }
         assertTrue("did not find capability for package javax.activation with custom version " + version_1_1_1,
                 customJavaxActivationVersionFound);
-        assertThat(unitsById(seeds).keySet(), hasItem("config.a.jre.virgo"));
+        assertTrue(unitsById(seeds).keySet().contains("config.a.jre.virgo"));
     }
 
     @Test(expected = FacadeException.class)

--- a/tycho-bundles/org.eclipse.tycho.test.utils/src/main/java/org/eclipse/tycho/repository/streaming/testutil/ProbeArtifactSink.java
+++ b/tycho-bundles/org.eclipse.tycho.test.utils/src/main/java/org/eclipse/tycho/repository/streaming/testutil/ProbeArtifactSink.java
@@ -17,8 +17,8 @@ import static org.eclipse.tycho.test.util.StatusMatchers.okStatus;
 import static org.eclipse.tycho.test.util.StatusMatchers.warningStatus;
 import static org.hamcrest.CoreMatchers.either;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -117,7 +117,7 @@ public class ProbeArtifactSink implements IArtifactSink {
     }
 
     public void checkConsistencyWithStatus(IStatus status) {
-        assertThat(status, is(notNullValue()));
+        assertNotNull(status);
 
         if (writeIsCommitted()) {
             // status must be non-fatal

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/ee/CustomExecutionEnvironmentTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/ee/CustomExecutionEnvironmentTest.java
@@ -14,8 +14,8 @@ import static org.hamcrest.CoreMatchers.any;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -49,8 +49,8 @@ public class CustomExecutionEnvironmentTest {
         createExecutionEnvironment();
 
         assertThat(customExecutionEnvironment.getProfileName(), is("name"));
-        assertThat(customExecutionEnvironment.getCompilerSourceLevelDefault(), is(nullValue()));
-        assertThat(customExecutionEnvironment.getCompilerTargetLevelDefault(), is(nullValue()));
+        assertNull(customExecutionEnvironment.getCompilerSourceLevelDefault());
+        assertNull(customExecutionEnvironment.getCompilerTargetLevelDefault());
         assertTrue(customExecutionEnvironment.getSystemPackages().isEmpty()); // explicitly specify template parameter to work around bug present 1.6.0_37 
         assertProperty(EquinoxConfiguration.PROP_OSGI_JAVA_PROFILE_NAME, "name");
     }
@@ -59,7 +59,8 @@ public class CustomExecutionEnvironmentTest {
     public void testProvidedSystemPackageNoVersion() throws Exception {
         createExecutionEnvironment(PACKAGE_JAVA_LANG);
 
-        assertThat(customExecutionEnvironment.getSystemPackages().stream().map(entry -> entry.packageName).collect(Collectors.toList()), hasItem("java.lang"));
+        assertThat(customExecutionEnvironment.getSystemPackages().stream().map(entry -> entry.packageName)
+                .collect(Collectors.toList()), hasItem("java.lang"));
         assertThat(customExecutionEnvironment.getProfileProperties().size(), is(2));
         assertProperty(Constants.FRAMEWORK_SYSTEMPACKAGES, "java.lang");
     }
@@ -68,7 +69,8 @@ public class CustomExecutionEnvironmentTest {
     public void testProvidedSystemPackageWithVersion() throws Exception {
         createExecutionEnvironment(PACKAGE_JAVAX_ACTIVATION_1_1);
 
-        assertThat(customExecutionEnvironment.getSystemPackages().stream().map(entry -> entry.packageName).collect(Collectors.toList()), hasItem("javax.activation"));
+        assertThat(customExecutionEnvironment.getSystemPackages().stream().map(entry -> entry.packageName)
+                .collect(Collectors.toList()), hasItem("javax.activation"));
         assertThat(customExecutionEnvironment.getProfileProperties().size(), is(2));
         assertProperty(Constants.FRAMEWORK_SYSTEMPACKAGES, "javax.activation;version=\"1.1\"");
     }
@@ -77,8 +79,10 @@ public class CustomExecutionEnvironmentTest {
     public void testTwoProvidedSystemPackages() throws Exception {
         createExecutionEnvironment(PACKAGE_JAVA_LANG, PACKAGE_JAVAX_ACTIVATION_1_1);
 
-        assertThat(customExecutionEnvironment.getSystemPackages().stream().map(entry -> entry.packageName).collect(Collectors.toList()), hasItem("java.lang"));
-        assertThat(customExecutionEnvironment.getSystemPackages().stream().map(entry -> entry.packageName).collect(Collectors.toList()), hasItem("javax.activation"));
+        assertThat(customExecutionEnvironment.getSystemPackages().stream().map(entry -> entry.packageName)
+                .collect(Collectors.toList()), hasItem("java.lang"));
+        assertThat(customExecutionEnvironment.getSystemPackages().stream().map(entry -> entry.packageName)
+                .collect(Collectors.toList()), hasItem("javax.activation"));
         assertThat(customExecutionEnvironment.getProfileProperties().size(), is(2));
         assertProperty(Constants.FRAMEWORK_SYSTEMPACKAGES, "java.lang,javax.activation;version=\"1.1\"");
     }
@@ -87,8 +91,8 @@ public class CustomExecutionEnvironmentTest {
     public void testOsgiEeCapability() throws Exception {
         createExecutionEnvironment(OSGI_JAVASE_1_6);
 
-        assertThat(customExecutionEnvironment.getSystemPackages().stream().map(entry -> entry.packageName).collect(Collectors.toList()),
-                not(CoreMatchers.<String> hasItem(any(String.class)))); // explicitly specify template parameter to work around bug present 1.6.0_37 
+        assertThat(customExecutionEnvironment.getSystemPackages().stream().map(entry -> entry.packageName)
+                .collect(Collectors.toList()), not(CoreMatchers.<String> hasItem(any(String.class)))); // explicitly specify template parameter to work around bug present 1.6.0_37 
         assertThat(customExecutionEnvironment.getProfileProperties().size(), is(3));
         assertProperty(Constants.FRAMEWORK_SYSTEMCAPABILITIES, "osgi.ee; osgi.ee=\"JavaSE\"; version:Version=\"1.6\"");
         assertProperty(Constants.FRAMEWORK_EXECUTIONENVIRONMENT, "JavaSE-1.6");

--- a/tycho-extras/tycho-eclipserun-plugin/src/test/java/org/eclipse/tycho/extras/eclipserun/EclipseRunMojoTest.java
+++ b/tycho-extras/tycho-eclipserun-plugin/src/test/java/org/eclipse/tycho/extras/eclipserun/EclipseRunMojoTest.java
@@ -12,9 +12,6 @@
  ******************************************************************************/
 package org.eclipse.tycho.extras.eclipserun;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -90,19 +87,18 @@ public class EclipseRunMojoTest extends AbstractTychoMojoTestCase {
 	public void testCreateCommandLineProgramArgs() throws MojoExecutionException {
 		LaunchConfiguration commandLine = runMojo.createCommandLine(installation);
 		List<String> programArgs = Arrays.asList(commandLine.getProgramArguments());
-		assertThat(programArgs, contains( //
-				"-install", installation.getLocation().getAbsolutePath(), //
+		assertTrue(programArgs.containsAll(List.of("-install", installation.getLocation().getAbsolutePath(), //
 				"-configuration", new File(workFolder, "configuration").getAbsolutePath(), //
 				"-data", new File(workFolder, "data").getAbsolutePath() //
-		));
+		)));
 	}
 
 	public void testDataDirectoryIsClearedBeforeLaunching() throws IOException, MojoExecutionException {
 		File markerFile = new File(workFolder, "data/markerfile").getAbsoluteFile();
 		markerFile.getParentFile().mkdirs();
 		markerFile.createNewFile();
-		assertThat(markerFile.exists(), is(true));
+		assertTrue(markerFile.exists());
 		runMojo.runEclipse(installation);
-		assertThat(markerFile.exists(), is(false));
+		assertFalse(markerFile.exists());
 	}
 }

--- a/tycho-extras/tycho-pomless/src/test/java/org/eclipse/tycho/pomless/TychoModelReaderTest.java
+++ b/tycho-extras/tycho-pomless/src/test/java/org/eclipse/tycho/pomless/TychoModelReaderTest.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.tycho.pomless;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import java.io.File;
@@ -153,7 +151,7 @@ public class TychoModelReaderTest extends PlexusTestCase {
             getTychoModelReader(TychoFeatureMapping.PACKAGING).read(featureXml, createReaderOptions(featureXml));
             fail();
         } catch (ModelParseException e) {
-            assertThat(e.getMessage(), containsString("missing or empty 'id' attribute in element 'feature'"));
+            assertTrue(e.getMessage().contains("missing or empty 'id' attribute in element 'feature'"));
         }
     }
 
@@ -164,7 +162,7 @@ public class TychoModelReaderTest extends PlexusTestCase {
             getTychoModelReader(TychoFeatureMapping.PACKAGING).read(featureXml, createReaderOptions(featureXml));
             fail();
         } catch (ModelParseException e) {
-            assertThat(e.getMessage(), containsString("missing or empty 'version' attribute in element 'feature'"));
+            assertTrue(e.getMessage().contains("missing or empty 'version' attribute in element 'feature'"));
         }
     }
 
@@ -177,7 +175,7 @@ public class TychoModelReaderTest extends PlexusTestCase {
                     createReaderOptions(buildProperties));
             fail();
         } catch (ModelParseException e) {
-            assertThat(e.getMessage(), containsString("Bundle-SymbolicName missing in"));
+            assertTrue(e.getMessage().contains("Bundle-SymbolicName missing in"));
         }
     }
 
@@ -190,7 +188,7 @@ public class TychoModelReaderTest extends PlexusTestCase {
                     createReaderOptions(buildProperties));
             fail();
         } catch (ModelParseException e) {
-            assertThat(e.getMessage(), containsString("Bundle-Version missing in"));
+            assertTrue(e.getMessage().contains("Bundle-Version missing in"));
         }
     }
 
@@ -201,7 +199,7 @@ public class TychoModelReaderTest extends PlexusTestCase {
         FileNotFoundException e = assertThrows(FileNotFoundException.class,
                 () -> getTychoModelReader(TychoBundleMapping.PACKAGING).read(buildProperties,
                         createReaderOptions(buildProperties)));
-        assertThat(e.getMessage(), containsString("No parent pom file found in"));
+        assertTrue(e.getMessage().contains("No parent pom file found in"));
     }
 
     @Test
@@ -242,7 +240,7 @@ public class TychoModelReaderTest extends PlexusTestCase {
             getTychoModelReader(TychoRepositoryMapping.PACKAGING).read(product, createReaderOptions(product));
             fail();
         } catch (ModelParseException e) {
-            assertThat(e.getMessage(), containsString("missing or empty 'uid' attribute in element 'product'"));
+            assertTrue(e.getMessage().contains("missing or empty 'uid' attribute in element 'product'"));
         }
     }
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/iu/IUMetadataGenerationTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/iu/IUMetadataGenerationTest.java
@@ -12,11 +12,10 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.iu;
 
-import static org.eclipse.tycho.test.util.TychoMatchers.hasSize;
-import static org.eclipse.tycho.test.util.TychoMatchers.isFile;
 import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.util.List;
@@ -30,41 +29,41 @@ import org.junit.Test;
 
 public class IUMetadataGenerationTest extends AbstractTychoIntegrationTest {
 
-    private static P2RepositoryTool repo;
+	private static P2RepositoryTool repo;
 
-    @BeforeClass
-    public static void runBuild() throws Exception {
-        Verifier verifier = new IUMetadataGenerationTest().getVerifier("iu.artifact", false);
-        verifier.executeGoal("verify");
-        verifier.verifyErrorFreeLog();
+	@BeforeClass
+	public static void runBuild() throws Exception {
+		Verifier verifier = new IUMetadataGenerationTest().getVerifier("iu.artifact", false);
+		verifier.executeGoal("verify");
+		verifier.verifyErrorFreeLog();
 
-        File repoProject = new File(verifier.getBasedir(), "repository");
-        repo = P2RepositoryTool.forEclipseRepositoryModule(repoProject);
-    }
+		File repoProject = new File(verifier.getBasedir(), "repository");
+		repo = P2RepositoryTool.forEclipseRepositoryModule(repoProject);
+	}
 
-    @Test
-    public void testIUWithArtifact() throws Exception {
-        IU finalIU = repo.getUniqueIU("iua.artifact");
+	@Test
+	public void testIUWithArtifact() throws Exception {
+		IU finalIU = repo.getUniqueIU("iua.artifact");
 
-        //Here we check that the final IU contained in the repo has the right shape
-        assertThat(finalIU.getProvidedCapabilities(), hasItem("org.eclipse.equinox.p2.iu/iua.artifact/1.0.0"));
-        List<String> properties = finalIU.getProperties();
-        assertThat(properties, hasItem("maven-groupId=" + "tycho-its-project.iu.artifact"));
-        assertThat(properties, hasItem("maven-artifactId=" + "iua.artifact"));
-        assertThat(properties, hasItem("maven-version=" + finalIU.getVersion()));
-        assertThat(finalIU.getArtifacts(), hasItem("binary/iua.artifact/1.0.0"));
+		// Here we check that the final IU contained in the repo has the right shape
+		assertThat(finalIU.getProvidedCapabilities(), hasItem("org.eclipse.equinox.p2.iu/iua.artifact/1.0.0"));
+		List<String> properties = finalIU.getProperties();
+		assertThat(properties, hasItem("maven-groupId=" + "tycho-its-project.iu.artifact"));
+		assertThat(properties, hasItem("maven-artifactId=" + "iua.artifact"));
+		assertThat(properties, hasItem("maven-version=" + finalIU.getVersion()));
+		assertThat(finalIU.getArtifacts(), hasItem("binary/iua.artifact/1.0.0"));
 
-        //check that the artifact is here
-        assertThat(repo.getBinaryArtifact("iua.artifact", "1.0.0"), isFile());
-    }
+		// check that the artifact is here
+		assertTrue(repo.getBinaryArtifact("iua.artifact", "1.0.0").isFile());
+	}
 
-    @Test
-    public void testIUWithoutArtifact() throws Exception {
-        IU finalIU = repo.getUniqueIU("iua.noartifact");
+	@Test
+	public void testIUWithoutArtifact() throws Exception {
+		IU finalIU = repo.getUniqueIU("iua.noartifact");
 
-        assertThat(finalIU.getProvidedCapabilities(), hasItem("org.eclipse.equinox.p2.iu/iua.noartifact/1.0.0"));
-        assertThat(finalIU.getArtifacts(), hasSize(0));
-        assertThat(repo.getBinaryArtifact("iua.noartifact", "1.0.0"), not(isFile()));
-    }
+		assertThat(finalIU.getProvidedCapabilities(), hasItem("org.eclipse.equinox.p2.iu/iua.noartifact/1.0.0"));
+		assertTrue(finalIU.getArtifacts().isEmpty());
+		assertFalse(repo.getBinaryArtifact("iua.noartifact", "1.0.0").isFile());
+	}
 
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/iu/ProductWithIUTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/iu/ProductWithIUTest.java
@@ -12,9 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.iu;
 
-import static org.eclipse.tycho.test.util.TychoMatchers.isFile;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 
@@ -35,13 +33,13 @@ public class ProductWithIUTest extends AbstractTychoIntegrationTest {
 
 		File rootFileInstalledByIU = new File(verifier.getBasedir(),
 				"eclipse-repository/target/products/main.product.id/linux/gtk/x86/myFile.txt");
-		assertThat(rootFileInstalledByIU, isFile());
+		assertTrue(rootFileInstalledByIU.isFile());
 
 		P2RepositoryTool p2Repository = P2RepositoryTool
 				.forEclipseRepositoryModule(new File(verifier.getBasedir(), "eclipse-repository"));
-		assertThat(p2Repository.findBinaryArtifact("iup.iuForRootFile"), isFile());
+		assertTrue(p2Repository.findBinaryArtifact("iup.iuForRootFile").isFile());
 
-		assertThat(p2Repository.getAllUnitIds(), hasItem("iup.iuForRootFile"));
+		assertTrue(p2Repository.getAllUnitIds().contains("iup.iuForRootFile"));
 	}
 
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/BasicP2RepositoryIntegrationTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/BasicP2RepositoryIntegrationTest.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.p2Repository;
 
-import static org.eclipse.tycho.test.util.TychoMatchers.isFile;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -49,7 +48,7 @@ public class BasicP2RepositoryIntegrationTest extends AbstractTychoIntegrationTe
 	@Test
 	public void test381377BundleInclusion() {
 		// check that (separately!) included bundle is there
-		assertThat(p2Repo.getBundleArtifact("com.sun.el", "2.2.0.v201303151357"), isFile());
+		assertTrue(p2Repo.getBundleArtifact("com.sun.el", "2.2.0.v201303151357").isFile());
 	}
 
 	@Test
@@ -71,24 +70,24 @@ public class BasicP2RepositoryIntegrationTest extends AbstractTychoIntegrationTe
 	@Test
 	public void test347416CustomFinalName() throws Exception {
 		File repositoryArchive = new File(verifier.getBasedir(), "target/" + CUSTOM_FINAL_NAME + ".zip");
-		assertThat(repositoryArchive, isFile());
+		assertTrue(repositoryArchive.isFile());
 	}
 
 	@Test
 	public void testResourcesProcessed() throws Exception {
 		File repository = new File(verifier.getBasedir(), "target/repository");
-		assertThat(new File(repository, "index.html"), isFile());
+		assertTrue(new File(repository, "index.html").isFile());
 		File aboutFile = new File(repository, "about/about.html");
-		assertThat(aboutFile, isFile());
+		assertTrue(aboutFile.isFile());
 		assertThat(Files.readString(aboutFile.toPath()).trim(), equalTo("About testrepo"));
 	}
 
 	@Test
 	public void testXZCompression() throws Exception {
 		File repository = new File(verifier.getBasedir(), "target/repository");
-		assertThat(new File(repository, "content.xml.xz"), isFile());
-		assertThat(new File(repository, "artifacts.xml.xz"), isFile());
-		assertThat(new File(repository, "p2.index"), isFile());
+		assertTrue(new File(repository, "content.xml.xz").isFile());
+		assertTrue(new File(repository, "artifacts.xml.xz").isFile());
+		assertTrue(new File(repository, "p2.index").isFile());
 	}
 
 	@Test

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/QualifierExpansionAndArtifactAssemblyTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/QualifierExpansionAndArtifactAssemblyTest.java
@@ -13,9 +13,9 @@
 package org.eclipse.tycho.test.p2Repository;
 
 import static org.eclipse.tycho.test.util.P2RepositoryTool.withIdAndVersion;
-import static org.eclipse.tycho.test.util.TychoMatchers.isFile;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.util.List;
@@ -86,14 +86,8 @@ public class QualifierExpansionAndArtifactAssemblyTest extends AbstractTychoInte
 		assertThat(inclusions, hasItem(withIdAndVersion("prr.example.bundle", BUNDLE_VERSION)));
 		assertThat(inclusions, hasItem(withIdAndVersion("org.eclipse.core.contenttype", "3.4.1.R35x_v20090826-0451"))); // a
 																														// bundle
-																														// from
-																														// the
-																														// external
-																														// target
-																														// platform
-
 		File featureJar = p2Repository.getFeatureArtifact("prr.example.feature", FEATURE_VERSION);
-		assertThat(featureJar, isFile());
+		assertTrue(featureJar.isFile());
 	}
 
 	@Test
@@ -111,7 +105,7 @@ public class QualifierExpansionAndArtifactAssemblyTest extends AbstractTychoInte
 	@Test
 	public void testPublishedBundleIU() throws Exception {
 		assertThat(p2Repository.getAllUnits(), hasItem(withIdAndVersion("prr.example.bundle", BUNDLE_VERSION)));
-		assertThat(p2Repository.getBundleArtifact("prr.example.bundle", BUNDLE_VERSION), isFile());
+		assertTrue(p2Repository.getBundleArtifact("prr.example.bundle", BUNDLE_VERSION).isFile());
 	}
 
 	// TODO 373817 test that inclusions in products have the right expanded
@@ -120,17 +114,17 @@ public class QualifierExpansionAndArtifactAssemblyTest extends AbstractTychoInte
 	@Test
 	public void testIncludedReactorArtifactsAreAssembled() throws Exception {
 		assertThat(p2Repository.getAllUnitIds(), hasItem("prr.example.included.feature" + ".feature.group"));
-		assertThat(p2Repository.getFeatureArtifact("prr.example.included.feature", DEFAULT_VERSION), isFile());
+		assertTrue(p2Repository.getFeatureArtifact("prr.example.included.feature", DEFAULT_VERSION).isFile());
 
 		assertThat(p2Repository.getAllUnitIds(), hasItem("prr.example.included.bundle"));
-		assertThat(p2Repository.getBundleArtifact("prr.example.included.bundle", DEFAULT_VERSION), isFile());
+		assertTrue(p2Repository.getBundleArtifact("prr.example.included.bundle", DEFAULT_VERSION).isFile());
 	}
 
 	@Test
 	public void testIncludedExternalArtifactIsAssembled() throws Exception {
 		assertThat(p2Repository.getAllUnitIds(), hasItem("org.eclipse.core.contenttype"));
-		assertThat(p2Repository.getBundleArtifact("org.eclipse.core.contenttype", "3.4.1.R35x_v20090826-0451"),
-				isFile());
+		assertTrue(
+				p2Repository.getBundleArtifact("org.eclipse.core.contenttype", "3.4.1.R35x_v20090826-0451").isFile());
 	}
 
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/RepoRefLocationP2RepositoryIntegrationTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/RepoRefLocationP2RepositoryIntegrationTest.java
@@ -12,10 +12,10 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.p2Repository;
 
-import static org.eclipse.tycho.test.util.TychoMatchers.isFile;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.util.List;
@@ -80,16 +80,16 @@ public class RepoRefLocationP2RepositoryIntegrationTest extends AbstractTychoInt
 		File target = new File(verifier.getBasedir(), "target");
 		File repository = new File(target, "repository");
 		File contentXml = new File(repository, "content.xml");
-		assertThat(contentXml, isFile());
+		assertTrue(contentXml.isFile());
 		File artifactXml = new File(repository, "artifacts.xml");
-		assertThat(artifactXml, isFile());
-		assertThat(new File(target, "category.xml"), isFile());
+		assertTrue(artifactXml.isFile());
+		assertTrue(new File(target, "category.xml").isFile());
 
 		Document artifactsDocument = XMLParser.parse(contentXml);
 		// See MetadataRepositoryIO.Writer#writeRepositoryReferences
 		List<Element> repositories = artifactsDocument.getChild("repository").getChild("references")
 				.getChildren("repository");
-		assertThat(repositories, hasSize(4));
+		assertEquals(4, repositories.size());
 		List<RepositoryReferenceData> actual = repositories.stream()
 				.map(e -> new RepositoryReferenceData(e.getAttributeValue("uri"), e.getAttributeValue("type"),
 						e.getAttributeValue("options")))

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/product/Tycho188P2EnabledRcpTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/product/Tycho188P2EnabledRcpTest.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.product;
 
-import static org.eclipse.tycho.test.util.TychoMatchers.isFile;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
@@ -124,7 +123,7 @@ public class Tycho188P2EnabledRcpTest extends AbstractTychoIntegrationTest {
 
 		// test that root level feature is assembled into the p2 repository...
 		File rootFeatureInRepo = p2Repository.findFeatureArtifact("pi.root-level-installed-feature");
-		assertThat(rootFeatureInRepo, isFile());
+		assertTrue(rootFeatureInRepo.isFile());
 
 		// ... although there is no dependency from the product IU.
 		assertThat(p2Repository.getUniqueIU("main.product.id").getRequiredIds(),

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/Junit4TestBundleTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/Junit4TestBundleTest.java
@@ -13,8 +13,7 @@
 package org.eclipse.tycho.test.surefire;
 
 import static org.eclipse.tycho.test.util.SurefireUtil.testResultFile;
-import static org.eclipse.tycho.test.util.TychoMatchers.exists;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
@@ -22,19 +21,19 @@ import org.junit.Test;
 
 public class Junit4TestBundleTest extends AbstractTychoIntegrationTest {
 
-    @Test
-    public void test() throws Exception {
+	@Test
+	public void test() throws Exception {
 
-        // a eclipse-test-plugin using JUnit 4 -> supported since MNGECLIPSE-1031
-        Verifier verifier = getVerifier("surefire.junit4/bundle.test");
+		// a eclipse-test-plugin using JUnit 4 -> supported since MNGECLIPSE-1031
+		Verifier verifier = getVerifier("surefire.junit4/bundle.test");
 
-        verifier.executeGoal("integration-test");
-        verifier.verifyErrorFreeLog();
+		verifier.executeGoal("integration-test");
+		verifier.verifyErrorFreeLog();
 
-        assertThat(testResultFile(verifier.getBasedir(), "bundle.test", "JUnit4Test"), exists());
+		assertTrue(testResultFile(verifier.getBasedir(), "bundle.test", "JUnit4Test").exists());
 
-        // ensure that JUnit 3 style tests also work -> related to bug 388909
-        assertThat(testResultFile(verifier.getBasedir(), "bundle.test", "JUnit3Test"), exists());
-    }
+		// ensure that JUnit 3 style tests also work -> related to bug 388909
+		assertTrue(testResultFile(verifier.getBasedir(), "bundle.test", "JUnit3Test").exists());
+	}
 
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/TestNGBundleTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/TestNGBundleTest.java
@@ -13,8 +13,7 @@
 package org.eclipse.tycho.test.surefire;
 
 import static org.eclipse.tycho.test.util.SurefireUtil.testResultFile;
-import static org.eclipse.tycho.test.util.TychoMatchers.exists;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 
@@ -24,21 +23,21 @@ import org.junit.Test;
 
 public class TestNGBundleTest extends AbstractTychoIntegrationTest {
 
-    @Test
-    public void test() throws Exception {
+	@Test
+	public void test() throws Exception {
 
-        Verifier verifier = getVerifier("surefire.testng");
-        verifier.executeGoal("integration-test");
-        verifier.verifyErrorFreeLog();
+		Verifier verifier = getVerifier("surefire.testng");
+		verifier.executeGoal("integration-test");
+		verifier.verifyErrorFreeLog();
 
-        assertThat(testResultFile(verifier.getBasedir() + File.separator + "bundle.test", "bundle.test", "TestNGTest"),
-                exists());
+		assertTrue(testResultFile(verifier.getBasedir() + File.separator + "bundle.test", "bundle.test", "TestNGTest")
+				.exists());
 
-        assertThat(testResultFile(verifier.getBasedir() + File.separator + "bundle.testGroups", "bundle.test",
-                "GroupsTest"), exists());
+		assertTrue(testResultFile(verifier.getBasedir() + File.separator + "bundle.testGroups", "bundle.test",
+				"GroupsTest").exists());
 
-        assertThat(testResultFile(verifier.getBasedir() + File.separator + "bundle.testSuites", "TestSuite"), exists());
+		assertTrue(testResultFile(verifier.getBasedir() + File.separator + "bundle.testSuites", "TestSuite").exists());
 
-    }
+	}
 
 }

--- a/tycho-metadata-model/pom.xml
+++ b/tycho-metadata-model/pom.xml
@@ -38,12 +38,6 @@
 			<artifactId>junit-jupiter-api</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest</artifactId>
-			<version>2.2</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 </project>

--- a/tycho-metadata-model/src/test/java/org/eclipse/tycho/maven/test/EclipseModelTest.java
+++ b/tycho-metadata-model/src/test/java/org/eclipse/tycho/maven/test/EclipseModelTest.java
@@ -32,7 +32,7 @@ import de.pdark.decentxml.Document;
 import de.pdark.decentxml.Element;
 import de.pdark.decentxml.XMLParser;
 
-public class EclipseModelTest {
+class EclipseModelTest {
 
     File target = new File("target/modelio");
 
@@ -42,7 +42,7 @@ public class EclipseModelTest {
     }
 
     @Test
-    public void testUpdateSite() throws Exception {
+    void testUpdateSite() throws Exception {
         UpdateSite site = UpdateSite.read(new File("src/test/resources/modelio/site.xml"));
 
         List<UpdateSite.SiteFeatureRef> features = site.getFeatures();
@@ -68,7 +68,7 @@ public class EclipseModelTest {
     }
 
     @Test
-    public void testFeature() throws Exception {
+    void testFeature() throws Exception {
         Feature feature = Feature.read(new File("src/test/resources/modelio/feature.xml"));
 
         assertEquals("1.0.0", feature.getVersion());
@@ -120,7 +120,7 @@ public class EclipseModelTest {
     }
 
     @Test
-    public void testPlatform() throws Exception {
+    void testPlatform() throws Exception {
         Platform platform = Platform.read(new File("src/test/resources/modelio/platform.xml"));
 
         assertEquals(false, platform.isTransient());
@@ -171,7 +171,7 @@ public class EclipseModelTest {
     }
 
     @Test
-    public void testDefaultXmlEncoding() throws Exception {
+    void testDefaultXmlEncoding() throws Exception {
         // Run the test with -Dfile.encoding=Cp1252 to be sure
 
         Feature feature = Feature.read(new File("src/test/resources/modelio/feature-default-encoding.xml"));

--- a/tycho-metadata-model/src/test/java/org/eclipse/tycho/maven/test/ProductConfigurationTest.java
+++ b/tycho-metadata-model/src/test/java/org/eclipse/tycho/maven/test/ProductConfigurationTest.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.tycho.maven.test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -32,10 +30,10 @@ import org.eclipse.tycho.model.PluginRef;
 import org.eclipse.tycho.model.ProductConfiguration;
 import org.junit.jupiter.api.Test;
 
-public class ProductConfigurationTest {
+class ProductConfigurationTest {
 
     @Test
-    public void testProductConfigurationParse() throws Exception {
+    void testProductConfigurationParse() throws Exception {
         ProductConfiguration config = ProductConfiguration
                 .read(getClass().getResourceAsStream("/product/MyFirstRCP.product"));
 
@@ -102,7 +100,7 @@ public class ProductConfigurationTest {
     }
 
     @Test
-    public void testProductConfigurationParseWithStartLevel() throws Exception {
+    void testProductConfigurationParseWithStartLevel() throws Exception {
         ProductConfiguration config = ProductConfiguration
                 .read(getClass().getResourceAsStream("/product/MyProduct.product"));
         Map<String, BundleConfiguration> bundles = config.getPluginConfiguration();
@@ -121,21 +119,21 @@ public class ProductConfigurationTest {
     }
 
     @Test
-    public void testFeatureInstallMode() throws Exception {
+    void testFeatureInstallMode() throws Exception {
         ProductConfiguration config = ProductConfiguration
                 .read(getClass().getResourceAsStream("/product/rootFeatures.product"));
 
         Map<String, InstallMode> modes = getInstallModes(config);
 
-        assertThat(modes.get("org.eclipse.rcp"), is(InstallMode.include));
-        assertThat(modes.get("org.eclipse.e4.rcp"), is(InstallMode.include));
-        assertThat(modes.get("org.eclipse.help"), is(InstallMode.root));
-        assertThat(modes.get("org.eclipse.egit"), is(InstallMode.root));
-        assertThat(modes.size(), is(4));
+        assertEquals(InstallMode.include, modes.get("org.eclipse.rcp"));
+        assertEquals(InstallMode.include, modes.get("org.eclipse.e4.rcp"));
+        assertEquals(InstallMode.root, modes.get("org.eclipse.help"));
+        assertEquals(InstallMode.root, modes.get("org.eclipse.egit"));
+        assertEquals(4, modes.size());
     }
 
     @Test
-    public void testRemoveRootFeatures() throws Exception {
+    void testRemoveRootFeatures() throws Exception {
         ProductConfiguration config = ProductConfiguration
                 .read(getClass().getResourceAsStream("/product/rootFeatures.product"));
 
@@ -143,9 +141,9 @@ public class ProductConfigurationTest {
 
         Map<String, InstallMode> modes = getInstallModes(config);
 
-        assertThat(modes.get("org.eclipse.rcp"), is(InstallMode.include));
-        assertThat(modes.get("org.eclipse.e4.rcp"), is(InstallMode.include));
-        assertThat(modes.size(), is(2));
+        assertEquals(InstallMode.include, modes.get("org.eclipse.rcp"));
+        assertEquals(InstallMode.include, modes.get("org.eclipse.e4.rcp"));
+        assertEquals(2, modes.size());
     }
 
     private static Map<String, InstallMode> getInstallModes(ProductConfiguration config) {

--- a/tycho-p2/tycho-p2-director-plugin/src/test/java/org/eclipse/tycho/plugins/p2/director/ProfileNameTest.java
+++ b/tycho-p2/tycho-p2-director-plugin/src/test/java/org/eclipse/tycho/plugins/p2/director/ProfileNameTest.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.tycho.plugins.p2.director;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
@@ -35,7 +33,7 @@ public class ProfileNameTest {
 
     @Test
     public void testNoEnvironmentSpecificNames() throws Exception {
-        assertThat(DEFAULT_NAME, is(ProfileName.getNameForEnvironment(LINUX_GTK_X86_64, null, DEFAULT_NAME)));
+        assertEquals(DEFAULT_NAME, ProfileName.getNameForEnvironment(LINUX_GTK_X86_64, null, DEFAULT_NAME));
     }
 
     @Test

--- a/tycho-p2/tycho-p2-director-plugin/src/test/java/org/eclipse/tycho/plugins/tar/TarGzArchiverTest.java
+++ b/tycho-p2/tycho-p2-director-plugin/src/test/java/org/eclipse/tycho/plugins/tar/TarGzArchiverTest.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.tycho.plugins.tar;
 
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -86,8 +84,8 @@ public class TarGzArchiverTest {
         archiver.createArchive();
         Map<String, TarArchiveEntry> tarEntries = getTarEntries();
         assertEquals(7, tarEntries.size());
-        assertThat(tarEntries.keySet(), hasItems("dir2/", "dir2/test.txt", "dir2/dir3/", "dir2/dir3/test.sh",
-                "dir2/testPermissions", "dir2/testLastModified", "dir2/testOwnerAndGroupName"));
+        assertTrue(tarEntries.keySet().containsAll(Set.of("dir2/", "dir2/test.txt", "dir2/dir3/", "dir2/dir3/test.sh",
+                "dir2/testPermissions", "dir2/testLastModified", "dir2/testOwnerAndGroupName")));
         TarArchiveEntry dirArchiveEntry = tarEntries.get("dir2/");
         assertTrue(dirArchiveEntry.isDirectory());
         TarArchiveEntry textFileEntry = tarEntries.get("dir2/test.txt");

--- a/tycho-packaging-plugin/src/test/java/org/eclipse/tycho/buildnumber/test/PackageIUMojoTest.java
+++ b/tycho-packaging-plugin/src/test/java/org/eclipse/tycho/buildnumber/test/PackageIUMojoTest.java
@@ -13,10 +13,6 @@
 package org.eclipse.tycho.buildnumber.test;
 
 import static org.eclipse.tycho.test.util.ArchiveContentUtil.getFilesInZip;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
 import java.util.List;
@@ -46,7 +42,7 @@ public class PackageIUMojoTest extends AbstractTychoMojoTestCase {
                 new File(basedir, "src/main/resources").getAbsolutePath());
         mojo.execute();
 
-        assertThat(getFilesInZip(new File(basedir, "target/iuWithPayload-1.0.0.zip")), hasItem("file.txt"));
+		assertTrue(getFilesInZip(new File(basedir, "target/iuWithPayload-1.0.0.zip")).contains("file.txt"));
     }
 
     public void testArtifactWithoutPayload() throws Exception {
@@ -64,9 +60,9 @@ public class PackageIUMojoTest extends AbstractTychoMojoTestCase {
 
         IU iu = IU.loadIU(new File(basedir, "target"));
         Element artifact = iu.getSelfArtifact();
-        assertThat(artifact, nullValue());
+		assertNull(artifact);
 
-        assertThat(new File(basedir, "target/iuWithoutPayload-1.0.0.zip").exists(), is(true));
+		assertTrue(new File(basedir, "target/iuWithoutPayload-1.0.0.zip").exists());
     }
 
     public void testInjectArtifactReference() throws Exception {
@@ -87,8 +83,8 @@ public class PackageIUMojoTest extends AbstractTychoMojoTestCase {
         IU iu = IU.loadIU(new File(basedir, "target"));
         Element artifact = iu.getSelfArtifact();
         assertNotNull(artifact);
-        assertThat(artifact.getAttributeValue("classifier"), is("binary"));
-        assertThat(artifact.getAttributeValue("id"), is("iuWithPayloadButNoArtifactReference"));
-        assertThat(artifact.getAttributeValue("version"), is("1.0.0"));
+		assertEquals("binary", artifact.getAttributeValue("classifier"));
+		assertEquals("iuWithPayloadButNoArtifactReference", artifact.getAttributeValue("id"));
+		assertEquals("1.0.0", artifact.getAttributeValue("version"));
     }
 }

--- a/tycho-packaging-plugin/src/test/java/org/eclipse/tycho/buildversion/BuildQualifierTest.java
+++ b/tycho-packaging-plugin/src/test/java/org/eclipse/tycho/buildversion/BuildQualifierTest.java
@@ -12,9 +12,6 @@
  *******************************************************************************/
 package org.eclipse.tycho.buildversion;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
@@ -220,7 +217,7 @@ public class BuildQualifierTest extends AbstractTychoMojoTestCase {
             mojo.execute();
             fail();
         } catch (MojoFailureException e) {
-            assertThat(e.getMessage(), containsString("Invalid build qualifier"));
+			assertTrue(e.getMessage().contains("Invalid build qualifier"));
         }
     }
 
@@ -232,7 +229,7 @@ public class BuildQualifierTest extends AbstractTychoMojoTestCase {
             mojo.execute();
             fail();
         } catch (MojoFailureException e) {
-            assertThat(e.getMessage(), containsString("Invalid build qualifier"));
+			assertTrue(e.getMessage().contains("Invalid build qualifier"));
         }
     }
 
@@ -244,7 +241,7 @@ public class BuildQualifierTest extends AbstractTychoMojoTestCase {
             mojo.execute();
             fail();
         } catch (MojoFailureException e) {
-            assertThat(e.getMessage(), containsString("This qualifier should be in error message"));
+			assertTrue(e.getMessage().contains("This qualifier should be in error message"));
         }
     }
 

--- a/tycho-release/tycho-versions-plugin/pom.xml
+++ b/tycho-release/tycho-versions-plugin/pom.xml
@@ -42,8 +42,6 @@
 			<groupId>de.pdark</groupId>
 			<artifactId>decentxml</artifactId>
 		</dependency>
-
-
 		<dependency>
 			<groupId>org.eclipse.tycho</groupId>
 			<artifactId>tycho-core</artifactId>

--- a/tycho-release/tycho-versions-plugin/src/test/java/org/eclipse/tycho/versions/pom/tests/MutablePomFileTest.java
+++ b/tycho-release/tycho-versions-plugin/src/test/java/org/eclipse/tycho/versions/pom/tests/MutablePomFileTest.java
@@ -13,8 +13,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.versions.pom.tests;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -24,7 +23,6 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
 import org.eclipse.tycho.versions.pom.PomFile;
-import org.junit.Assert;
 import org.junit.Test;
 
 import de.pdark.decentxml.XMLParseException;
@@ -37,19 +35,19 @@ public class MutablePomFileTest {
     public void testWhitespacesInValuesAreIgnored() throws Exception {
         subject = getPom("/poms/whitespaceInElementText.xml");
 
-        assertThat(subject.getParent().getGroupId(), is("ignorewhitespace"));
-        assertThat(subject.getParent().getArtifactId(), is("parent"));
-        assertThat(subject.getParent().getVersion(), is("1.0.0-SNAPSHOT"));
-        assertThat(subject.getParentVersion(), is("1.0.0-SNAPSHOT"));
-        assertThat(subject.getGroupId(), is("without.space"));
-        assertThat(subject.getArtifactId(), is("bundle"));
-        assertThat(subject.getVersion(), is("1.0.1-SNAPSHOT"));
-        assertThat(subject.getPackaging(), is("pom"));
+        assertEquals("ignorewhitespace", subject.getParent().getGroupId());
+        assertEquals("parent", subject.getParent().getArtifactId());
+        assertEquals("1.0.0-SNAPSHOT", subject.getParent().getVersion());
+        assertEquals("1.0.0-SNAPSHOT", subject.getParentVersion());
+        assertEquals("without.space", subject.getGroupId());
+        assertEquals("bundle", subject.getArtifactId());
+        assertEquals("1.0.1-SNAPSHOT", subject.getVersion());
+        assertEquals("pom", subject.getPackaging());
 
-        assertThat(subject.getModules().get(0), is("child"));
-        assertThat(subject.getProfiles().get(0).getModules().get(0), is("profileChild"));
+        assertEquals("child", subject.getModules().get(0));
+        assertEquals("profileChild", subject.getProfiles().get(0).getModules().get(0));
 
-        assertThat(subject.getProperties().get(0).getValue(), is("value-without-space"));
+        assertEquals("value-without-space", subject.getProperties().get(0).getValue());
     }
 
     public void testSetVersion() throws Exception {
@@ -68,65 +66,65 @@ public class MutablePomFileTest {
     @Test
     public void testSetExplicitVersion() throws Exception {
         subject = getPom("/poms/inheritedVersion.xml");
-        assertThat(subject.getParentVersion(), is("1.0.2"));
-        assertThat(subject.getVersion(), is("1.0.2"));
+        assertEquals("1.0.2", subject.getParentVersion());
+        assertEquals("1.0.2", subject.getVersion());
 
         subject.setVersion("1.1.0-SNAPSHOT");
 
-        assertThat(subject.getVersion(), is("1.1.0-SNAPSHOT"));
+        assertEquals("1.1.0-SNAPSHOT", subject.getVersion());
         assertContent(subject, "/poms/inheritedVersion_changedProjectVersion.xml");
     }
 
     @Test
     public void testSetParentVersionDoesNotChangeEffectiveVersionOfChild() throws Exception {
         subject = getPom("/poms/inheritedVersion.xml");
-        assertThat(subject.getParentVersion(), is("1.0.2"));
-        assertThat(subject.getVersion(), is("1.0.2"));
+        assertEquals("1.0.2", subject.getParentVersion());
+        assertEquals("1.0.2", subject.getVersion());
 
         subject.setParentVersion("3.0.0");
 
-        assertThat(subject.getParentVersion(), is("3.0.0"));
-        assertThat(subject.getVersion(), is("1.0.2"));
+        assertEquals("3.0.0", subject.getParentVersion());
+        assertEquals("1.0.2", subject.getVersion());
         assertContent(subject, "/poms/inheritedVersion_changedParentVersion.xml");
     }
 
     @Test
     public void testSetVersionDoesNotIntroduceRedundantVersions() throws Exception {
         subject = getPom("/poms/inheritedVersion.xml");
-        assertThat(subject.getParentVersion(), is("1.0.2"));
-        assertThat(subject.getVersion(), is("1.0.2"));
+        assertEquals("1.0.2", subject.getParentVersion());
+        assertEquals("1.0.2", subject.getVersion());
 
         subject.setVersion("3.0.0");
         subject.setParentVersion("3.0.0");
 
-        assertThat(subject.getVersion(), is("3.0.0"));
-        assertThat(subject.getParentVersion(), is("3.0.0"));
+        assertEquals("3.0.0", subject.getVersion());
+        assertEquals("3.0.0", subject.getParentVersion());
         assertContent(subject, "/poms/inheritedVersion_changedBothVersions.xml");
     }
 
     @Test
     public void testSetVersionPreservesRedundantVersion() throws Exception {
         subject = getPom("/poms/inheritedVersionRedundant.xml");
-        assertThat(subject.getParentVersion(), is("1.0.2"));
-        assertThat(subject.getVersion(), is("1.0.2")); // project.version is stated explicitly in the POM, although it could be inherited
+        assertEquals("1.0.2", subject.getParentVersion());
+        assertEquals("1.0.2", subject.getVersion()); // project.version is stated explicitly in the POM, although it could be inherited
 
         subject.setVersion("3.0.0");
         subject.setParentVersion("3.0.0");
 
-        assertThat(subject.getVersion(), is("3.0.0"));
-        assertThat(subject.getParentVersion(), is("3.0.0"));
+        assertEquals("3.0.0", subject.getVersion());
+        assertEquals("3.0.0", subject.getParentVersion());
         assertContent(subject, "/poms/inheritedVersionRedundant_changedBothVersions.xml"); // project.version tag still exists
     }
 
     @Test
     public void testSetVersionPrefersNonRedundantVersionDeclarationIfVersionsWereDifferent() throws Exception {
         subject = getPom("/poms/inheritedVersion_changedProjectVersion.xml");
-        assertThat(subject.getParentVersion(), is("1.0.2"));
-        assertThat(subject.getVersion(), is("1.1.0-SNAPSHOT"));
+        assertEquals("1.0.2", subject.getParentVersion());
+        assertEquals("1.1.0-SNAPSHOT", subject.getVersion());
 
         subject.setVersion("1.0.2");
 
-        assertThat(subject.getVersion(), is("1.0.2"));
+        assertEquals("1.0.2", subject.getVersion());
         assertContent(subject, "/poms/inheritedVersion.xml"); // no project.version tag
     }
 
@@ -145,7 +143,7 @@ public class MutablePomFileTest {
             pomFile = new File(url.toURI());
             PomFile.read(pomFile, true);
         } catch (Exception pe) {
-            Assert.assertEquals("This Pom " + pomFile.getAbsolutePath() + " is in the Wrong Format", pe.getMessage());
+            assertEquals("This Pom " + pomFile.getAbsolutePath() + " is in the Wrong Format", pe.getMessage());
             throw pe;
         }
     }
@@ -162,15 +160,13 @@ public class MutablePomFileTest {
         PomFile.write(pom, buf);
         byte[] actual = buf.toByteArray();
 
-        Assert.assertEquals(toAsciiStringWithoutLineFeeds(expected), toAsciiStringWithoutLineFeeds(actual));
+        assertEquals(toAsciiStringWithoutLineFeeds(expected), toAsciiStringWithoutLineFeeds(actual));
     }
 
     private static byte[] toByteArray(String path) throws IOException {
-        byte expected[];
         try (InputStream is = MutablePomFileTest.class.getResourceAsStream(path)) {
-            expected = is.readAllBytes();
+            return is.readAllBytes();
         }
-        return expected;
     }
 
     private static String toAsciiStringWithoutLineFeeds(byte[] bytes) {

--- a/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/TestMojoTest.java
+++ b/tycho-surefire/tycho-surefire-plugin/src/test/java/org/eclipse/tycho/surefire/TestMojoTest.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.tycho.surefire;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -64,7 +62,7 @@ public class TestMojoTest {
             testMojo.splitArgLine("\"'missing closing double-quote'");
             fail("unreachable code");
         } catch (MojoExecutionException e) {
-            assertThat(e.getMessage(), containsString("unbalanced quotes"));
+            assertTrue(e.getMessage().contains("unbalanced quotes"));
         }
     }
 

--- a/tycho-testing-harness/src/main/java/org/eclipse/tycho/test/util/TychoMatchers.java
+++ b/tycho-testing-harness/src/main/java/org/eclipse/tycho/test/util/TychoMatchers.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.util;
 
-import java.io.File;
-import java.util.Collection;
 import java.util.List;
 
 import org.hamcrest.CoreMatchers;
@@ -65,59 +63,4 @@ public class TychoMatchers {
         };
     }
 
-    /**
-     * Creates a matcher matching any collection with the given size.
-     * 
-     * @see CoreMatchers#hasItem(Matcher)
-     */
-    public static <T> Matcher<Collection<? extends T>> hasSize(final int size) {
-        return new TypeSafeMatcher<Collection<? extends T>>() {
-
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("a collection with size " + size);
-            }
-
-            @Override
-            protected boolean matchesSafely(Collection<? extends T> item) {
-                return item.size() == size;
-            }
-        };
-    }
-
-    /**
-     * Returns a matcher matching any existing file or directory.
-     */
-    public static Matcher<File> exists() {
-        return new TypeSafeMatcher<File>() {
-
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("an existing file or directory");
-            }
-
-            @Override
-            public boolean matchesSafely(File item) {
-                return item.exists();
-            }
-        };
-    }
-
-    /**
-     * Returns a matcher matching any existing, regular file.
-     */
-    public static Matcher<File> isFile() {
-        return new TypeSafeMatcher<File>() {
-
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("an existing file");
-            }
-
-            @Override
-            public boolean matchesSafely(File item) {
-                return item.isFile();
-            }
-        };
-    }
 }

--- a/tycho-testing-harness/src/main/java/org/eclipse/tycho/testing/TestUtil.java
+++ b/tycho-testing-harness/src/main/java/org/eclipse/tycho/testing/TestUtil.java
@@ -12,8 +12,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.testing;
 
-import static org.eclipse.tycho.test.util.TychoMatchers.exists;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,7 +24,7 @@ public class TestUtil {
 
     public static File getTestResourceLocation(String name) throws IOException {
         File src = new File(PlexusTestCase.getBasedir(), "src/test/resources/" + name);
-        assertThat(src, exists());
+        assertTrue(src.exists());
         return src;
     }
 


### PR DESCRIPTION
Most of the hamcrest usages are just complicating things e.g.
assertThat(object, is(not(nullValue())) instead of
assertNotNull(object).
In addition to that we have a mix of hamcrest 1.x and 2.x due to junit
4/5 mixture.
Extra points for less dependencies in some projects.
This doesn't remove all hamcrest usages possible but the patch is big
enough already so trying to deliver it now.