### PR TITLE
Remove tycho.mode=maven

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -59,6 +59,9 @@ Please note that we use another new feature from Maven 3.8.5 here, where you can
 
 You can now control your Tycho version for `.mvn/extensions.xml` and your `pom.xml` in one place and still override it on the commandline with `-Dtycho-version=...`
 
+### Support for -Dtycho.mode=maven removed
+
+The property has never been properly documented and excluding tycho resolution is risky if one is not 100% sure what the effects are (e.g  using it with maven-dependency-plugin will result will many dependency not being listed at all). Clean phase is manually excluded by Tycho as we clearly know that it doesn't need resolution, if there is the need for more such exclusions they should be done similarly.
 
 ### Support for non-modular JVMs no longer top tier
 

--- a/tycho-bundles/tycho-bundles-external/pom.xml
+++ b/tycho-bundles/tycho-bundles-external/pom.xml
@@ -31,7 +31,7 @@
 		1. Run "mvn clean install" in tycho-bundles folder. This is necessary to populate local repo with information
 		   about org.eclipse.tycho.noopsecurity bundle
 		2. If necessary, change p2 repository url in tycho-bundles/pom.xml
-		3. In this folder, run mvn -Dtycho.mode=maven -Dtycho-version=0.11.0-SNAPSHOT org.sonatype.tycho.extras:tycho-version-bump-plugin:0.11.0-SNAPSHOT:update-product
+		3. In this folder, run mvn -Dtycho-version=0.11.0-SNAPSHOT org.sonatype.tycho.extras:tycho-version-bump-plugin:0.11.0-SNAPSHOT:update-product
 		4. Edit tycho-p2-runtime.product and remove version lock on org.eclipse.tycho.noopsecurity bundle
 
 		Luckily, we don't need to include new p2 version too often.

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/TychoMavenLifecycleParticipant.java
@@ -15,7 +15,6 @@ package org.eclipse.tycho.core.maven;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -57,10 +56,9 @@ import org.eclipse.tycho.resolver.TychoResolver;
 public class TychoMavenLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
     private static final String TYCHO_GROUPID = "org.eclipse.tycho";
-    private static final Set<String> TYCHO_PLUGIN_IDS = new HashSet<>(Arrays.asList("tycho-maven-plugin",
-            "tycho-p2-director-plugin", "tycho-p2-plugin", "tycho-p2-publisher-plugin", "tycho-p2-repository-plugin",
-            "tycho-packaging-plugin", "tycho-source-plugin", "tycho-surefire-plugin",
-            "tycho-versions-plugin", "tycho-compiler-plugin"));
+    private static final Set<String> TYCHO_PLUGIN_IDS = Set.of("tycho-maven-plugin", "tycho-p2-director-plugin",
+            "tycho-p2-plugin", "tycho-p2-publisher-plugin", "tycho-p2-repository-plugin", "tycho-packaging-plugin",
+            "tycho-source-plugin", "tycho-surefire-plugin", "tycho-versions-plugin", "tycho-compiler-plugin");
     private static final String P2_USER_AGENT_KEY = "p2.userAgent";
     private static final String P2_USER_AGENT_VALUE = "tycho/";
 
@@ -268,8 +266,7 @@ public class TychoMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
 
     private boolean disableLifecycleParticipation(MavenSession session) {
         // command line property to disable Tycho lifecycle participant
-        return "maven".equals(session.getUserProperties().get("tycho.mode"))
-                || session.getUserProperties().containsKey("m2e.version")
+        return session.getUserProperties().containsKey("m2e.version")
                 // disable for 'clean-only' builds. Consider that Maven can be invoked without explicit goals, if default goals are specified
                 || (!session.getGoals().isEmpty() && CLEAN_PHASES.containsAll(session.getGoals()));
     }


### PR DESCRIPTION
This was helpful for cases where tycho resolution is not needed but very
few people are aware of it and thus not widely used. As custom support
to exclude "clean" (probably the most widely used) has been added the
reasons to have it diminished significantly. If there is need for more
to be excluded it should be done like for "clean" rather than rely on
undocumented property.
Fixes #676