### PR TITLE
Stop using old update sites in IT tests.

### DIFF
--- a/tycho-its/projects/TYCHO0209tychoRepositoryRoundtrip/build01/pom.xml
+++ b/tycho-its/projects/TYCHO0209tychoRepositoryRoundtrip/build01/pom.xml
@@ -15,14 +15,14 @@
   </modules>
 
   <properties>
-    <p2.repo>http://download.eclipse.org/releases/galileo</p2.repo>
+    <target-platform>http://download.eclipse.org/releases/latest</target-platform>
   </properties>
 
   <repositories>
     <repository>
       <id>p2</id>
       <layout>p2</layout>
-      <url>${p2.repo}</url>
+      <url>${target-platform}</url>
     </repository>
   </repositories>
 

--- a/tycho-its/projects/TYCHO0209tychoRepositoryRoundtrip/build02/pom.xml
+++ b/tycho-its/projects/TYCHO0209tychoRepositoryRoundtrip/build02/pom.xml
@@ -13,14 +13,14 @@
   </modules>
 
   <properties>
-    <p2.repo>http://download.eclipse.org/releases/galileo</p2.repo>
+    <target-platform>http://download.eclipse.org/releases/latest</target-platform>
   </properties>
 
   <repositories>
     <repository>
       <id>p2</id>
       <layout>p2</layout>
-      <url>${p2.repo}</url>
+      <url>${target-platform}</url>
     </repository>
     <repository>
       <id>remote</id>

--- a/tycho-its/projects/TYCHO253extraClassPathEntries/org.eclipse.tycho.testExtraClasspathTest1/pom.xml
+++ b/tycho-its/projects/TYCHO253extraClassPathEntries/org.eclipse.tycho.testExtraClasspathTest1/pom.xml
@@ -17,14 +17,14 @@
   <version>1.0.0-SNAPSHOT</version>
 
   <properties>
-    <p2.repo>http://download.eclipse.org/releases/galileo</p2.repo>
+    <target-platform>http://download.eclipse.org/releases/latest</target-platform>
   </properties>
 
   <repositories>
     <repository>
       <id>p2</id>
       <layout>p2</layout>
-      <url>${p2.repo}</url>
+      <url>${target-platform}</url>
     </repository>
   </repositories>
 

--- a/tycho-its/projects/TYCHO253extraClassPathEntries/org.eclipse.tycho.testExtraClasspathTest2/pom.xml
+++ b/tycho-its/projects/TYCHO253extraClassPathEntries/org.eclipse.tycho.testExtraClasspathTest2/pom.xml
@@ -17,14 +17,14 @@
   <version>1.0.0-SNAPSHOT</version>
 
   <properties>
-    <p2.repo>http://download.eclipse.org/releases/galileo</p2.repo>
+    <target-platform>http://download.eclipse.org/releases/latest</target-platform>
   </properties>
 
   <repositories>
     <repository>
       <id>p2</id>
       <layout>p2</layout>
-      <url>${p2.repo}</url>
+      <url>${target-platform}</url>
     </repository>
   </repositories>
 

--- a/tycho-its/projects/TYCHO253extraClassPathEntries/org.eclipse.tycho.testExtraClasspathTest3/pom.xml
+++ b/tycho-its/projects/TYCHO253extraClassPathEntries/org.eclipse.tycho.testExtraClasspathTest3/pom.xml
@@ -17,14 +17,14 @@
   <version>1.0.0-SNAPSHOT</version>
 
   <properties>
-    <p2.repo>http://download.eclipse.org/releases/galileo</p2.repo>
+    <target-platform>http://download.eclipse.org/releases/latest</target-platform>
   </properties>
 
   <repositories>
     <repository>
       <id>p2</id>
       <layout>p2</layout>
-      <url>${p2.repo}</url>
+      <url>${target-platform}</url>
     </repository>
   </repositories>
 

--- a/tycho-its/projects/TYCHO503Path With Spaces/pom.xml
+++ b/tycho-its/projects/TYCHO503Path With Spaces/pom.xml
@@ -26,7 +26,7 @@
 						<environment>
 							<os>linux</os>
 							<ws>gtk</ws>
-							<arch>x86</arch>
+							<arch>x86_64</arch>
 						</environment>
 					</environments>
 				</configuration>
