### PR TITLE
Stop using old/ancient update sites in tests.

### DIFF
--- a/tycho-its/projects/compiler.javaxAnnotationImport/pom.xml
+++ b/tycho-its/projects/compiler.javaxAnnotationImport/pom.xml
@@ -9,9 +9,9 @@
 	<packaging>eclipse-plugin</packaging>
 	<repositories>
 		<repository>
-			<id>2018-12</id>
+			<id>target-platform</id>
 			<layout>p2</layout>
-			<url>http://download.eclipse.org/releases/2018-12</url>
+			<url>http://download.eclipse.org/releases/latest</url>
 		</repository>
 	</repositories>
 	<build>

--- a/tycho-its/projects/jar-signing-extra/pom.xml
+++ b/tycho-its/projects/jar-signing-extra/pom.xml
@@ -58,8 +58,8 @@
 	
 	<repositories>
 		<repository>
-			<id>download.eclipse.org_releases_indigo</id>
-			<url>http://download.eclipse.org/releases/indigo/</url>
+			<id>target-platform</id>
+			<url>http://download.eclipse.org/releases/latest/</url>
 			<layout>p2</layout>
 		</repository>
 	</repositories>

--- a/tycho-its/projects/jar-signing/pom.xml
+++ b/tycho-its/projects/jar-signing/pom.xml
@@ -86,8 +86,8 @@
 	
 	<repositories>
 		<repository>
-			<id>download.eclipse.org_releases_indigo</id>
-			<url>http://download.eclipse.org/releases/indigo/</url>
+			<id>target-platform</id>
+			<url>http://download.eclipse.org/releases/latest/</url>
 			<layout>p2</layout>
 		</repository>
 	</repositories>

--- a/tycho-its/projects/licenseFeature/pom.xml
+++ b/tycho-its/projects/licenseFeature/pom.xml
@@ -8,14 +8,14 @@
   <packaging>pom</packaging>
 
   <properties>
-    <e342-repo>http://download.eclipse.org/releases/ganymede</e342-repo>
+    <target-latest>http://download.eclipse.org/releases/latest</target-latest>
   </properties>
 
   <repositories>
     <repository>
-      <id>e342</id>
+      <id>target-platform</id>
       <layout>p2</layout>
-      <url>${e342-repo}</url>
+      <url>${target-latest}</url>
     </repository>
   </repositories>
 

--- a/tycho-its/projects/p2Inf.multiEnv/pom.xml
+++ b/tycho-its/projects/p2Inf.multiEnv/pom.xml
@@ -8,14 +8,14 @@
   <packaging>pom</packaging>
 
   <properties>
-    <e342-repo>http://download.eclipse.org/releases/ganymede</e342-repo>
+    <repo>http://download.eclipse.org/releases/latest</repo>
   </properties>
 
   <repositories>
     <repository>
-      <id>e342</id>
+      <id>target-platform</id>
       <layout>p2</layout>
-      <url>${e342-repo}</url>
+      <url>${repo}</url>
     </repository>
   </repositories>
 

--- a/tycho-its/projects/packaging.reproducibleArtifacts/baseline/src/pom.xml
+++ b/tycho-its/projects/packaging.reproducibleArtifacts/baseline/src/pom.xml
@@ -8,15 +8,15 @@
   <packaging>pom</packaging>
 
   <properties>
-    <e342-repo>http://download.eclipse.org/releases/ganymede</e342-repo>
+    <repo>http://download.eclipse.org/releases/latest</repo>
     <versionQualifier>1</versionQualifier>
   </properties>
 
   <repositories>
     <repository>
-      <id>e342</id>
+      <id>target-platform</id>
       <layout>p2</layout>
-      <url>${e342-repo}</url>
+      <url>${repo}</url>
     </repository>
   </repositories>
 

