### PR TITLE
Ignore .gitignore and .gitatributes file types from packaging

### DIFF
--- a/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/AbstractTychoPackagingMojo.java
+++ b/tycho-packaging-plugin/src/main/java/org/eclipse/tycho/packaging/AbstractTychoPackagingMojo.java
@@ -103,6 +103,10 @@ public abstract class AbstractTychoPackagingMojo extends AbstractMojo {
         }
         if (useDefaultExcludes) {
             allExcludes.addAll(Arrays.asList(AbstractScanner.DEFAULTEXCLUDES));
+			// keep ignoring the following files after
+			// https://github.com/codehaus-plexus/plexus-utils/pull/174
+			allExcludes.add("**/.gitignore");
+			allExcludes.add("**/.gitattributes");
         }
 
         fileSet.setExcludes(allExcludes.toArray(new String[allExcludes.size()]));

--- a/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/SourceFeatureMojo.java
+++ b/tycho-source-plugin/src/main/java/org/eclipse/tycho/source/SourceFeatureMojo.java
@@ -662,6 +662,9 @@ public class SourceFeatureMojo extends AbstractMojo {
         }
         if (useDefaultExcludes) {
             allExcludes.addAll(Arrays.asList(AbstractScanner.DEFAULTEXCLUDES));
+            // keep ignoring the following files after https://github.com/codehaus-plexus/plexus-utils/pull/174
+            allExcludes.add("**/.gitignore");
+            allExcludes.add("**/.gitattributes");
         }
 
         fileSet.setExcludes(allExcludes.toArray(new String[allExcludes.size()]));


### PR DESCRIPTION
Caused by https://github.com/codehaus-plexus/plexus-utils/pull/174 .
Fixes https://github.com/eclipse/tycho/issues/966 .