### PR TITLE
Issue #861 Do not fail assemble-repository on empty project

### DIFF
--- a/tycho-p2/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/AssembleRepositoryMojo.java
+++ b/tycho-p2/tycho-p2-repository-plugin/src/main/java/org/eclipse/tycho/plugins/p2/repository/AssembleRepositoryMojo.java
@@ -148,7 +148,8 @@ public class AssembleRepositoryMojo extends AbstractRepositoryMojo {
 
                 Collection<DependencySeed> projectSeeds = TychoProjectUtils.getDependencySeeds(getReactorProject());
                 if (projectSeeds.isEmpty()) {
-                    throw new MojoFailureException("No content specified for p2 repository");
+                    getLog().warn("No content specified for p2 repository");
+                    return;
                 }
 
                 RepositoryReferences sources = getVisibleRepositories();


### PR DESCRIPTION
Running "assemble-repository" on an empty project will now log a warning
instead of failing the build