--- a/tycho-its/projects/packaging.reproducibleArtifacts/changedattachedartifact/pom.xml
+++ b/tycho-its/projects/packaging.reproducibleArtifacts/changedattachedartifact/pom.xml
@@ -12,16 +12,16 @@
   </description>
   
   <properties>
-    <e342-repo>http://download.eclipse.org/releases/ganymede</e342-repo>
+    <target-platform>http://download.eclipse.org/releases/latest</target-platform>
     
     <versionQualifier>1</versionQualifier>
   </properties>
 
   <repositories>
     <repository>
-      <id>e342</id>
+      <id>target</id>
       <layout>p2</layout>
-      <url>${e342-repo}</url>
+      <url>${target-platform}</url>
     </repository>
   </repositories>
 

--- a/tycho-its/projects/packaging.reproducibleArtifacts/contentchanged/pom.xml
+++ b/tycho-its/projects/packaging.reproducibleArtifacts/contentchanged/pom.xml
@@ -14,16 +14,16 @@
    -->
 
   <properties>
-    <e342-repo>http://download.eclipse.org/releases/ganymede</e342-repo>
+    <target-platform>http://download.eclipse.org/releases/latest</target-platform>
     
     <versionQualifier>1</versionQualifier>
   </properties>
 
   <repositories>
     <repository>
-      <id>e342</id>
+      <id>target-platform</id>
       <layout>p2</layout>
-      <url>${e342-repo}</url>
+      <url>${target-platform}</url>
     </repository>
   </repositories>
 

--- a/tycho-its/projects/packaging.reproducibleArtifacts/newattachedartifact/pom.xml
+++ b/tycho-its/projects/packaging.reproducibleArtifacts/newattachedartifact/pom.xml
@@ -12,16 +12,16 @@
   </description>
 
   <properties>
-    <e342-repo>http://download.eclipse.org/releases/ganymede</e342-repo>
+    <target-platform>http://download.eclipse.org/releases/latest</target-platform>
 
     <versionQualifier>1</versionQualifier>
   </properties>
 
   <repositories>
     <repository>
-      <id>e342</id>
+      <id>target-platform</id>
       <layout>p2</layout>
-      <url>${e342-repo}</url>
+      <url>${target-platform}</url>
     </repository>
   </repositories>
 

--- a/tycho-its/projects/pomDependency.ignore/pom.xml
+++ b/tycho-its/projects/pomDependency.ignore/pom.xml
@@ -11,13 +11,13 @@
 
 	<properties>
 		<tycho-version>3.0.0-SNAPSHOT</tycho-version>
-		<p2-repo>http://download.eclipse.org/releases/2019-03</p2-repo>
+		<target-platform>http://download.eclipse.org/releases/latest</target-platform>
 	</properties>
 
 	<repositories>
 		<repository>
 			<id>sdk</id>
-			<url>${p2-repo}</url>
+			<url>${target-platform}</url>
 			<layout>p2</layout>
 		</repository>
 	</repositories>

--- a/tycho-its/projects/product.archiveFormat/pom.xml
+++ b/tycho-its/projects/product.archiveFormat/pom.xml
@@ -9,14 +9,14 @@
   <packaging>eclipse-repository</packaging>
 
   <properties>
-    <e342-repo>http://download.eclipse.org/releases/ganymede</e342-repo>
+    <target-platform>http://download.eclipse.org/releases/latest</target-platform>
   </properties>
 
   <repositories>
     <repository>
       <id>e342</id>
       <layout>p2</layout>
-      <url>${e342-repo}</url>
+      <url>${target-platform}</url>
     </repository>
   </repositories>
 

--- a/tycho-its/projects/product.metaRequirements/pom.xml
+++ b/tycho-its/projects/product.metaRequirements/pom.xml
@@ -20,7 +20,7 @@
 		<repository>
 			<id>indigo</id>
 			<layout>p2</layout>
-			<url>http://download.eclipse.org/releases/indigo</url>
+			<url>http://download.eclipse.org/releases/latest</url>
 		</repository>
 	</repositories>
 