@@ -49,7 +49,7 @@
 	<repositories>
 		<repository>
 			<id>helios</id>
-			<url>http://download.eclipse.org/releases/helios</url>
+			<url>http://download.eclipse.org/releases/latest</url>
 			<layout>p2</layout>
 		</repository>
 	</repositories>

--- a/tycho-its/projects/issue271/pom.xml
+++ b/tycho-its/projects/issue271/pom.xml
@@ -29,7 +29,7 @@
 		</repository>
 		<repository>
 			<id>eclipse</id>
-			<url>http://download.eclipse.org/releases/mars/</url>
+			<url>http://download.eclipse.org/releases/latest/</url>
 			<layout>p2</layout>
 		</repository>
 	</repositories>

--- a/tycho-its/projects/resolver.extraRequirements/dynamicimport-package/pom.xml
+++ b/tycho-its/projects/resolver.extraRequirements/dynamicimport-package/pom.xml
@@ -21,7 +21,7 @@
   </description>
 
   <properties>
-    <target-platform>http://download.eclipse.org/releases/ganymede</target-platform>
+    <target-platform>http://download.eclipse.org/releases/latest</target-platform>
   </properties>
 
   <modules>

--- a/tycho-its/projects/resolver.extraRequirements/fragment-split-package/pom.xml
+++ b/tycho-its/projects/resolver.extraRequirements/fragment-split-package/pom.xml
@@ -14,7 +14,7 @@
   </description>
 
   <properties>
-    <e342-repo>http://download.eclipse.org/releases/ganymede</e342-repo>
+    <e342-repo>http://download.eclipse.org/releases/latest</e342-repo>
   </properties>
 
   <modules>

--- a/tycho-its/projects/resolver.nativeCode/pom.xml
+++ b/tycho-its/projects/resolver.nativeCode/pom.xml
@@ -7,15 +7,11 @@
   <version>1.0.0</version>
   <packaging>eclipse-plugin</packaging>
 
-  <properties>
-    <e342-repo>http://download.eclipse.org/releases/ganymede</e342-repo>
-  </properties>
-
   <repositories>
     <repository>
       <id>repository</id>
       <layout>p2</layout>
-      <url>https://download.eclipse.org/tools/orbit/downloads/drops/R20201130205003/repository</url>
+      <url>https://download.eclipse.org/tools/orbit/downloads/drops/R20220302172233/repository</url>
     </repository>
   </repositories>
 

--- a/tycho-its/projects/resolver.optionalDependencies/require-bundle/pom.xml
+++ b/tycho-its/projects/resolver.optionalDependencies/require-bundle/pom.xml
@@ -8,14 +8,14 @@
   <packaging>eclipse-plugin</packaging>
 
   <properties>
-    <e342-repo>http://download.eclipse.org/releases/ganymede</e342-repo>
+    <target-platform>http://download.eclipse.org/releases/latest</target-platform>
   </properties>
 
   <repositories>
     <repository>
       <id>e342</id>
       <layout>p2</layout>
-      <url>${e342-repo}</url>
+      <url>${target-platform}</url>
     </repository>
   </repositories>
 

--- a/tycho-its/projects/surefire.bundleUnpack/pom.xml
+++ b/tycho-its/projects/surefire.bundleUnpack/pom.xml
@@ -12,14 +12,14 @@
   </modules>
 
   <properties>
-    <p2.repo>http://download.eclipse.org/releases/galileo</p2.repo>
+    <target-platform>http://download.eclipse.org/releases/latest</target-platform>
   </properties>
 
   <repositories>
     <repository>
       <id>p2</id>
       <layout>p2</layout>
-      <url>${p2.repo}</url>
+      <url>${target-platform}</url>
     </repository>
   </repositories>
 

--- a/tycho-its/projects/target.maven.autofeature/test.target
+++ b/tycho-its/projects/target.maven.autofeature/test.target
@@ -3,8 +3,8 @@
 <target includeMode="feature" name="issue-242">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="http://download.eclipse.org/releases/2020-06"/>
-			<unit id="org.eclipse.pde.feature.group" version="3.14.400.v20200604-0540"/>
+			<repository location="http://download.eclipse.org/releases/latest"/>
+			<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
 		</location>
 		<location includeDependencyScope="compile" includeSource="true" missingManifest="generate" type="Maven">
 			<dependencies>

