### PR TITLE
Another round of hamcrest usage removal.

### DIFF
--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/local/GAVArtifactDescriptorTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/local/GAVArtifactDescriptorTest.java
@@ -12,10 +12,8 @@
  *******************************************************************************/
 package org.eclipse.tycho.repository.local;
 
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import org.eclipse.equinox.internal.p2.metadata.ArtifactKey;
 import org.eclipse.equinox.p2.metadata.IArtifactKey;
@@ -46,17 +44,17 @@ public class GAVArtifactDescriptorTest {
                 OTHER_EXTENSION);
         subject = new GAVArtifactDescriptor(createP2Descriptor(), coordinates);
 
-        assertThat(subject.getArtifactKey(), is(TEST_KEY));
-        assertThat(subject.getMavenCoordinates(), is(coordinates));
+        assertEquals(TEST_KEY, subject.getArtifactKey());
+        assertEquals(coordinates, subject.getMavenCoordinates());
     }
 
     @Test
     public void testCreationFromP2Key() {
         subject = new GAVArtifactDescriptor(TEST_KEY);
 
-        assertThat(subject.getArtifactKey(), is(TEST_KEY));
-        assertThat(subject.getMavenCoordinates(), is(new MavenRepositoryCoordinates("p2.p2.class", "p2.id",
-                "4.3.0.20130614", DEFAULT_CLASSIFIER, DEFAULT_EXTENSION)));
+        assertEquals(TEST_KEY, subject.getArtifactKey());
+        assertEquals(new MavenRepositoryCoordinates("p2.p2.class", "p2.id", "4.3.0.20130614", DEFAULT_CLASSIFIER,
+                DEFAULT_EXTENSION), subject.getMavenCoordinates());
     }
 
     @Test
@@ -65,9 +63,9 @@ public class GAVArtifactDescriptorTest {
         // no maven properties set
         subject = new GAVArtifactDescriptor(input);
 
-        assertThat(subject.getArtifactKey(), is(TEST_KEY));
-        assertThat(subject.getMavenCoordinates(), is(new MavenRepositoryCoordinates("p2.p2.class", "p2.id",
-                "4.3.0.20130614", DEFAULT_CLASSIFIER, DEFAULT_EXTENSION)));
+        assertEquals(TEST_KEY, subject.getArtifactKey());
+        assertEquals(new MavenRepositoryCoordinates("p2.p2.class", "p2.id", "4.3.0.20130614", DEFAULT_CLASSIFIER,
+                DEFAULT_EXTENSION), subject.getMavenCoordinates());
     }
 
     @Test
@@ -80,9 +78,9 @@ public class GAVArtifactDescriptorTest {
 
         subject = new GAVArtifactDescriptor(input);
 
-        assertThat(subject.getArtifactKey(), is(TEST_KEY));
-        assertThat(subject.getMavenCoordinates(),
-                is(new MavenRepositoryCoordinates(TEST_GAV, DEFAULT_CLASSIFIER, DEFAULT_EXTENSION)));
+        assertEquals(TEST_KEY, subject.getArtifactKey());
+        assertEquals(new MavenRepositoryCoordinates(TEST_GAV, DEFAULT_CLASSIFIER, DEFAULT_EXTENSION),
+                subject.getMavenCoordinates());
     }
 
     @Test
@@ -94,8 +92,8 @@ public class GAVArtifactDescriptorTest {
 
         subject = new GAVArtifactDescriptor(input);
 
-        assertThat(subject.getMavenCoordinates(),
-                is(new MavenRepositoryCoordinates(TEST_GAV, OTHER_CLASSIFIER, OTHER_EXTENSION)));
+        assertEquals(new MavenRepositoryCoordinates(TEST_GAV, OTHER_CLASSIFIER, OTHER_EXTENSION),
+                subject.getMavenCoordinates());
     }
 
     @Test
@@ -106,8 +104,8 @@ public class GAVArtifactDescriptorTest {
 
         subject = new GAVArtifactDescriptor(input);
 
-        assertThat(subject.getMavenCoordinates(),
-                is(new MavenRepositoryCoordinates(TEST_GAV, DEFAULT_CLASSIFIER, DEFAULT_EXTENSION)));
+        assertEquals(new MavenRepositoryCoordinates(TEST_GAV, DEFAULT_CLASSIFIER, DEFAULT_EXTENSION),
+                subject.getMavenCoordinates());
     }
 
     @Test
@@ -119,8 +117,8 @@ public class GAVArtifactDescriptorTest {
         subject = new GAVArtifactDescriptor(input);
 
         // treated like completely missing properties
-        assertThat(subject.getMavenCoordinates(), is(new MavenRepositoryCoordinates("p2.p2.class", "p2.id",
-                "4.3.0.20130614", DEFAULT_CLASSIFIER, DEFAULT_EXTENSION)));
+        assertEquals(new MavenRepositoryCoordinates("p2.p2.class", "p2.id", "4.3.0.20130614", DEFAULT_CLASSIFIER,
+                DEFAULT_EXTENSION), subject.getMavenCoordinates());
     }
 
     @Test
@@ -131,8 +129,8 @@ public class GAVArtifactDescriptorTest {
 
         subject = serializeAndDeSerialize(original);
 
-        assertThat(subject.getArtifactKey(), is(TEST_KEY));
-        assertThat(subject.getMavenCoordinates(), is(coordinates));
+        assertEquals(TEST_KEY, subject.getArtifactKey());
+        assertEquals(coordinates, subject.getMavenCoordinates());
     }
 
     @Test
@@ -143,8 +141,8 @@ public class GAVArtifactDescriptorTest {
 
         ArtifactDescriptor serialized = new ArtifactDescriptor(subject);
 
-        assertThat(serialized.getProperties().keySet(), not(hasItem("maven-classifier")));
-        assertThat(serialized.getProperties().keySet(), not(hasItem("maven-extension")));
+        assertFalse(serialized.getProperties().keySet().contains("maven-classifier"));
+        assertFalse(serialized.getProperties().keySet().contains("maven-extension"));
     }
 
     @Test
@@ -160,8 +158,8 @@ public class GAVArtifactDescriptorTest {
 
         subject = serializeAndDeSerialize(original);
 
-        assertThat(subject.getArtifactKey(), is(TEST_KEY));
-        assertThat(subject.getMavenCoordinates(), is(explicitCoordinatesWithDefaults));
+        assertEquals(TEST_KEY, subject.getArtifactKey());
+        assertEquals(explicitCoordinatesWithDefaults, subject.getMavenCoordinates());
     }
 
     @Test
@@ -170,13 +168,13 @@ public class GAVArtifactDescriptorTest {
                 OTHER_EXTENSION);
         subject = new GAVArtifactDescriptor(createP2Descriptor(), coordinates);
 
-        assertThat(subject.getMavenCoordinates().getLocalRepositoryPath(new MockMavenContext(null, false, null, null) {
-
-            @Override
-            public String getExtension(String artifactType) {
-                return artifactType;
-            }
-        }), is("mvn/group/mvn.id/4.3.0-SNAPSHOT/mvn.id-4.3.0-SNAPSHOT-mvn.classifier.mvn.fileextension"));
+        assertEquals("mvn/group/mvn.id/4.3.0-SNAPSHOT/mvn.id-4.3.0-SNAPSHOT-mvn.classifier.mvn.fileextension",
+                subject.getMavenCoordinates().getLocalRepositoryPath(new MockMavenContext(null, false, null, null) {
+                    @Override
+                    public String getExtension(String artifactType) {
+                        return artifactType;
+                    }
+                }));
     }
 
     @Test
@@ -185,13 +183,13 @@ public class GAVArtifactDescriptorTest {
                 DEFAULT_EXTENSION);
         subject = new GAVArtifactDescriptor(createP2Descriptor(), coordinates);
 