--- a/tycho-its/projects/resolver.extraRequirements/artificial/pom.xml
+++ b/tycho-its/projects/resolver.extraRequirements/artificial/pom.xml
@@ -11,7 +11,7 @@
     <repository>
       <id>e342</id>
       <layout>p2</layout>
-      <url>${e342-repo}</url>
+      <url>${target-platform}</url>
     </repository>
   </repositories>
 

--- a/tycho-its/projects/resolver.extraRequirements/dynamicimport-package/pom.xml
+++ b/tycho-its/projects/resolver.extraRequirements/dynamicimport-package/pom.xml
@@ -21,7 +21,7 @@
   </description>
 
   <properties>
-    <e342-repo>http://download.eclipse.org/releases/ganymede</e342-repo>
+    <target-platform>http://download.eclipse.org/releases/ganymede</target-platform>
   </properties>
 
   <modules>
@@ -31,9 +31,9 @@
 
   <repositories>
     <repository>
-      <id>e342</id>
+      <id>repo</id>
       <layout>p2</layout>
-      <url>${e342-repo}</url>
+      <url>${target-platform}</url>
     </repository>
   </repositories>
 

--- a/tycho-its/projects/resolver.extraRequirements/fragment-split-package/pom.xml
+++ b/tycho-its/projects/resolver.extraRequirements/fragment-split-package/pom.xml
@@ -27,7 +27,7 @@
     <repository>
       <id>e342</id>
       <layout>p2</layout>
-      <url>${e342-repo}</url>
+      <url>${target-platform}</url>
     </repository>
   </repositories>
 

--- a/tycho-its/projects/resolver.extraRequirements/implicit-fragment-import-package/pom.xml
+++ b/tycho-its/projects/resolver.extraRequirements/implicit-fragment-import-package/pom.xml
@@ -14,7 +14,7 @@
   </description>
 
   <properties>
-    <e342-repo>http://download.eclipse.org/releases/ganymede</e342-repo>
+    <target-platform>http://download.eclipse.org/releases/latest</target-platform>
   </properties>
 
   <modules>
@@ -27,7 +27,7 @@
     <repository>
       <id>e342</id>
       <layout>p2</layout>
-      <url>${e342-repo}</url>
+      <url>${target-platform}</url>
     </repository>
   </repositories>
 

--- a/tycho-its/projects/resolver.extraRequirements/import-package-directives/pom.xml
+++ b/tycho-its/projects/resolver.extraRequirements/import-package-directives/pom.xml
@@ -26,7 +26,7 @@
   </description>
 
   <properties>
-    <e342-repo>http://download.eclipse.org/releases/ganymede</e342-repo>
+    <target-platform>http://download.eclipse.org/releases/latest</target-platform>
   </properties>
 
   <modules>
@@ -39,7 +39,7 @@
     <repository>
       <id>e342</id>
       <layout>p2</layout>