--- a/tycho-its/projects/target.maven.pom/test.target
+++ b/tycho-its/projects/target.maven.pom/test.target
@@ -3,8 +3,8 @@
 <target name="test">
 <locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="http://download.eclipse.org/releases/2020-06"/>
-			<unit id="org.eclipse.sdk.feature.group" version="4.16.0.v20200604-0951"/>
+			<repository location="http://download.eclipse.org/releases/latest"/>
+			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 		</location>
 	<location includeSource="true" missingManifest="generate" type="Maven">
 		<dependencies>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO0209tychoRepositoryRoundtrip/TychoRepositoryRoundtripTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/TYCHO0209tychoRepositoryRoundtrip/TychoRepositoryRoundtripTest.java
@@ -18,7 +18,6 @@ import java.io.File;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.eclipse.tycho.test.util.ResourceUtil.P2Repositories;
 import org.junit.Test;
 
 public class TychoRepositoryRoundtripTest extends AbstractTychoIntegrationTest {
@@ -26,15 +25,13 @@ public class TychoRepositoryRoundtripTest extends AbstractTychoIntegrationTest {
 	@Test
 	public void testLocalMavenRepository() throws Exception {
 		// build01
-		Verifier v01 = getVerifier("TYCHO0209tychoRepositoryRoundtrip/build01", false);
-		v01.addCliOption("-Dp2.repo=" + P2Repositories.ECLIPSE_LATEST.toString());
+		Verifier v01 = getVerifier("TYCHO0209tychoRepositoryRoundtrip/build01", true);
 		v01.executeGoal("install");
 		v01.verifyErrorFreeLog();
 
 		final boolean ignoreLocallyInstalledArtifacts = false;
 		// build02, some dependencies come from local, some from remote repositories
-		Verifier v02 = getVerifier("TYCHO0209tychoRepositoryRoundtrip/build02", false, ignoreLocallyInstalledArtifacts);
-		v02.addCliOption("-Dp2.rep" + P2Repositories.ECLIPSE_LATEST.toString());
+		Verifier v02 = getVerifier("TYCHO0209tychoRepositoryRoundtrip/build02", true, ignoreLocallyInstalledArtifacts);
 		v02.executeGoal("install");
 		v02.verifyErrorFreeLog();
 		v02.verifyTextInLog(

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/OptionalDependenciesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/OptionalDependenciesTest.java
@@ -14,7 +14,6 @@ package org.eclipse.tycho.test.resolver;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.eclipse.tycho.test.util.ResourceUtil.P2Repositories;
 import org.junit.Test;
 
 // tests that optional dependencies are put on the compile class path (bug 351842)
@@ -22,8 +21,7 @@ public class OptionalDependenciesTest extends AbstractTychoIntegrationTest {
 
 	@Test
 	public void testOptionallyRequiredBundleIsOnCompileClassPath() throws Exception {
-		Verifier verifier = getVerifier("/resolver.optionalDependencies/require-bundle", false);
-		verifier.addCliOption("-De342-repo=" + P2Repositories.ECLIPSE_342.toString());
+		Verifier verifier = getVerifier("/resolver.optionalDependencies/require-bundle", true);
 		verifier.executeGoal("verify");
 		verifier.verifyErrorFreeLog();
 	}

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/ExplodedTestDependenciesTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/surefire/ExplodedTestDependenciesTest.java
@@ -16,7 +16,6 @@ import java.io.File;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
-import org.eclipse.tycho.test.util.ResourceUtil.P2Repositories;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -26,8 +25,7 @@ public class ExplodedTestDependenciesTest extends AbstractTychoIntegrationTest {
 	public void testLocalMavenRepository() throws Exception {
 		// project that marks org.apache.ant as "exploded" (unpacked) for the test
 		// runtime -> supported since TYCHO-340
-		Verifier v01 = getVerifier("surefire.bundleUnpack", false);
-		v01.addCliOption("-Dp2.repo=" + P2Repositories.ECLIPSE_LATEST.toString());
+		Verifier v01 = getVerifier("surefire.bundleUnpack", true);
 		v01.executeGoal("install");
 		v01.verifyErrorFreeLog();
 		// TODO this is only an indirect test; it should test that the bundles nested


### PR DESCRIPTION
Simpler code, easier to change target platform and makes sure things
work correctly with latest Eclipse Platform.

Fixes #594