-        assertThat(subject.getMavenCoordinates().getLocalRepositoryPath(new MockMavenContext(null, false, null, null) {
-
-            @Override
-            public String getExtension(String artifactType) {
-                return "jar";
-            }
-        }), is("mvn/group/mvn.id/4.3.0-SNAPSHOT/mvn.id-4.3.0-SNAPSHOT.jar"));
+        assertEquals("mvn/group/mvn.id/4.3.0-SNAPSHOT/mvn.id-4.3.0-SNAPSHOT.jar",
+                subject.getMavenCoordinates().getLocalRepositoryPath(new MockMavenContext(null, false, null, null) {
+                    @Override
+                    public String getExtension(String artifactType) {
+                        return "jar";
+                    }
+                }));
     }
 
     private static ArtifactDescriptor createP2Descriptor() {

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/local/LocalArtifactRepositoryP2APITest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/local/LocalArtifactRepositoryP2APITest.java
@@ -16,7 +16,6 @@ package org.eclipse.tycho.repository.local;
 import static org.eclipse.tycho.repository.streaming.testutil.ProbeArtifactSink.newArtifactSinkFor;
 import static org.eclipse.tycho.repository.streaming.testutil.ProbeRawArtifactSink.newRawArtifactSinkFor;
 import static org.eclipse.tycho.test.util.StatusMatchers.errorStatus;
-import static org.eclipse.tycho.test.util.StatusMatchers.okStatus;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -174,7 +173,7 @@ public class LocalArtifactRepositoryP2APITest {
 
         assertThat(result, hasItem(ARTIFACT_A_KEY));
         assertThat(result, hasItem(ARTIFACT_B_KEY));
-        assertThat(result, is(ORIGINAL_KEYS));
+        assertEquals(ORIGINAL_KEYS, result);
     }
 
     @Test
@@ -184,7 +183,7 @@ public class LocalArtifactRepositoryP2APITest {
         assertThat(result, hasItem(ARTIFACT_A_DESCRIPTOR_1));
         assertThat(result, hasItem(ARTIFACT_A_DESCRIPTOR_2));
         assertThat(result, hasItem(ARTIFACT_B_DESCRIPTOR));
-        assertThat(result, is(ORIGINAL_DESCRIPTORS));
+        assertEquals(ORIGINAL_DESCRIPTORS, result);
     }
 
     @Test
@@ -266,8 +265,8 @@ public class LocalArtifactRepositoryP2APITest {
     public void testRemoveAll() {
         subject.removeAll();
 
-        assertThat(allKeysIn(subject).size(), is(0));
-        assertThat(allDescriptorsIn(subject).size(), is(0));
+        assertTrue(allKeysIn(subject).isEmpty());
+        assertTrue(allDescriptorsIn(subject).isEmpty());
         assertTotal(-2, -3);
     }
 
@@ -313,8 +312,8 @@ public class LocalArtifactRepositoryP2APITest {
         testSink = newArtifactSinkFor(ARTIFACT_A_KEY);
         status = subject.getArtifact(testSink, null);
 
-        assertThat(status, is(okStatus()));
-        assertThat(testSink.getFilesInZip(), is(ARTIFACT_A_CONTENT));
+        assertTrue(status.isOK());
+        assertEquals(ARTIFACT_A_CONTENT, testSink.getFilesInZip());
     }
 
     @Test
@@ -324,7 +323,7 @@ public class LocalArtifactRepositoryP2APITest {
 
         assertFalse(testSink.writeIsStarted());
         assertThat(status, is(errorStatus()));
-        assertThat(status.getCode(), is(ProvisionException.ARTIFACT_NOT_FOUND));
+        assertEquals(ProvisionException.ARTIFACT_NOT_FOUND, status.getCode());
     }
 
     @Test
@@ -380,8 +379,8 @@ public class LocalArtifactRepositoryP2APITest {
     public void testGetArtifactToStream() throws Exception {
         status = subject.getArtifact(ARTIFACT_A_CANONICAL, testOutputStream, null);
 
-        assertThat(status, is(okStatus()));
-        assertThat(testOutputStream.getFilesInZip(), is(ARTIFACT_A_CONTENT));
+        assertTrue(status.isOK());
+        assertEquals(ARTIFACT_A_CONTENT, testOutputStream.getFilesInZip());
     }
 
     @SuppressWarnings("deprecation")
@@ -389,10 +388,10 @@ public class LocalArtifactRepositoryP2APITest {
     public void testGetNonContainedArtifactToStream() {
         status = subject.getArtifact(OTHER_DESCRIPTOR, testOutputStream, null);
 
-        assertThat(testOutputStream.writtenBytes(), is(0));
+        assertEquals(0, testOutputStream.writtenBytes());
         assertThat(testOutputStream.getStatus(), is(errorStatus())); // from IStateful
         assertThat(status, is(errorStatus()));
-        assertThat(status.getCode(), is(ProvisionException.ARTIFACT_NOT_FOUND));
+        assertEquals(ProvisionException.ARTIFACT_NOT_FOUND, status.getCode());
     }
 
     @Test
@@ -400,8 +399,8 @@ public class LocalArtifactRepositoryP2APITest {
         rawTestSink = newRawArtifactSinkFor(ARTIFACT_A_CANONICAL);
         status = subject.getRawArtifact(rawTestSink, null);
 
-        assertThat(status, is(okStatus()));
-        assertThat(rawTestSink.md5AsHex(), is(ARTIFACT_A_CANONICAL_MD5));
+        assertTrue(status.isOK());
+        assertEquals(ARTIFACT_A_CANONICAL_MD5, rawTestSink.md5AsHex());
     }
 
     @Test
@@ -415,7 +414,7 @@ public class LocalArtifactRepositoryP2APITest {
 
         assertFalse(rawTestSink.writeIsStarted());
         assertThat(status, is(errorStatus()));
-        assertThat(status.getCode(), is(ProvisionException.ARTIFACT_NOT_FOUND));
+        assertEquals(ProvisionException.ARTIFACT_NOT_FOUND, status.getCode());
     }
 
     @Test
@@ -440,8 +439,8 @@ public class LocalArtifactRepositoryP2APITest {
     public void testGetRawArtifactForCanonicalFormatToStream() throws Exception {
         status = subject.getRawArtifact(ARTIFACT_A_CANONICAL, testOutputStream, null);
 
-        assertThat(status, is(okStatus()));
-        assertThat(testOutputStream.md5AsHex(), is(ARTIFACT_A_CANONICAL_MD5));
+        assertTrue(status.isOK());
+        assertEquals(ARTIFACT_A_CANONICAL_MD5, testOutputStream.md5AsHex());
     }
 
     @SuppressWarnings("deprecation")
@@ -452,10 +451,10 @@ public class LocalArtifactRepositoryP2APITest {
         // getRawArtifact does not convert from packed to canonical format
         status = subject.getRawArtifact(ARTIFACT_B_CANONICAL, testOutputStream, null);
 
-        assertThat(testOutputStream.writtenBytes(), is(0));
+        assertEquals(0, testOutputStream.writtenBytes());
         assertThat(testOutputStream.getStatus(), is(errorStatus())); // from IStateful
         assertThat(status, is(errorStatus()));
-        assertThat(status.getCode(), is(ProvisionException.ARTIFACT_NOT_FOUND));
+        assertEquals(ProvisionException.ARTIFACT_NOT_FOUND, status.getCode());
     }
 
     @Test
@@ -466,7 +465,7 @@ public class LocalArtifactRepositoryP2APITest {
 
         assertTrue(subject.contains(NEW_KEY));
         assertTrue(subject.contains(localCanonicalDescriptorFor(NEW_KEY)));
-        assertThat(readSizeOfArtifact(NEW_KEY), is(33));
+        assertEquals(33, readSizeOfArtifact(NEW_KEY));
     }
 
     @Test
@@ -482,7 +481,7 @@ public class LocalArtifactRepositoryP2APITest {
         }
 
         assertThat(expectedException, is(instanceOf(ProvisionException.class)));
-        assertThat(expectedException.getStatus().getCode(), is(ProvisionException.ARTIFACT_EXISTS));
+        assertEquals(ProvisionException.ARTIFACT_EXISTS, expectedException.getStatus().getCode());
     }
 
     @Test
@@ -504,7 +503,7 @@ public class LocalArtifactRepositoryP2APITest {
 
         assertTrue(subject.contains(NEW_KEY));
         assertTrue(subject.contains(localCanonicalDescriptorFor(NEW_KEY)));
-        assertThat(readSizeOfArtifact(NEW_KEY), is(22));
+        assertEquals(22, readSizeOfArtifact(NEW_KEY));
     }
 
     @Test
@@ -515,7 +514,7 @@ public class LocalArtifactRepositoryP2APITest {
 
         assertTrue(subject.contains(NEW_DESCRIPTOR));
         assertTrue(subject.contains(NEW_DESCRIPTOR.getArtifactKey()));
-        assertThat(readSizeOfRawArtifact(NEW_DESCRIPTOR), is(33));
+        assertEquals(33, readSizeOfRawArtifact(NEW_DESCRIPTOR));
     }
 
     @SuppressWarnings("deprecation")
@@ -528,7 +527,7 @@ public class LocalArtifactRepositoryP2APITest {
         assertTrue(subject.contains(NEW_KEY));
         assertTrue(subject.contains(NEW_DESCRIPTOR));
         subject.getRawArtifact(NEW_DESCRIPTOR, testOutputStream, null);
-        assertThat(testOutputStream.writtenBytes(), is(33));
+        assertEquals(33, testOutputStream.writtenBytes());
     }
 
     @SuppressWarnings("deprecation")
@@ -543,7 +542,7 @@ public class LocalArtifactRepositoryP2APITest {
         }
 
         assertThat(expectedException, is(instanceOf(ProvisionException.class)));
-        assertThat(expectedException.getStatus().getCode(), is(ProvisionException.ARTIFACT_EXISTS));
+        assertEquals(ProvisionException.ARTIFACT_EXISTS, expectedException.getStatus().getCode());
     }
 
     @SuppressWarnings("deprecation")
@@ -601,8 +600,8 @@ public class LocalArtifactRepositoryP2APITest {
     }
 
     private void assertNoChanges() {
-        assertThat(allKeysIn(subject), is(ORIGINAL_KEYS));
-        assertThat(allDescriptorsIn(subject), is(ORIGINAL_DESCRIPTORS));
+        assertEquals(ORIGINAL_KEYS, allKeysIn(subject));
+        assertEquals(ORIGINAL_DESCRIPTORS, allDescriptorsIn(subject));
     }
 
     private void assertTotal(int keyDiff, int descriptorDiff) {

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/local/LocalArtifactRepositoryTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/local/LocalArtifactRepositoryTest.java
@@ -12,11 +12,9 @@
  *******************************************************************************/
 package org.eclipse.tycho.repository.local;
 
-import static org.eclipse.tycho.test.util.StatusMatchers.okStatus;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -247,7 +245,7 @@ public class LocalArtifactRepositoryTest {
             }
         };
         IStatus status = repo.getArtifacts(new IArtifactRequest[] { errorRequest }, new NullProgressMonitor());
-        assertThat(status, not(okStatus()));
+        assertFalse(status.isOK());
     }
 
     @Test

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/local/MirroringArtifactProviderErrorTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/local/MirroringArtifactProviderErrorTest.java
@@ -14,8 +14,7 @@ package org.eclipse.tycho.repository.local;
 
 import static java.util.Collections.singletonList;
 import static org.eclipse.tycho.repository.streaming.testutil.ProbeArtifactSink.newArtifactSinkFor;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 import org.eclipse.equinox.p2.metadata.IArtifactKey;
@@ -74,7 +73,7 @@ public class MirroringArtifactProviderErrorTest {
     }
 
     private void assertNotMirrored(IArtifactKey key) {
-        assertThat(localRepository.getArtifactDescriptors(key).length, is(0));
+        assertEquals(0, localRepository.getArtifactDescriptors(key).length);
     }
 
 }

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/local/MirroringArtifactProviderTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/local/MirroringArtifactProviderTest.java
@@ -16,12 +16,9 @@ import static org.eclipse.tycho.repository.streaming.testutil.ProbeArtifactSink.
 import static org.eclipse.tycho.repository.streaming.testutil.ProbeRawArtifactSink.newRawArtifactSinkFor;
 import static org.eclipse.tycho.repository.testutil.ArtifactRepositoryTestUtils.ANY_ARTIFACT_KEY_QUERY;
 import static org.eclipse.tycho.repository.testutil.ArtifactRepositoryTestUtils.canonicalDescriptorFor;
-import static org.eclipse.tycho.test.util.StatusMatchers.errorStatus;
-import static org.eclipse.tycho.test.util.StatusMatchers.okStatus;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -136,7 +133,7 @@ public class MirroringArtifactProviderTest {
     @Test
     public void testQuery() {
         IQueryResult<IArtifactKey> result = subject.query(ANY_ARTIFACT_KEY_QUERY, null);
-        assertThat(result.toSet().size(), is(3));
+        assertEquals(3, result.toSet().size());
 
         assertNotMirrored(BUNDLE_A_KEY);
     }
@@ -148,8 +145,8 @@ public class MirroringArtifactProviderTest {
         testSink = newArtifactSinkFor(BUNDLE_L_KEY);
         status = subject.getArtifact(testSink, null);
 
-        assertThat(status, okStatus());
-        assertThat(testSink.getFilesInZip(), is(BUNDLE_L_CONTENT_FILES));
+        assertTrue(status.isOK());
+        assertEquals(BUNDLE_L_CONTENT_FILES, testSink.getFilesInZip());
     }
 
     @Test
@@ -158,8 +155,8 @@ public class MirroringArtifactProviderTest {
         status = subject.getArtifact(testSink, null);
 
         assertFalse(testSink.writeIsStarted());
-        assertThat(status, is(errorStatus()));
-        assertThat(status.getCode(), is(ProvisionException.ARTIFACT_NOT_FOUND));
+        assertEquals(IStatus.ERROR, status.getSeverity());
+        assertEquals(ProvisionException.ARTIFACT_NOT_FOUND, status.getCode());
     }
 
     // TODO set up a test which uses a Jetty server?
@@ -176,14 +173,14 @@ public class MirroringArtifactProviderTest {
 
     @Test
     public void testGetAlreadyMirroredArtifactFile() {
-        assertThat(subject.getArtifactFile(BUNDLE_L_KEY),
-                is(new File(localRepositoryRoot, localRepoPathOf(BUNDLE_L_KEY))));
+        assertEquals(new File(localRepositoryRoot, localRepoPathOf(BUNDLE_L_KEY)),
+                subject.getArtifactFile(BUNDLE_L_KEY));
     }
 
     @Test
     public void testGetArtifactFile() {
-        assertThat(subject.getArtifactFile(BUNDLE_A_KEY),
-                is(new File(localRepositoryRoot, localRepoPathOf(BUNDLE_A_KEY))));
+        assertEquals(new File(localRepositoryRoot, localRepoPathOf(BUNDLE_A_KEY)),
+                subject.getArtifactFile(BUNDLE_A_KEY));
 
         assertMirrored(BUNDLE_A_KEY);
     }
@@ -195,7 +192,7 @@ public class MirroringArtifactProviderTest {
 
     @Test
     public void testGetArtifactDescriptorsOfUnavailableArtifact() {
-        assertThat(subject.getArtifactDescriptors(OTHER_KEY).length, is(0));
+        assertEquals(0, subject.getArtifactDescriptors(OTHER_KEY).length);
     }
 
     @Test
@@ -213,8 +210,8 @@ public class MirroringArtifactProviderTest {
     @Test
     public void testGetRawCanonicalArtifactFile() {
         // the getArtifactFile method that takes a descriptor returns the raw file
-        assertThat(subject.getArtifactFile(canonicalDescriptorFor(BUNDLE_A_KEY)),
-                is(new File(localRepositoryRoot, localRepoPathOf(BUNDLE_A_KEY))));
+        assertEquals(new File(localRepositoryRoot, localRepoPathOf(BUNDLE_A_KEY)),
+                subject.getArtifactFile(canonicalDescriptorFor(BUNDLE_A_KEY)));
 
         assertMirrored(BUNDLE_A_KEY);
     }
@@ -230,16 +227,16 @@ public class MirroringArtifactProviderTest {
         status = subject.getRawArtifact(rawTestSink, null);
 
         assertFalse(rawTestSink.writeIsStarted());
-        assertThat(status, is(errorStatus()));
-        assertThat(status.getCode(), is(ProvisionException.ARTIFACT_NOT_FOUND));
+        assertEquals(IStatus.ERROR, status.getSeverity());
+        assertEquals(ProvisionException.ARTIFACT_NOT_FOUND, status.getCode());
     }
 
     private void assertNotMirrored(IArtifactKey key) {
-        assertThat(localRepository.getArtifactDescriptors(key).length, is(0));
+        assertEquals(0, localRepository.getArtifactDescriptors(key).length);
     }
 
     private void assertMirrored(IArtifactKey key) {
-        assertThat(localRepository.getArtifactDescriptors(key).length, not(is(0)));
+        assertNotEquals(0, localRepository.getArtifactDescriptors(key).length);
     }
 
     private static String localRepoPathOf(IArtifactKey key) {

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/module/ModuleArtifactRepositoryTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/module/ModuleArtifactRepositoryTest.java
@@ -14,7 +14,6 @@ package org.eclipse.tycho.repository.module;
 
 import static org.eclipse.tycho.repository.testutil.ArtifactRepositoryTestUtils.allKeysIn;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -85,15 +84,15 @@ public class ModuleArtifactRepositoryTest {
     public void testLoadRepository() throws Exception {
         subject = ModuleArtifactRepository.restoreInstance(null, existingModuleDir);
 
-        assertThat(artifactSizeOf(BUNDLE_ARTIFACT_KEY, subject), is(BUNDLE_ARTIFACT_SIZE));
-        assertThat(artifactSizeOf(SOURCE_ARTIFACT_KEY, subject), is(SOURCE_ARTIFACT_SIZE));
+        assertEquals(BUNDLE_ARTIFACT_SIZE, artifactSizeOf(BUNDLE_ARTIFACT_KEY, subject));
+        assertEquals(SOURCE_ARTIFACT_SIZE, artifactSizeOf(SOURCE_ARTIFACT_KEY, subject));
     }
 
     @Test
     public void testLoadRepositoryWithFactory() throws Exception {
         subject = (ModuleArtifactRepository) loadRepositoryViaAgent(existingModuleDir);
 
-        assertThat(subject.getArtifactDescriptors(SOURCE_ARTIFACT_KEY).length, is(1));
+        assertEquals(1, subject.getArtifactDescriptors(SOURCE_ARTIFACT_KEY).length);
     }
 
     @Test(expected = ProvisionException.class)
@@ -105,7 +104,7 @@ public class ModuleArtifactRepositoryTest {
         try {
             subject = (ModuleArtifactRepository) loadRepositoryViaAgent(corruptRepository);
         } catch (ProvisionException e) {
-            assertThat(e.getStatus().getCode(), is(ProvisionException.REPOSITORY_FAILED_READ));
+            assertEquals(ProvisionException.REPOSITORY_FAILED_READ, e.getStatus().getCode());
             assertThat(e.getStatus().getMessage(), containsString("Error while reading repository"));
             assertThat(e.getStatus().getMessage(), containsString("Maven coordinate properties are missing"));
             throw e;
@@ -128,7 +127,7 @@ public class ModuleArtifactRepositoryTest {
         writeAndClose(sink.beginWrite(), BINARY_ARTIFACT_SIZE);
         sink.commitWrite();
 
-        assertThat(artifactSizeOf(BINARY_ARTIFACT_KEY, subject), is(BINARY_ARTIFACT_SIZE));
+        assertEquals(BINARY_ARTIFACT_SIZE, artifactSizeOf(BINARY_ARTIFACT_KEY, subject));
     }
 
     @SuppressWarnings("deprecation")
@@ -139,7 +138,7 @@ public class ModuleArtifactRepositoryTest {
         OutputStream outputStream = subject.getOutputStream(newDescriptor(BINARY_ARTIFACT_KEY));
         writeAndClose(outputStream, BINARY_ARTIFACT_SIZE);
 
-        assertThat(artifactSizeOf(BINARY_ARTIFACT_KEY, subject), is(BINARY_ARTIFACT_SIZE));
+        assertEquals(BINARY_ARTIFACT_SIZE, artifactSizeOf(BINARY_ARTIFACT_KEY, subject));
     }
 
     @Test
@@ -148,7 +147,7 @@ public class ModuleArtifactRepositoryTest {
         subject = ModuleArtifactRepository.createInstance(null, repoDir);
 
         IArtifactRepository result = loadRepositoryViaAgent(repoDir);
-        assertThat(allKeysIn(result).size(), is(0));
+        assertTrue(allKeysIn(result).isEmpty());
     }
 
     @Test
@@ -161,7 +160,7 @@ public class ModuleArtifactRepositoryTest {
         writeAndClose(outputStream, BINARY_ARTIFACT_SIZE);
 
         IArtifactRepository result = loadRepositoryViaAgent(repoDir);
-        assertThat(artifactSizeOf(BINARY_ARTIFACT_KEY, result), is(BINARY_ARTIFACT_SIZE));
+        assertEquals(BINARY_ARTIFACT_SIZE, artifactSizeOf(BINARY_ARTIFACT_KEY, result));
     }
 
     @Test

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/module/ModuleMetadataRepositoryTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/module/ModuleMetadataRepositoryTest.java
@@ -13,8 +13,8 @@
 package org.eclipse.tycho.repository.module;
 
 import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -79,7 +79,7 @@ public class ModuleMetadataRepositoryTest {
 
         subject = new ModuleMetadataRepository(null, targetFolder);
 
-        assertThat(unitsIn(subject).size(), is(0));
+        assertTrue(unitsIn(subject).isEmpty());
     }
 
     @Test
@@ -99,7 +99,7 @@ public class ModuleMetadataRepositoryTest {
         subject = new ModuleMetadataRepository(null, targetFolder);
 
         IMetadataRepository result = loadRepositoryViaAgent(targetFolder);
-        assertThat(unitsIn(result).size(), is(0));
+        assertTrue(unitsIn(result).isEmpty());
     }
 
     @Test

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/module/PublishingRepositoryTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/module/PublishingRepositoryTest.java
@@ -14,12 +14,12 @@ package org.eclipse.tycho.repository.module;
 
 import static org.eclipse.tycho.repository.module.ModuleArtifactRepositoryTest.writeAndClose;
 import static org.eclipse.tycho.repository.testutil.ArtifactRepositoryTestUtils.allKeysIn;
-import static org.eclipse.tycho.test.util.TychoMatchers.isFile;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -74,7 +74,7 @@ public class PublishingRepositoryTest {
         assertThat(artifacts.keySet(), hasItem("p2artifacts"));
 
         for (File artifactFile : artifacts.values()) {
-            assertThat(artifactFile, isFile());
+            assertTrue(artifactFile.isFile());
         }
 
         // file name extension is used when attaching the artifacts
@@ -92,7 +92,7 @@ public class PublishingRepositoryTest {
         assertThat(artifacts.keySet(), hasItem("p2artifacts"));
 
         for (File artifactFile : artifacts.values()) {
-            assertThat(artifactFile, isFile());
+            assertTrue(artifactFile.isFile());
         }
     }
 
@@ -105,12 +105,12 @@ public class PublishingRepositoryTest {
         assertThat(allKeysIn(artifactRepo), hasItem(AttachedTestArtifact.key));
 
         IArtifactDescriptor[] descriptors = artifactRepo.getArtifactDescriptors(AttachedTestArtifact.key);
-        assertThat(descriptors.length, is(1));
+        assertEquals(1, descriptors.length);
         Map<String, String> props = descriptors[0].getProperties();
-        assertThat(props.get(TychoConstants.PROP_GROUP_ID), is(project.getGroupId()));
-        assertThat(props.get(TychoConstants.PROP_ARTIFACT_ID), is(project.getArtifactId()));
-        assertThat(props.get(TychoConstants.PROP_VERSION), is(project.getVersion()));
-        assertThat(props.get(TychoConstants.PROP_CLASSIFIER), is(AttachedTestArtifact.classifier));
+        assertEquals(project.getGroupId(), props.get(TychoConstants.PROP_GROUP_ID));
+        assertEquals(project.getArtifactId(), props.get(TychoConstants.PROP_ARTIFACT_ID));
+        assertEquals(project.getVersion(), props.get(TychoConstants.PROP_VERSION));
+        assertEquals(AttachedTestArtifact.classifier, props.get(TychoConstants.PROP_CLASSIFIER));
     }
 
     private static void insertTestArtifact(PublishingRepository publishingRepo) throws ProvisionException, IOException {

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/p2base/artifact/provider/CompositeArtifactProviderTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/p2base/artifact/provider/CompositeArtifactProviderTest.java
@@ -13,8 +13,7 @@
 package org.eclipse.tycho.repository.p2base.artifact.provider;
 
 import static org.eclipse.tycho.p2.maven.repository.tests.TestRepositoryContent.BUNDLE_A_KEY;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.net.URI;
@@ -51,7 +50,7 @@ public class CompositeArtifactProviderTest extends CompositeArtifactProviderTest
     public void testGetArtifactFile() {
         File result = subject.getArtifactFile(BUNDLE_A_KEY);
 
-        assertThat(result, is(artifactInLocalRepo(BUNDLE_A_KEY, TestRepositoryContent.REPO_BUNDLE_A, ".jar")));
+        assertEquals(artifactInLocalRepo(BUNDLE_A_KEY, TestRepositoryContent.REPO_BUNDLE_A, ".jar"), result);
     }
 
     private static File artifactInLocalRepo(IArtifactKey key, URI localRepository, String extension) {

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/p2base/artifact/provider/CompositeArtifactProviderTestBase.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/p2base/artifact/provider/CompositeArtifactProviderTestBase.java
@@ -35,6 +35,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -114,7 +115,7 @@ public abstract class CompositeArtifactProviderTestBase<T extends IRawArtifactPr
     @Test
     public void testQuery() {
         IQueryResult<IArtifactKey> result = subject.query(ANY_ARTIFACT_KEY_QUERY, null);
-        assertThat(result.toSet().size(), is(2));
+        assertEquals(2, result.toSet().size());
     }
 
     @Test
@@ -122,7 +123,7 @@ public abstract class CompositeArtifactProviderTestBase<T extends IRawArtifactPr
         subject = createCompositeArtifactProvider(REPO_BUNDLE_A);
 
         IQueryResult<IArtifactKey> result = subject.query(ANY_ARTIFACT_KEY_QUERY, null);
-        assertThat(result.toSet().size(), is(1));
+        assertEquals(1, result.toSet().size());
     }
 
     @Test
@@ -130,7 +131,7 @@ public abstract class CompositeArtifactProviderTestBase<T extends IRawArtifactPr
         subject = createCompositeArtifactProvider(new URI[0]);
 
         IQueryResult<IArtifactKey> result = subject.query(ANY_ARTIFACT_KEY_QUERY, null);
-        assertThat(result.toSet().size(), is(0));
+        assertTrue(result.toSet().isEmpty());
     }
 
     @Test
@@ -138,8 +139,8 @@ public abstract class CompositeArtifactProviderTestBase<T extends IRawArtifactPr
         testSink = newArtifactSinkFor(BUNDLE_A_KEY);
         status = subject.getArtifact(testSink, null);
 
-        assertThat(status, okStatus());
-        assertThat(testSink.getFilesInZip(), is(BUNDLE_A_FILES));
+        assertTrue(status.isOK());
+        assertEquals(BUNDLE_A_FILES, testSink.getFilesInZip());
     }
 
     @Test
@@ -149,7 +150,7 @@ public abstract class CompositeArtifactProviderTestBase<T extends IRawArtifactPr
 
         assertFalse(testSink.writeIsStarted());
         assertThat(status, is(errorStatus()));
-        assertThat(status.getCode(), is(ProvisionException.ARTIFACT_NOT_FOUND));
+        assertEquals(ProvisionException.ARTIFACT_NOT_FOUND, status.getCode());
         assertThat(status, statusWithMessageWhich(containsString("is not available in")));
     }
 
@@ -164,7 +165,7 @@ public abstract class CompositeArtifactProviderTestBase<T extends IRawArtifactPr
         assertThat(status.getMessage(), containsString("Some attempts to read"));
         assertThat(asList(status.getChildren()), hasItem(errorStatus()));
         assertThat(asList(status.getChildren()), hasItem(okStatus()));
-        assertThat(testSink.getFilesInZip(), is(BUNDLE_A_FILES));
+        assertEquals(BUNDLE_A_FILES, testSink.getFilesInZip());
     }
 
     @Test
@@ -209,7 +210,7 @@ public abstract class CompositeArtifactProviderTestBase<T extends IRawArtifactPr
 
         assertFalse(rawTestSink.writeIsStarted());
         assertThat(status, is(errorStatus()));
-        assertThat(status.getCode(), is(ProvisionException.ARTIFACT_NOT_FOUND));
+        assertEquals(ProvisionException.ARTIFACT_NOT_FOUND, status.getCode());
         assertThat(status, statusWithMessageWhich(containsString("is not available in")));
     }
 
@@ -219,8 +220,8 @@ public abstract class CompositeArtifactProviderTestBase<T extends IRawArtifactPr
         rawTestSink = new ProbeRawArtifactSink(canonicalDescriptorFor(BUNDLE_A_KEY));
         status = subject.getRawArtifact(rawTestSink, null);
 
-        assertThat(status, is(okStatus()));
-        assertThat(rawTestSink.md5AsHex(), is(BUNDLE_A_CONTENT_MD5));
+        assertTrue(status.isOK());
+        assertEquals(BUNDLE_A_CONTENT_MD5, rawTestSink.md5AsHex());
     }
 
     @Test
@@ -231,7 +232,7 @@ public abstract class CompositeArtifactProviderTestBase<T extends IRawArtifactPr
                 testOutputStream);
         status = subject.getRawArtifact(nonRestartableSink, null);
 
-        assertThat(status, is(okStatus()));
+        assertTrue(status.isOK());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -245,7 +246,7 @@ public abstract class CompositeArtifactProviderTestBase<T extends IRawArtifactPr
         List<IArtifactDescriptor> result = Arrays.asList(subject.getArtifactDescriptors(BUNDLE_A_KEY));
 
         assertThat(result, hasItem(inCanonicalFormat()));
-        assertThat(result.size(), is(2)); // no duplicates
+        assertEquals(2, result.size()); // no duplicates
     }
 
     @Test
@@ -259,7 +260,7 @@ public abstract class CompositeArtifactProviderTestBase<T extends IRawArtifactPr
         rawTestSink = newRawArtifactSinkFor(canonicalDescriptorFor(BUNDLE_A_KEY));
         status = subject.getRawArtifact(rawTestSink, null);
 
-        assertThat(rawTestSink.md5AsHex(), is(BUNDLE_A_CONTENT_MD5)); // raw artifacts are never processed -> files should be identical
+        assertEquals(BUNDLE_A_CONTENT_MD5, rawTestSink.md5AsHex()); // raw artifacts are never processed -> files should be identical
     }
 
 }

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/p2base/artifact/provider/formats/LocalArtifactTransferPolicyTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/p2base/artifact/provider/formats/LocalArtifactTransferPolicyTest.java
@@ -12,13 +12,10 @@
  *******************************************************************************/
 package org.eclipse.tycho.repository.p2base.artifact.provider.formats;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -51,7 +48,7 @@ public class LocalArtifactTransferPolicyTest {
         List<IArtifactDescriptor> result = subject.sortFormatsByPreference(descriptors);
 
         assertNull(result.get(0).getProperty(IArtifactDescriptor.FORMAT));
-        assertThat(formatsOf(result.get(1), result.get(2)), is(asSet("customFormat", "anotherFormat")));
+        assertEquals(Set.of("customFormat", "anotherFormat"), formatsOf(result.get(1), result.get(2)));
         assertEquals(3, result.size());
     }
 
@@ -61,10 +58,6 @@ public class LocalArtifactTransferPolicyTest {
             result.add(descriptor.getProperty(IArtifactDescriptor.FORMAT));
         }
         return result;
-    }
-
-    static Set<String> asSet(String... values) {
-        return new HashSet<>(Arrays.asList(values));
     }
 
     static IArtifactDescriptor[] loadDescriptorsFromRepository(String repository, P2Context p2Context)

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/p2base/artifact/repository/FileRepositoryArtifactProviderTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/p2base/artifact/repository/FileRepositoryArtifactProviderTest.java
@@ -16,8 +16,7 @@ package org.eclipse.tycho.repository.p2base.artifact.repository;
 import static org.eclipse.tycho.p2.maven.repository.tests.TestRepositoryContent.BUNDLE_A_KEY;
 import static org.eclipse.tycho.p2.maven.repository.tests.TestRepositoryContent.REPO_BUNDLE_A;
 import static org.eclipse.tycho.p2.maven.repository.tests.TestRepositoryContent.REPO_BUNDLE_AB;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
 import java.io.File;
