### PR TITLE
Make checks for 'feature-source'/'p2-metadata' executions more precise

### DIFF
--- a/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/OsgiSourceMojo.java
+++ b/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/OsgiSourceMojo.java
@@ -61,10 +61,10 @@ import org.osgi.framework.Version;
 /**
  * Goal to create a JAR-package containing all the source files of a osgi project.
  */
-@Mojo(name = "plugin-source", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, threadSafe = true)
+@Mojo(name = OsgiSourceMojo.GOAL, defaultPhase = LifecyclePhase.PREPARE_PACKAGE, threadSafe = true)
 public class OsgiSourceMojo extends AbstractSourceJarMojo {
 
-    private static final String GOAL = "plugin-source";
+    static final String GOAL = "plugin-source";
 
     static final String MANIFEST_HEADER_ECLIPSE_SOURCE_BUNDLE = "Eclipse-SourceBundle";
     private static final String MANIFEST_BUNDLE_LOCALIZATION_BASENAME = BUNDLE_LOCALIZATION_DEFAULT_BASENAME + "-src";

--- a/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/SourceFeatureMojo.java
+++ b/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/SourceFeatureMojo.java
@@ -30,7 +30,6 @@ import org.apache.maven.archiver.MavenArchiveConfiguration;
 import org.apache.maven.archiver.MavenArchiver;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Plugin;
-import org.apache.maven.model.PluginExecution;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -90,8 +89,10 @@ import de.pdark.decentxml.Element;
  * <code>&lt;originalFeature&gt;/feature.properties</code>.
  * 
  */
-@Mojo(name = "feature-source", defaultPhase = LifecyclePhase.PACKAGE, threadSafe = true)
+@Mojo(name = SourceFeatureMojo.GOAL, defaultPhase = LifecyclePhase.PACKAGE, threadSafe = true)
 public class SourceFeatureMojo extends AbstractMojo {
+
+    static final String GOAL = "feature-source";
 
     public enum MissingSourcesAction {
         FAIL, WARN;
@@ -257,7 +258,7 @@ public class SourceFeatureMojo extends AbstractMojo {
                 projectHelper.attachArtifact(project, outputJarFile, SOURCES_FEATURE_CLASSIFIER);
                 if (!isP2GenerationEnabled()) {
                     logger.warn(
-                            "org.eclipse.tycho:tycho-p2-plugin seems not to be enabled but will be required if the generated feature is used in an update-site. You can add the following snippet to your pom: \n" //
+                            "org.eclipse.tycho:tycho-p2-plugin seems not to be enabled but will be required if the generated source-feature is used in an update-site or another feature. You can add the following snippet to your pom: \n" //
                                     + "            <plugin>\n"
                                     + "                <groupId>org.eclipse.tycho</groupId>\n" //
                                     + "                <artifactId>tycho-p2-plugin</artifactId>\n" //
@@ -282,13 +283,7 @@ public class SourceFeatureMojo extends AbstractMojo {
 
     protected boolean isP2GenerationEnabled() {
         Plugin plugin = project.getPlugin("org.eclipse.tycho:tycho-p2-plugin");
-        if (plugin != null) {
-            PluginExecution execution = plugin.getExecutionsAsMap().get("attach-p2-metadata");
-            if (execution != null) {
-                return execution.getGoals().contains("p2-metadata");
-            }
-        }
-        return false;
+        return plugin != null && plugin.getExecutions().stream().anyMatch(e -> e.getGoals().contains("p2-metadata"));
     }
 
     static File getSourcesFeatureOutputDir(MavenProject project) {

--- a/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/SourceFeatureP2MetadataProvider.java
+++ b/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/SourceFeatureP2MetadataProvider.java
@@ -64,7 +64,8 @@ public class SourceFeatureP2MetadataProvider implements P2MetadataProvider, Init
         }
         Plugin plugin = project.getPlugin("org.eclipse.tycho:tycho-source-plugin");
         if (plugin != null) {
-            PluginExecution execution = plugin.getExecutionsAsMap().get("feature-source");
+            PluginExecution execution = plugin.getExecutions().stream()
+                    .filter(e -> e.getGoals().contains(SourceFeatureMojo.GOAL)).findFirst().orElse(null);
             if (execution == null) {
                 return null;
             }


### PR DESCRIPTION
Using a Plugin execution's goal and not its id as criteria to check for its presence is more precise. The id can be chosen arbitrarily and requiring a specific id can easily lead to false positive and false negative results.

For example it took me some time to find out in https://github.com/eclipse-equinox/equinox.bundles/pull/20 that using the 'wrong' id for the execution of the `tycho-source-plugin:feature-source` goal is the reason the source-feature is not found when resolving a feature that includes it. The id was actually chosen badly due to copy-pasting but the success of a build should not depend on if I name the id `source-feature` or `feature-source`.

Furthermore the m2e build constantly displays a warning that the `tycho-p2-plugin:p2-metadata` were not executed and that this would lead to problems when including the generated source-feature in an update-site just because the execution-id is `p2-metadata` instead of `attach-p2-metadata`.

Fixes https://github.com/eclipse/tycho/issues/85