-      <url>${e342-repo}</url>
+      <url>${target-platform}</url>
     </repository>
   </repositories>
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/JavaxAnnotationImportTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/compiler/JavaxAnnotationImportTest.java
@@ -19,9 +19,9 @@ import org.junit.Test;
 
 public class JavaxAnnotationImportTest extends AbstractTychoIntegrationTest {
 
-    @Test
-    public void testStrictImportJREPackages() throws Exception {
-        Verifier verifier = getVerifier("compiler.javaxAnnotationImport", false);
-        verifier.executeGoal("compile");
-    }
+	@Test
+	public void testStrictImportJREPackages() throws Exception {
+		Verifier verifier = getVerifier("compiler.javaxAnnotationImport", true);
+		verifier.executeGoal("compile");
+	}
 }

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/jarsigning/JarSigningTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/jarsigning/JarSigningTest.java
@@ -35,7 +35,7 @@ public class JarSigningTest extends AbstractTychoIntegrationTest {
 
 	@Test
 	public void testSigning() throws Exception {
-		Verifier verifier = getVerifier("jar-signing", false);
+		Verifier verifier = getVerifier("jar-signing", true);
 
 		verifier.executeGoal("verify");
 		verifier.verifyErrorFreeLog();
@@ -45,7 +45,7 @@ public class JarSigningTest extends AbstractTychoIntegrationTest {
 
 	@Test
 	public void testExtraSigning() throws Exception {
-		Verifier verifier = getVerifier("jar-signing-extra", false);
+		Verifier verifier = getVerifier("jar-signing-extra", true);
 
 		verifier.executeGoal("verify");
 		verifier.verifyErrorFreeLog();

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/licenseFeature/LicenseFeatureTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/licenseFeature/LicenseFeatureTest.java
@@ -26,7 +26,6 @@ import java.util.zip.ZipFile;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.model.Feature;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.eclipse.tycho.test.util.ResourceUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -35,8 +34,7 @@ public class LicenseFeatureTest extends AbstractTychoIntegrationTest {
 
 	@Test
 	public void test() throws Exception {
-		Verifier verifier = getVerifier("/licenseFeature", false);
-		verifier.addCliOption("-De342-repo=" + ResourceUtil.P2Repositories.ECLIPSE_342.toString());
+		Verifier verifier = getVerifier("/licenseFeature", true);
 		verifier.executeGoal("verify");
 		verifier.verifyErrorFreeLog();
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Inf/MultienvP2infTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Inf/MultienvP2infTest.java
@@ -23,7 +23,6 @@ import java.util.zip.ZipFile;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.eclipse.tycho.test.util.ResourceUtil;
 import org.junit.Test;
 
 import de.pdark.decentxml.Document;
@@ -35,8 +34,7 @@ public class MultienvP2infTest extends AbstractTychoIntegrationTest {
 
 	@Test
 	public void test() throws Exception {
-		Verifier verifier = getVerifier("/p2Inf.multiEnv", false);
-		verifier.addCliOption("-De342-repo=" + ResourceUtil.P2Repositories.ECLIPSE_342);
+		Verifier verifier = getVerifier("/p2Inf.multiEnv", true);
 		verifier.executeGoals(Arrays.asList("clean", "verify"));
 		verifier.verifyErrorFreeLog();
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/packaging/BaselineValidateAndReplaceTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/packaging/BaselineValidateAndReplaceTest.java
@@ -11,7 +11,6 @@ import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.codehaus.plexus.util.FileUtils;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.eclipse.tycho.test.util.ResourceUtil;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -27,8 +26,7 @@ public class BaselineValidateAndReplaceTest extends AbstractTychoIntegrationTest
 	}
 
 	private Verifier getVerifier(String project, File baselineRepo) throws Exception {
-		Verifier verifier = getVerifier("/packaging.reproducibleArtifacts/" + project, false);
-		verifier.addCliOption("-De342-repo=" + ResourceUtil.P2Repositories.ECLIPSE_342.toString());
+		Verifier verifier = getVerifier("/packaging.reproducibleArtifacts/" + project, true);
 		verifier.addCliOption("-Dbaseline-repo=" + baselineRepo.toURI().toString());
 		return verifier;
 	}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/pomDependencyConsider/PomDependencyIgnoreTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/pomDependencyConsider/PomDependencyIgnoreTest.java
@@ -17,7 +17,7 @@ public class PomDependencyIgnoreTest extends AbstractTychoIntegrationTest {
 
 	@Test
 	public void testIgnorePomDependency() throws Exception {
-		Verifier verifier = getVerifier("pomDependency.ignore", false, true);
+		Verifier verifier = getVerifier("pomDependency.ignore", true, true);
 		verifier.executeGoal("verify");
 		verifier.verifyErrorFreeLog();
 	}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/product/ProductArchiveFormatTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/product/ProductArchiveFormatTest.java
@@ -17,14 +17,12 @@ import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.eclipse.tycho.test.util.ResourceUtil;
 import org.junit.Test;
 
 public class ProductArchiveFormatTest extends AbstractTychoIntegrationTest {
 	@Test
 	public void test() throws Exception {
-		Verifier verifier = getVerifier("/product.archiveFormat", false);
-		verifier.addCliOption("-De342-repo=" + ResourceUtil.P2Repositories.ECLIPSE_342.toString());
+		Verifier verifier = getVerifier("/product.archiveFormat", true);
 		verifier.executeGoals(List.of("clean", "verify"));
 		verifier.verifyErrorFreeLog();
 

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/ExtraCompilerRequirementsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/ExtraCompilerRequirementsTest.java
@@ -16,7 +16,6 @@ import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.eclipse.tycho.test.util.ResourceUtil.P2Repositories;
 import org.junit.Test;
 
 // tests the various use cases of extraRequirements (bug 363331)
@@ -26,40 +25,35 @@ public class ExtraCompilerRequirementsTest extends AbstractTychoIntegrationTest 
 	public void testArtificial() throws Exception {
 		// TODO this is an artificial test case - find a test closer to a real use case
 		// TODO avoid remote repositories
-		Verifier verifier = getVerifier("/resolver.extraRequirements/artificial", false);
-		verifier.addCliOption("-De342-repo=" + P2Repositories.ECLIPSE_LATEST.toString());
+		Verifier verifier = getVerifier("/resolver.extraRequirements/artificial", true);
 		verifier.executeGoals(List.of("clean", "verify"));
 		verifier.verifyErrorFreeLog();
 	}
 
 	@Test
 	public void testDynamicImportPackage() throws Exception {
-		Verifier verifier = getVerifier("/resolver.extraRequirements/dynamicimport-package", false);
-		verifier.addCliOption("-De342-repo=" + P2Repositories.ECLIPSE_LATEST.toString());
+		Verifier verifier = getVerifier("/resolver.extraRequirements/dynamicimport-package", true);
 		verifier.executeGoals(List.of("clean", "verify"));
 		verifier.verifyErrorFreeLog();
 	}
 
 	@Test
 	public void testFragmentSplitPackage() throws Exception {
-		Verifier verifier = getVerifier("/resolver.extraRequirements/fragment-split-package", false);
-		verifier.addCliOption("-De342-repo=" + P2Repositories.ECLIPSE_LATEST.toString());
+		Verifier verifier = getVerifier("/resolver.extraRequirements/fragment-split-package", true);
 		verifier.executeGoals(List.of("clean", "verify"));
 		verifier.verifyErrorFreeLog();
 	}
 
 	@Test
 	public void testFragmentImportPackage() throws Exception {
-		Verifier verifier = getVerifier("/resolver.extraRequirements/implicit-fragment-import-package", false);
-		verifier.addCliOption("-De342-repo=" + P2Repositories.ECLIPSE_LATEST.toString());
+		Verifier verifier = getVerifier("/resolver.extraRequirements/implicit-fragment-import-package", true);
 		verifier.executeGoals(List.of("clean", "verify"));
 		verifier.verifyErrorFreeLog();
 	}
 
 	@Test
 	public void testImportPackageDirectives() throws Exception {
-		Verifier verifier = getVerifier("/resolver.extraRequirements/import-package-directives", false);
-		verifier.addCliOption("-De342-repo=" + P2Repositories.ECLIPSE_LATEST.toString());
+		Verifier verifier = getVerifier("/resolver.extraRequirements/import-package-directives", true);
 		verifier.executeGoals(List.of("clean", "verify"));
 		verifier.verifyErrorFreeLog();
 	}


### PR DESCRIPTION
Speeding up tests as downloads are shared and sometimes reducing usage
of archive.eclipse.org . Even better is that it verifies things still
work with latest version.
Bonus points for simplifying tests code at some points.
Part 1 of a fix for https://github.com/eclipse/tycho/issues/594 .