@@ -55,7 +54,7 @@ public class FileRepositoryArtifactProviderTest {
     public void testGetArtifactFile() {
         File result = subject.getArtifactFile(BUNDLE_A_KEY);
 
-        assertThat(result, is(artifactInLocalRepo(BUNDLE_A_KEY, TestRepositoryContent.REPO_BUNDLE_A, ".jar")));
+        assertEquals(artifactInLocalRepo(BUNDLE_A_KEY, TestRepositoryContent.REPO_BUNDLE_A, ".jar"), result);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/p2base/artifact/repository/ProviderOnlyArtifactRepositoryTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/p2base/artifact/repository/ProviderOnlyArtifactRepositoryTest.java
@@ -20,10 +20,9 @@ import static org.eclipse.tycho.p2.maven.repository.tests.TestRepositoryContent.
 import static org.eclipse.tycho.p2.maven.repository.tests.TestRepositoryContent.REPO_BUNDLE_AB;
 import static org.eclipse.tycho.p2.maven.repository.tests.TestRepositoryContent.REPO_BUNLDE_AB_PACK_CORRUPT;
 import static org.eclipse.tycho.repository.testutil.ArtifactRepositoryTestUtils.canonicalDescriptorFor;
-import static org.eclipse.tycho.test.util.StatusMatchers.okStatus;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.net.URI;
 
@@ -62,8 +61,8 @@ public class ProviderOnlyArtifactRepositoryTest {
 
         IStatus status = subject.getArtifact(canonicalDescriptorFor(BUNDLE_A_KEY), testOutputStream, null);
 
-        assertThat(status, is(okStatus()));
-        assertThat(testOutputStream.getFilesInZip(), is(BUNDLE_A_FILES));
+        assertTrue(status.isOK());
+        assertEquals(BUNDLE_A_FILES, testOutputStream.getFilesInZip());
     }
 
     @SuppressWarnings("deprecation")
@@ -73,8 +72,8 @@ public class ProviderOnlyArtifactRepositoryTest {
 
         IStatus status = subject.getRawArtifact(canonicalDescriptorFor(BUNDLE_A_KEY), testOutputStream, null);
 
-        assertThat(status, is(okStatus()));
-        assertThat(testOutputStream.md5AsHex(), is(BUNDLE_A_CONTENT_MD5));
+        assertTrue(status.isOK());
+        assertEquals(BUNDLE_A_CONTENT_MD5, testOutputStream.md5AsHex());
     }
 
     @SuppressWarnings("deprecation")
@@ -84,8 +83,8 @@ public class ProviderOnlyArtifactRepositoryTest {
 
         IStatus status = subject.getRawArtifact(canonicalDescriptorFor(BUNDLE_A_KEY), testOutputStream, null);
 
-        assertThat(testOutputStream.getStatus(), is(okStatus()));
-        assertThat(status, is(okStatus()));
+        assertTrue(testOutputStream.getStatus().isOK());
+        assertTrue(status.isOK());
     }
 
     private static ProviderOnlyArtifactRepository createProviderOnlyArtifactRepositoryDelegatingTo(

--- a/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/util/StatusToolTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.maven.repository.tests/src/test/java/org/eclipse/tycho/repository/util/StatusToolTest.java
@@ -13,10 +13,10 @@
 package org.eclipse.tycho.repository.util;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
@@ -30,8 +30,8 @@ public class StatusToolTest {
     public void testSimpleStatus() {
         IStatus status = new Status(IStatus.ERROR, PLUGIN_ID, "Simple error");
 
-        assertThat(StatusTool.toLogMessage(status), is("Simple error"));
-        assertThat(StatusTool.collectProblems(status), is("Simple error"));
+        assertEquals("Simple error", StatusTool.toLogMessage(status));
+        assertEquals("Simple error", StatusTool.collectProblems(status));
         assertNull(StatusTool.findException(status));
     }
 
@@ -40,7 +40,7 @@ public class StatusToolTest {
         Throwable exception = new Exception();
         IStatus status = new Status(IStatus.ERROR, PLUGIN_ID, "Simple error", exception);
 
-        assertThat(StatusTool.findException(status), is(sameInstance(exception)));
+        assertSame(exception, StatusTool.findException(status));
     }
 
     @Test
@@ -54,13 +54,13 @@ public class StatusToolTest {
         MultiStatus status = new MultiStatus(PLUGIN_ID, 0, children, "Complicated error. See children for details.",
                 null);
 
-        assertThat(StatusTool.toLogMessage(status),
-                is("Complicated error. See children for details.:\n   Detail 1\n   Detail 2\n   Detail 3"));
-        assertThat(StatusTool.collectProblems(status),
-                is("Complicated error. See children for details.: [Detail 1; Detail 2; Detail 3]"));
+        assertEquals("Complicated error. See children for details.:\n   Detail 1\n   Detail 2\n   Detail 3",
+                StatusTool.toLogMessage(status));
+        assertEquals("Complicated error. See children for details.: [Detail 1; Detail 2; Detail 3]",
+                StatusTool.collectProblems(status));
 
         // use the first exception found
-        assertThat(StatusTool.findException(status), is(sameInstance(exceptionChild2)));
+        assertSame(exceptionChild2, StatusTool.findException(status));
     }
 
     @Test
@@ -73,7 +73,7 @@ public class StatusToolTest {
         root.add(child);
 
         // prefer root exceptions over child exceptions
-        assertThat(StatusTool.findException(root), is(sameInstance(exceptionRoot)));
+        assertSame(exceptionRoot, StatusTool.findException(root));
     }
 
     @Test
@@ -89,10 +89,10 @@ public class StatusToolTest {
         child2.add(new Status(IStatus.ERROR, PLUGIN_ID, "Child 2.1"));
         root.add(child2);
 
-        assertThat(StatusTool.toLogMessage(root),
-                is("Root message:\n   Child 1:\n      Child 1.1\n      Child 1.2\n   Child 2:\n      Child 2.1"));
-        assertThat(StatusTool.collectProblems(root),
-                is("Root message: [Child 1: [Child 1.1; Child 1.2]; Child 2: [Child 2.1]]"));
+        assertEquals("Root message:\n   Child 1:\n      Child 1.1\n      Child 1.2\n   Child 2:\n      Child 2.1",
+                StatusTool.toLogMessage(root));
+        assertEquals("Root message: [Child 1: [Child 1.1; Child 1.2]; Child 2: [Child 2.1]]",
+                StatusTool.collectProblems(root));
     }
 
     @Test
@@ -103,8 +103,8 @@ public class StatusToolTest {
         IStatus[] children = new IStatus[] { Status.OK_STATUS, info, Status.OK_STATUS, error, warning };
         MultiStatus status = new MultiStatus(PLUGIN_ID, 0, children, "Root message", null);
 
-        assertThat(StatusTool.collectProblems(status),
-                is("Root message: [Info message; Error message; Warning message]"));
+        assertEquals("Root message: [Info message; Error message; Warning message]",
+                StatusTool.collectProblems(status));
     }
 
     @Test

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/resolver/P2ResolverTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/resolver/P2ResolverTest.java
@@ -24,7 +24,6 @@ import static org.eclipse.tycho.p2.target.ExecutionEnvironmentTestUtils.customEE
 import static org.eclipse.tycho.p2.target.ExecutionEnvironmentTestUtils.standardEEResolutionHintProvider;
 import static org.eclipse.tycho.p2.testutil.InstallableUnitMatchers.unitWithId;
 import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -241,7 +240,7 @@ public class P2ResolverTest extends P2ResolverTestBase {
 
         result = singleEnv(impl.resolveTargetDependencies(getTargetPlatform(), projectToResolve));
 
-        assertThat(result.getArtifacts().size(), is(2));
+        assertEquals(2, result.getArtifacts().size());
         assertThat(result.getArtifacts(), hasItem(withId("bundle.nodeps")));
         assertThat(result.getArtifacts(), hasItem(withId("org.eclipse.ui.ide.application")));
     }
@@ -379,7 +378,7 @@ public class P2ResolverTest extends P2ResolverTestBase {
         result = singleEnv(impl.resolveTargetDependencies(
                 getTargetPlatform(customEEResolutionHintProvider("Custom_Profile-2")), projectToResolve));
 
-        assertThat(result.getNonReactorUnits().size(), is(1));
+        assertEquals(1, result.getNonReactorUnits().size());
         assertContainsUnit("a.jre.custom.profile", result.getNonReactorUnits());
         // I don't know why we should expect a config.a.jre.custom.profile IU here
     }
@@ -408,8 +407,8 @@ public class P2ResolverTest extends P2ResolverTestBase {
         Exception e = assertThrows(Exception.class, () -> {
             result = singleEnv(impl.resolveTargetDependencies(getTargetPlatform(), projectToResolve));
             // ... or the p2.inf "artifact" could also just be omitted
-            assertThat(getClassifiedArtifact(result, null).getType(), is(ArtifactType.TYPE_ECLIPSE_FEATURE));
-            assertThat(result.getArtifacts().size(), is(1));
+            assertEquals(ArtifactType.TYPE_ECLIPSE_FEATURE, getClassifiedArtifact(result, null).getType());
+            assertEquals(1, result.getArtifacts().size());
         });
         assertTrue(e.getMessage().contains("classifier"));
 
@@ -422,9 +421,7 @@ public class P2ResolverTest extends P2ResolverTestBase {
                 TYPE_ECLIPSE_FEATURE, "p2Inf.additional-artifact");
         result = singleEnv(impl.resolveTargetDependencies(getTargetPlatform(), projectToResolve));
 
-        assertThat(getClassifiedArtifact(result, null).getType(), is(ArtifactType.TYPE_ECLIPSE_FEATURE));
-        // this is the current behaviour, but the p2.inf "artifact" could also be omitted
-        //assertThat(getClassifiedArtifact(result, "p2inf").getType(), is(ArtifactType.TYPE_ECLIPSE_PLUGIN));
+        assertEquals(ArtifactType.TYPE_ECLIPSE_FEATURE, getClassifiedArtifact(result, null).getType());
     }
 
     @Test

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/PomDependencyCollectorTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/PomDependencyCollectorTest.java
@@ -16,8 +16,9 @@ package org.eclipse.tycho.p2.target;
 
 import static org.eclipse.tycho.p2.testutil.InstallableUnitMatchers.unitWithId;
 import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.util.Collection;
@@ -62,7 +63,7 @@ public class PomDependencyCollectorTest {
 
         Collection<IInstallableUnit> units = (Collection<IInstallableUnit>) subject.getMavenInstallableUnits().keySet();
         assertThat(units, hasItem(unitWithId("test.unit.source")));
-        assertThat(units.size(), is(1));
+        assertEquals(1, units.size());
     }
 
     @Test
@@ -74,7 +75,7 @@ public class PomDependencyCollectorTest {
 
         Collection<IInstallableUnit> units = (Collection<IInstallableUnit>) subject.getMavenInstallableUnits().keySet();
         assertThat(units, hasItem(unitWithId("test.unit")));
-        assertThat(units.size(), is(1));
+        assertEquals(1, units.size());
     }
 
     @Test
@@ -85,7 +86,7 @@ public class PomDependencyCollectorTest {
         subject.addArtifactWithExistingMetadata(artifact, existingMetadata());
 
         Collection<IInstallableUnit> units = (Collection<IInstallableUnit>) subject.getMavenInstallableUnits().keySet();
-        assertThat(units.size(), is(0));
+        assertTrue(units.isEmpty());
     }
 
     static ArtifactMock artifactWithClassifier(String classifier) throws Exception {

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TargetDefinitionResolverIncludeSourceTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TargetDefinitionResolverIncludeSourceTest.java
@@ -17,9 +17,9 @@ import static org.eclipse.tycho.p2.target.TargetDefinitionResolverTest.defaultEn
 import static org.eclipse.tycho.p2.target.TargetDefinitionResolverTest.definitionWith;
 import static org.eclipse.tycho.p2.target.TargetDefinitionResolverTest.versionedIdsOf;
 import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import org.eclipse.equinox.p2.metadata.IVersionedId;
 import org.eclipse.equinox.p2.metadata.VersionedId;
@@ -79,7 +79,7 @@ public class TargetDefinitionResolverIncludeSourceTest {
 
         assertThat(versionedIdsOf(content), hasItem(BUNDLE_WITH_SOURCES));
         assertThat(versionedIdsOf(content), hasItem(SOURCE_BUNDLE));
-        assertThat(content.query(QueryUtil.ALL_UNITS, null).toUnmodifiableSet().size(), is(2));
+        assertEquals(2, content.query(QueryUtil.ALL_UNITS, null).toUnmodifiableSet().size());
     }
 
     @Test
@@ -91,7 +91,7 @@ public class TargetDefinitionResolverIncludeSourceTest {
 
         assertThat(versionedIdsOf(content), hasItem(BUNDLE_WITH_SOURCES));
         assertThat(versionedIdsOf(content), hasItem(SOURCE_BUNDLE));
-        assertThat(content.query(QueryUtil.ALL_UNITS, null).toUnmodifiableSet().size(), is(2));
+        assertEquals(2, content.query(QueryUtil.ALL_UNITS, null).toUnmodifiableSet().size());
     }
 
     @Test
@@ -102,7 +102,7 @@ public class TargetDefinitionResolverIncludeSourceTest {
         TargetDefinitionContent content = subject.resolveContentWithExceptions(definition, p2Context.getAgent());
 
         assertThat(versionedIdsOf(content), not(hasItem(SOURCE_BUNDLE)));
-        assertThat(content.query(QueryUtil.ALL_UNITS, null).toUnmodifiableSet().size(), is(1));
+        assertEquals(1, content.query(QueryUtil.ALL_UNITS, null).toUnmodifiableSet().size());
     }
 
     @Test
@@ -113,7 +113,7 @@ public class TargetDefinitionResolverIncludeSourceTest {
         TargetDefinitionContent content = subject.resolveContentWithExceptions(definition, p2Context.getAgent());
 
         assertThat(versionedIdsOf(content), not(hasItem(SOURCE_BUNDLE)));
-        assertThat(content.query(QueryUtil.ALL_UNITS, null).toUnmodifiableSet().size(), is(1));
+        assertEquals(1, content.query(QueryUtil.ALL_UNITS, null).toUnmodifiableSet().size());
     }
 
     @Test
@@ -126,7 +126,7 @@ public class TargetDefinitionResolverIncludeSourceTest {
         assertThat(versionedIdsOf(content), hasItem(NOSOURCE_BUNDLE));
         assertThat(versionedIdsOf(content), hasItem(BUNDLE_WITH_SOURCES));
         assertThat(versionedIdsOf(content), hasItem(SOURCE_BUNDLE));
-        assertThat(content.query(QueryUtil.ALL_UNITS, null).toUnmodifiableSet().size(), is(3));
+        assertEquals(3, content.query(QueryUtil.ALL_UNITS, null).toUnmodifiableSet().size());
     }
 
     @Test
@@ -139,7 +139,7 @@ public class TargetDefinitionResolverIncludeSourceTest {
         assertThat(versionedIdsOf(content), hasItem(NOSOURCE_BUNDLE));
         assertThat(versionedIdsOf(content), hasItem(BUNDLE_WITH_SOURCES));
         assertThat(versionedIdsOf(content), hasItem(SOURCE_BUNDLE));
-        assertThat(content.query(QueryUtil.ALL_UNITS, null).toUnmodifiableSet().size(), is(3));
+        assertEquals(3, content.query(QueryUtil.ALL_UNITS, null).toUnmodifiableSet().size());
     }
 
     static class WithSourceLocationStub extends LocationStub implements InstallableUnitLocation {

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TargetPlatformBundlePublisherTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TargetPlatformBundlePublisherTest.java
@@ -91,20 +91,20 @@ public class TargetPlatformBundlePublisherTest {
 
         assertThat(publishedUnit, is(unit(bundleId, bundleVersion)));
         assertThat(publishedUnit.getProperties(), containsGAV(GROUP_ID, ARTIFACT_ID, VERSION));
-        assertThat(publishedUnit.getArtifacts().size(), is(1));
+        assertEquals(1, publishedUnit.getArtifacts().size());
 
         IArtifactKey referencedArtifact = publishedUnit.getArtifacts().iterator().next();
         IRawArtifactProvider artifactRepo = subject.getArtifactRepoOfPublishedBundles();
         assertThat(artifactRepo, contains(referencedArtifact));
 
         IArtifactDescriptor[] artifactDescriptors = artifactRepo.getArtifactDescriptors(referencedArtifact);
-        assertThat(artifactDescriptors.length, is(1));
+        assertEquals(1, artifactDescriptors.length);
         assertThat(artifactDescriptors[0].getProperties(), containsGAV(GROUP_ID, ARTIFACT_ID, VERSION));
         assertThat(artifactDescriptors[0].getProperties(),
                 hasProperty("download.md5", "6303323acc98658c0fed307c84db4411"));
 
         // test that reading the artifact succeeds (because the way it is added to the repository is a bit special) 
-        assertThat(artifactMD5Of(referencedArtifact, artifactRepo), is("6303323acc98658c0fed307c84db4411"));
+        assertEquals("6303323acc98658c0fed307c84db4411", artifactMD5Of(referencedArtifact, artifactRepo));
     }
 
     @Test

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TargetPlatformTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/target/TargetPlatformTest.java
@@ -15,8 +15,7 @@ package org.eclipse.tycho.p2.target;
 import static org.eclipse.tycho.p2.testutil.InstallableUnitUtil.createBundleIU;
 import static org.eclipse.tycho.p2.testutil.InstallableUnitUtil.createFeatureIU;
 import static org.eclipse.tycho.p2.testutil.InstallableUnitUtil.createProductIU;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -52,9 +51,9 @@ public class TargetPlatformTest {
     public void testResolveFixedVersion() throws Exception {
         ArtifactKey key = subject.resolveArtifact("eclipse-plugin", "some.bundle", "1.1.0.v2013");
 
-        assertThat(key.getType(), is(ArtifactType.TYPE_ECLIPSE_PLUGIN));
-        assertThat(key.getId(), is("some.bundle"));
-        assertThat(key.getVersion(), is("1.1.0.v2013"));
+        assertEquals(ArtifactType.TYPE_ECLIPSE_PLUGIN, key.getType());
+        assertEquals("some.bundle", key.getId());
+        assertEquals("1.1.0.v2013", key.getVersion());
     }
 
     @Test
@@ -83,7 +82,7 @@ public class TargetPlatformTest {
     public void testResolveLatestVersionThroughZeros() throws Exception {
         ArtifactKey key = subject.resolveArtifact("eclipse-plugin", "some.bundle", "0.0.0");
 
-        assertThat(key.getVersion(), is("1.2.0"));
+        assertEquals("1.2.0", key.getVersion());
     }
 
     @Test
@@ -91,14 +90,14 @@ public class TargetPlatformTest {
         // e.g. when version attribute is omitted
         ArtifactKey key = subject.resolveArtifact("eclipse-plugin", "some.bundle", null);
 
-        assertThat(key.getVersion(), is("1.2.0"));
+        assertEquals("1.2.0", key.getVersion());
     }
 
     @Test
     public void testResolveLatestQualifierWithQualifierLiteral() throws Exception {
         ArtifactKey key = subject.resolveArtifact("eclipse-plugin", "some.bundle", "1.1.0.qualifier");
 
-        assertThat(key.getVersion(), is("1.1.0.v2014"));
+        assertEquals("1.1.0.v2014", key.getVersion());
     }
 
     @Test
@@ -106,7 +105,7 @@ public class TargetPlatformTest {
         ArtifactKey key = subject.resolveArtifact("eclipse-plugin", "some.bundle", "1.1.0");
 
         // three-segment versions don't have a special semantic in the PDE, so 1.1.0 doesn't resolve to 1.1.0.v2014 (cf. bug 373844)
-        assertThat(key.getVersion(), is("1.1.0"));
+        assertEquals("1.1.0", key.getVersion());
     }
 
     @Test
@@ -116,9 +115,9 @@ public class TargetPlatformTest {
 
         ArtifactKey key = subject.resolveArtifact("eclipse-plugin", "unit", ANY_VERSION);
 
-        assertThat(key.getType(), is(ArtifactType.TYPE_ECLIPSE_PLUGIN));
-        assertThat(key.getId(), is("unit"));
-        assertThat(key.getVersion(), is("1.0.0"));
+        assertEquals(ArtifactType.TYPE_ECLIPSE_PLUGIN, key.getType());
+        assertEquals("unit", key.getId());
+        assertEquals("1.0.0", key.getVersion());
     }
 
     @Test
@@ -128,9 +127,9 @@ public class TargetPlatformTest {
 
         ArtifactKey key = subject.resolveArtifact("eclipse-product", "unit", ANY_VERSION);
 
-        assertThat(key.getType(), is(ArtifactType.TYPE_ECLIPSE_PRODUCT));
-        assertThat(key.getId(), is("unit"));
-        assertThat(key.getVersion(), is("1.99.0"));
+        assertEquals(ArtifactType.TYPE_ECLIPSE_PRODUCT, key.getType());
+        assertEquals("unit", key.getId());
+        assertEquals("1.99.0", key.getVersion());
     }
 
     @Test
@@ -140,9 +139,9 @@ public class TargetPlatformTest {
 
         ArtifactKey key = subject.resolveArtifact("p2-installable-unit", "unit", ANY_VERSION);
 
-        assertThat(key.getType(), is(ArtifactType.TYPE_INSTALLABLE_UNIT));
-        assertThat(key.getId(), is("unit"));
-        assertThat(key.getVersion(), is("2.0.0"));
+        assertEquals(ArtifactType.TYPE_INSTALLABLE_UNIT, key.getType());
+        assertEquals("unit", key.getId());
+        assertEquals("2.0.0", key.getVersion());
     }
 
     @Test
@@ -153,9 +152,9 @@ public class TargetPlatformTest {
 
         ArtifactKey key = subject.resolveArtifact("eclipse-feature", "unit", ANY_VERSION);
 
-        assertThat(key.getType(), is(ArtifactType.TYPE_ECLIPSE_FEATURE));
-        assertThat(key.getId(), is("unit")); // id is feature id
-        assertThat(key.getVersion(), is("1.2.0"));
+        assertEquals(ArtifactType.TYPE_ECLIPSE_FEATURE, key.getType());
+        assertEquals("unit", key.getId()); // id is feature id
+        assertEquals("1.2.0", key.getVersion());
     }
 
     @Test

--- a/tycho-bundles/org.eclipse.tycho.p2.tools.tests/src/test/java/org/eclipse/tycho/p2/tools/publisher/PublishProductToolTest.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.tools.tests/src/test/java/org/eclipse/tycho/p2/tools/publisher/PublishProductToolTest.java
@@ -22,8 +22,6 @@ import static org.eclipse.tycho.p2.testutil.InstallableUnitUtil.createBundleIU;
 import static org.eclipse.tycho.p2.testutil.InstallableUnitUtil.createFeatureIU;
 import static org.eclipse.tycho.p2.testutil.MatchingItemFinder.getUnique;
 import static org.eclipse.tycho.p2.tools.test.util.ResourceUtil.resourceFile;
-import static org.eclipse.tycho.test.util.TychoMatchers.hasSize;
-import static org.eclipse.tycho.test.util.TychoMatchers.isFile;
 import static org.hamcrest.CoreMatchers.both;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.endsWith;
@@ -31,7 +29,9 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -61,7 +61,6 @@ import org.eclipse.tycho.repository.publishing.PublishingRepository;
 import org.eclipse.tycho.test.util.LogVerifier;
 import org.eclipse.tycho.test.util.P2Context;
 import org.eclipse.tycho.test.util.ReactorProjectIdentitiesStub;
-import org.eclipse.tycho.test.util.TychoMatchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -115,7 +114,7 @@ public class PublishProductToolTest {
         subject = initPublisher();
         Collection<DependencySeed> seeds = subject.publishProduct(productDefinition, launcherBinaries, FLAVOR);
 
-        assertThat(seeds.size(), is(1));
+        assertEquals(1, seeds.size());
         DependencySeed seed = seeds.iterator().next();
 
         Set<Object> publishedUnits = outputRepository.getInstallableUnits();
@@ -126,7 +125,7 @@ public class PublishProductToolTest {
         // TODO 348586 drop productUid from classifier
         String executableClassifier = "productUid.executable.testws.testos.testarch";
         assertThat(artifactLocations.keySet(), hasItem(executableClassifier));
-        assertThat(artifactLocations.get(executableClassifier), isFile());
+        assertTrue(artifactLocations.get(executableClassifier).isFile());
         assertThat(artifactLocations.get(executableClassifier).toString(), endsWith(".zip"));
     }
 
@@ -137,7 +136,7 @@ public class PublishProductToolTest {
 
         IInstallableUnit unit = getUnit(subject.publishProduct(productDefinition, null, FLAVOR));
 
-        assertThat(unit.getVersion().toString(), is("0.1.0." + QUALIFIER));
+        assertEquals("0.1.0." + QUALIFIER, unit.getVersion().toString());
     }
 
     @Test
@@ -233,7 +232,7 @@ public class PublishProductToolTest {
 
         assertThat(unitsIn(outputRepository), hasItem(unitWithId("extra.iu")));
         IInstallableUnit extraUnit = getUnique(unitWithId("extra.iu"), unitsIn(outputRepository));
-        assertThat(extraUnit.getVersion().toString(), is("1.2.3." + QUALIFIER));
+        assertEquals("1.2.3." + QUALIFIER, extraUnit.getVersion().toString());
         assertThat(extraUnit, hasSelfCapability());
     }
 
@@ -278,20 +277,20 @@ public class PublishProductToolTest {
                 not(hasItem(requirement("org.eclipse.help.feature.group", "2.0.102.v20140128"))));
         assertThat(productUnit.getRequirements(), not(hasItem(requirement("org.eclipse.egit.feature.group", "2.0"))));
 
-        assertThat(seeds.get(1).getId(), is("org.eclipse.help"));
+        assertEquals("org.eclipse.help", seeds.get(1).getId());
         assertThat((IInstallableUnit) seeds.get(1).getInstallableUnit(),
                 is(unitWithId("org.eclipse.help.feature.group")));
-        assertThat(seeds.get(2).getId(), is("org.eclipse.egit"));
+        assertEquals("org.eclipse.egit", seeds.get(2).getId());
         assertThat((IInstallableUnit) seeds.get(2).getInstallableUnit(),
                 is(unitWithId("org.eclipse.egit.feature.group")));
-        assertThat(seeds, hasSize(3));
+        assertEquals(3, seeds.size());
     }
 
     /**
      * Returns the IU from the only dependency seed.
      */
     private static IInstallableUnit getUnit(Collection<DependencySeed> seeds) {
-        assertThat(seeds, TychoMatchers.hasSize(1));
+        assertEquals(1, seeds.size());
         return (IInstallableUnit) seeds.iterator().next().getInstallableUnit();
     }
 

--- a/tycho-bundles/org.eclipse.tycho.test.utils/src/main/java/org/eclipse/tycho/test/util/LogVerifier.java
+++ b/tycho-bundles/org.eclipse.tycho.test.utils/src/main/java/org/eclipse/tycho/test/util/LogVerifier.java
@@ -14,8 +14,8 @@
 package org.eclipse.tycho.test.util;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -127,7 +127,7 @@ public class LogVerifier extends Verifier {
 
         void checkLoggedErrors() {
             if (expectNoErrors) {
-                assertThat(getLoggedErrors(), is(""));
+                assertEquals("", getLoggedErrors());
             } else {
                 Matcher<String> combinedMatcher = CoreMatchers.allOf(loggedErrorsMatchers);
                 assertThat(getLoggedErrors(), combinedMatcher);
@@ -136,7 +136,7 @@ public class LogVerifier extends Verifier {
 
         void checkLoggedWarnings() {
             if (expectNoWarnings) {
-                assertThat(getLoggedWarnings(), is(""));
+                assertEquals("", getLoggedWarnings());
             } else {
                 Matcher<String> combinedMatcher = CoreMatchers.allOf(loggedWarningsMatchers);
                 assertThat(getLoggedWarnings(), combinedMatcher);

--- a/tycho-bundles/org.eclipse.tycho.test.utils/src/main/java/org/eclipse/tycho/test/util/TychoMatchers.java
+++ b/tycho-bundles/org.eclipse.tycho.test.utils/src/main/java/org/eclipse/tycho/test/util/TychoMatchers.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.tycho.test.util;
 
-import java.io.File;
-import java.util.Collection;
 import java.util.List;
 
 import org.hamcrest.CoreMatchers;
@@ -65,59 +63,4 @@ public class TychoMatchers {
         };
     }
 
-    /**
-     * Creates a matcher matching any collection with the given size.
-     * 
-     * @see CoreMatchers#hasItem(Matcher)
-     */
-    public static <T> Matcher<Collection<? extends T>> hasSize(final int size) {
-        return new TypeSafeMatcher<Collection<? extends T>>() {
-
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("a collection with size " + size);
-            }
-
-            @Override
-            protected boolean matchesSafely(Collection<? extends T> item) {
-                return item.size() == size;
-            }
-        };
-    }
-
-    /**
-     * Returns a matcher matching any existing file or directory.
-     */
-    public static Matcher<File> exists() {
-        return new TypeSafeMatcher<File>() {
-
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("an existing file or directory");
-            }
-
-            @Override
-            public boolean matchesSafely(File item) {
-                return item.exists();
-            }
-        };
-    }
-
-    /**
-     * Returns a matcher matching any existing, regular file.
-     */
-    public static Matcher<File> isFile() {
-        return new TypeSafeMatcher<File>() {
-
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("an existing file");
-            }
-
-            @Override
-            public boolean matchesSafely(File item) {
-                return item.isFile();
-            }
-        };
-    }
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/artifacts/configuration/TargetPlatformFilterConfigurationReaderTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/artifacts/configuration/TargetPlatformFilterConfigurationReaderTest.java
@@ -80,7 +80,7 @@ public class TargetPlatformFilterConfigurationReaderTest extends AbstractMojoTes
         List<TargetPlatformFilter> filters = subject.parseFilterConfiguration(filterConfig);
 
         for (TargetPlatformFilter filter : filters) {
-            assertThat(filter.getAction(), is(FilterAction.REMOVE_ALL));
+            assertEquals(FilterAction.REMOVE_ALL, filter.getAction());
         }
 
         assertThat(filters.get(0).getScopePattern(), is(patternWithoutVersion(CapabilityType.OSGI_BUNDLE,

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/ee/CustomExecutionEnvironmentTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/ee/CustomExecutionEnvironmentTest.java
@@ -12,9 +12,9 @@ package org.eclipse.tycho.core.ee;
 
 import static org.hamcrest.CoreMatchers.any;
 import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -48,7 +48,7 @@ public class CustomExecutionEnvironmentTest {
     public void testEmptyExecutionEnvironment() {
         createExecutionEnvironment();
 
-        assertThat(customExecutionEnvironment.getProfileName(), is("name"));
+        assertEquals("name", customExecutionEnvironment.getProfileName());
         assertNull(customExecutionEnvironment.getCompilerSourceLevelDefault());
         assertNull(customExecutionEnvironment.getCompilerTargetLevelDefault());
         assertTrue(customExecutionEnvironment.getSystemPackages().isEmpty()); // explicitly specify template parameter to work around bug present 1.6.0_37 
@@ -61,7 +61,7 @@ public class CustomExecutionEnvironmentTest {
 
         assertThat(customExecutionEnvironment.getSystemPackages().stream().map(entry -> entry.packageName)
                 .collect(Collectors.toList()), hasItem("java.lang"));
-        assertThat(customExecutionEnvironment.getProfileProperties().size(), is(2));
+        assertEquals(2, customExecutionEnvironment.getProfileProperties().size());
         assertProperty(Constants.FRAMEWORK_SYSTEMPACKAGES, "java.lang");
     }
 
@@ -71,7 +71,7 @@ public class CustomExecutionEnvironmentTest {
 
         assertThat(customExecutionEnvironment.getSystemPackages().stream().map(entry -> entry.packageName)
                 .collect(Collectors.toList()), hasItem("javax.activation"));
-        assertThat(customExecutionEnvironment.getProfileProperties().size(), is(2));
+        assertEquals(2, customExecutionEnvironment.getProfileProperties().size());
         assertProperty(Constants.FRAMEWORK_SYSTEMPACKAGES, "javax.activation;version=\"1.1\"");
     }
 
@@ -83,7 +83,7 @@ public class CustomExecutionEnvironmentTest {
                 .collect(Collectors.toList()), hasItem("java.lang"));
         assertThat(customExecutionEnvironment.getSystemPackages().stream().map(entry -> entry.packageName)
                 .collect(Collectors.toList()), hasItem("javax.activation"));
-        assertThat(customExecutionEnvironment.getProfileProperties().size(), is(2));
+        assertEquals(2, customExecutionEnvironment.getProfileProperties().size());
         assertProperty(Constants.FRAMEWORK_SYSTEMPACKAGES, "java.lang,javax.activation;version=\"1.1\"");
     }
 
@@ -93,7 +93,7 @@ public class CustomExecutionEnvironmentTest {
 
         assertThat(customExecutionEnvironment.getSystemPackages().stream().map(entry -> entry.packageName)
                 .collect(Collectors.toList()), not(CoreMatchers.<String> hasItem(any(String.class)))); // explicitly specify template parameter to work around bug present 1.6.0_37 
-        assertThat(customExecutionEnvironment.getProfileProperties().size(), is(3));
+        assertEquals(3, customExecutionEnvironment.getProfileProperties().size());
         assertProperty(Constants.FRAMEWORK_SYSTEMCAPABILITIES, "osgi.ee; osgi.ee=\"JavaSE\"; version:Version=\"1.6\"");
         assertProperty(Constants.FRAMEWORK_EXECUTIONENVIRONMENT, "JavaSE-1.6");
     }
@@ -102,7 +102,7 @@ public class CustomExecutionEnvironmentTest {
     public void testTwoOsgiEeCapabilities() throws Exception {
         createExecutionEnvironment(OSGI_JAVASE_1_6, OSGI_OSGIMINIMUM_1_0);
 
-        assertThat(customExecutionEnvironment.getProfileProperties().size(), is(3));
+        assertEquals(3, customExecutionEnvironment.getProfileProperties().size());
         assertProperty(Constants.FRAMEWORK_SYSTEMCAPABILITIES, "osgi.ee; osgi.ee=\"JavaSE\"; version:Version=\"1.6\","
                 + "osgi.ee; osgi.ee=\"OSGi/Minimum\"; version:Version=\"1.0\"");
         assertProperty(Constants.FRAMEWORK_EXECUTIONENVIRONMENT, "JavaSE-1.6,OSGi/Minimum-1.0");
@@ -112,7 +112,7 @@ public class CustomExecutionEnvironmentTest {
     public void testOsgiEeCapabilityInTwoVersions() throws Exception {
         createExecutionEnvironment(OSGI_JAVASE_1_6, OSGI_JAVASE_1_7);
 
-        assertThat(customExecutionEnvironment.getProfileProperties().size(), is(3));
+        assertEquals(3, customExecutionEnvironment.getProfileProperties().size());
         assertProperty(Constants.FRAMEWORK_EXECUTIONENVIRONMENT, "JavaSE-1.6,JavaSE-1.7");
         assertProperty(Constants.FRAMEWORK_SYSTEMCAPABILITIES,
                 "osgi.ee; osgi.ee=\"JavaSE\"; version:List<Version>=\"1.6, 1.7\"");
@@ -122,7 +122,7 @@ public class CustomExecutionEnvironmentTest {
     public void testOsgiEeCapabilityStrangeVersion() throws Exception {
         createExecutionEnvironment(new SystemCapability(Type.OSGI_EE, "JavaSE", "1.6.1"));
 
-        assertThat(customExecutionEnvironment.getProfileProperties().size(), is(3));
+        assertEquals(3, customExecutionEnvironment.getProfileProperties().size());
         assertProperty(Constants.FRAMEWORK_EXECUTIONENVIRONMENT, "JavaSE-1.6.1");
         assertProperty(Constants.FRAMEWORK_SYSTEMCAPABILITIES,
                 "osgi.ee; osgi.ee=\"JavaSE\"; version:Version=\"1.6.1\"");
@@ -132,7 +132,7 @@ public class CustomExecutionEnvironmentTest {
     public void testOsgiEeCapabilityAlphanumericVersion() throws Exception {
         createExecutionEnvironment(new SystemCapability(Type.OSGI_EE, "JavaSE", "AlphaRelease.beta-245.0"));
 
-        assertThat(customExecutionEnvironment.getProfileProperties().size(), is(3));
+        assertEquals(3, customExecutionEnvironment.getProfileProperties().size());
         assertProperty(Constants.FRAMEWORK_EXECUTIONENVIRONMENT, "JavaSE-AlphaRelease.beta-245.0");
         assertProperty(Constants.FRAMEWORK_SYSTEMCAPABILITIES,
                 "osgi.ee; osgi.ee=\"JavaSE\"; version:Version=\"AlphaRelease.beta-245.0\"");
@@ -147,7 +147,7 @@ public class CustomExecutionEnvironmentTest {
         }
         customExecutionEnvironment = new CustomExecutionEnvironment("name", javaSeVersions);
 
-        assertThat(customExecutionEnvironment.getProfileProperties().size(), is(3));
+        assertEquals(3, customExecutionEnvironment.getProfileProperties().size());
         assertProperty(Constants.FRAMEWORK_EXECUTIONENVIRONMENT,
                 "J2SE-1.2,J2SE-1.3,J2SE-1.4,J2SE-1.5,JavaSE-1.6,JavaSE-1.7");
     }
@@ -167,7 +167,7 @@ public class CustomExecutionEnvironmentTest {
     }
 
     private void assertProperty(String key, String value) {
-        assertThat(customExecutionEnvironment.getProfileProperties().getProperty(key), is(value));
+        assertEquals(value, customExecutionEnvironment.getProfileProperties().getProperty(key));
     }
 
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/maven/TychoInterpolatorTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/maven/TychoInterpolatorTest.java
@@ -10,8 +10,7 @@
  *******************************************************************************/
 package org.eclipse.tycho.core.maven;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -21,7 +20,6 @@ import java.util.Properties;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.settings.Settings;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -62,66 +60,66 @@ public class TychoInterpolatorTest {
     @Test
     public void testProjectPropertiesGetInterpolated() {
         String interpolated = interpolator.interpolate("${myProjectPropertyKey}");
-        Assert.assertEquals("myProjectPropertyValue", interpolated);
+        assertEquals("myProjectPropertyValue", interpolated);
     }
 
     @Test
     public void testUserPropertiesGetInterpolated() {
         String interpolated = interpolator.interpolate("${myUserPropertyKey}");
-        Assert.assertEquals("myUserPropertyValue", interpolated);
+        assertEquals("myUserPropertyValue", interpolated);
     }
 
     @Test
     public void testSystemPropertiesGetInterpolated() {
         String interpolated = interpolator.interpolate("${mySystemPropertyKey}");
-        Assert.assertEquals("mySystemPropertyValue", interpolated);
+        assertEquals("mySystemPropertyValue", interpolated);
     }
 
     @Test
     public void testLocalRepositoryGetInterpolated() {
         String interpolated = interpolator.interpolate("${localRepository}");
-        Assert.assertEquals("myLocalRepo", interpolated);
+        assertEquals("myLocalRepo", interpolated);
     }
 
     @Test
     public void testBaseDirGetInterpolated() {
         String interpolated = interpolator.interpolate("${basedir}");
-        Assert.assertEquals("absolutePathToBaseDir", interpolated);
+        assertEquals("absolutePathToBaseDir", interpolated);
     }
 
     @Test
     public void testVersionGetInterpolated() {
         String interpolated = interpolator.interpolate("${version}");
-        Assert.assertEquals("1.0.0", interpolated);
+        assertEquals("1.0.0", interpolated);
     }
 
     @Test
     public void testProjectMembersGetInterpolated() {
         when(project.getArtifactId()).thenReturn("myArtifactId");
         String interpolated = interpolator.interpolate("${project.artifactId}");
-        Assert.assertEquals("myArtifactId", interpolated);
+        assertEquals("myArtifactId", interpolated);
     }
 
     @Test
     public void testSettingsMembersGetInterpolated() {
         when(settings.getSourceLevel()).thenReturn("mySourceLevel");
         String interpolated = interpolator.interpolate("${settings.sourceLevel}");
-        Assert.assertEquals("mySourceLevel", interpolated);
+        assertEquals("mySourceLevel", interpolated);
     }
 
     @Test
     public void testInterpolateSubString() {
-        assertThat(interpolator.interpolate("pre1${localRepository}1post"), is("pre1myLocalRepo1post"));
+        assertEquals("pre1myLocalRepo1post", interpolator.interpolate("pre1${localRepository}1post"));
     }
 
     @Test
     public void testInterpolateNonExisting() {
-        assertThat(interpolator.interpolate("${undefined}"), is("${undefined}"));
+        assertEquals("${undefined}", interpolator.interpolate("${undefined}"));
     }
 
     @Test
     public void testInterpolateSyntaxError() {
-        assertThat(interpolator.interpolate("${not closed"), is("${not closed"));
+        assertEquals("${not closed", interpolator.interpolate("${not closed"));
     }
 
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/test/DependencyComputerTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/test/DependencyComputerTest.java
@@ -11,7 +11,6 @@
 package org.eclipse.tycho.core.test;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertArrayEquals;
@@ -129,8 +128,8 @@ public class DependencyComputerTest extends AbstractTychoMojoTestCase {
         List<DependencyEntry> dependencies = dependencyComputer.computeDependencies(bundle);
 
         if (dependencies.size() > 0) {
-            assertThat(dependencies.size(), is(1));
-            assertThat(dependencies.get(0).module.getSymbolicName(), is(Constants.SYSTEM_BUNDLE_SYMBOLICNAME));
+            assertEquals(1, dependencies.size());
+            assertEquals(Constants.SYSTEM_BUNDLE_SYMBOLICNAME, dependencies.get(0).module.getSymbolicName());
         }
     }
 

--- a/tycho-packaging-plugin/src/test/java/org/eclipse/tycho/packaging/FeatureXmlTransformerTest.java
+++ b/tycho-packaging-plugin/src/test/java/org/eclipse/tycho/packaging/FeatureXmlTransformerTest.java
@@ -13,8 +13,8 @@
 package org.eclipse.tycho.packaging;
 
 import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -68,9 +68,10 @@ public class FeatureXmlTransformerTest {
 
         assertThat(feature.getPlugins(), hasItem(plugin("org.junit4", "4.8.1.v20100302")));
         PluginRef plugin = feature.getPlugins().get(0);
-        assertThat(plugin.getId(), is("org.junit4"));
-        assertThat(plugin.getDownloadSize(), is(1L)); // 1720 bytes rounded to kiB
-        assertThat(plugin.getInstallSize(), is(2L)); // 2419 bytes rounded to kiB // TODO shouldn't installSize=downloadSize for unpack=false?
+		assertEquals("org.junit4", plugin.getId());
+		assertEquals(1L, plugin.getDownloadSize()); // 1720 bytes rounded to kiB
+		assertEquals(2L, plugin.getInstallSize()); // 2419 bytes rounded to kiB // TODO shouldn't
+													// installSize=downloadSize for unpack=false?
         assertFalse(plugin.isUnpack());
     }
 


### PR DESCRIPTION
JUnit API is reach enough now to not need this library. For the future
hamcrest usage will be reduced even more and aim at not needing it at
all.