### PR TITLE
Document some previously undocumented system properties.

### DIFF
--- a/src/site/markdown/SystemProperties.md
+++ b/src/site/markdown/SystemProperties.md
@@ -1,0 +1,21 @@
+## System Properties
+
+Tycho understands some system properties beyond the ones documented in the respective goals to fine-tune certain behavior and to help with troubleshooting.
+
+Disclaimer: This page is incomplete.
+
+
+### Common Properties
+
+These properties are understood by the Tycho-core and affect all maven plugins:
+
+Name | Value | Documentation
+--- | --- | ---
+tycho.mode | `maven` | Completely disables the Tycho lifecycle participant in Maven. For standard Tycho use-cases this is typically not necessary, since e.g. the `clean` goal already disables this. However, this can be useful when explicitly invoking external goals, e.g. `mvn -Dtycho.mode=maven com.foo.bar:some-plugin:some-goal`, in order to improve performance.
+
+### Troubleshooting
+
+Name | Value | Documentation
+--- | --- | ---
+tycho.debug.artifactcomparator | _any_ | In `tycho-p2-plugin`, output verbose artifact comparison information during baseline validation
+tycho.debug.resolver | `true` or _artifactId_ | Enable debug output for the artifact resolver for all projects or the project with the given _artifactId_

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -16,6 +16,7 @@
 			<item name="Versions Plugin" href="tycho-release/tycho-versions-plugin/plugin-info.html" />
 			<item name="Properties">
 				<item name="Build Properties" href="BuildProperties.html" />
+				<item name="System Properties" href="SystemProperties.html" />
             	<item name="Tycho Properties" href="TychoProperties.html" />
 			</item>
 		</menu>


### PR DESCRIPTION
Especially, `tycho.mode=maven`, as an alternative to removing (#676).



I also did a quick full-text search on the Tycho sources. There are a bunch of more undocumented properties:

* `tycho.tar`
* `tycho.equinox.resolver.uses`
* `tycho.equinox.resolver.batch.size`
* `tycho.equinox.resolver.batch.timeout`
* `tycho.equinox.resolver.executor.threads`
* `tycho.bundlereader.lock.timeout`
* `tycho.internal.ProjectorResolutionStrategy.maxIterations`
* `tycho.buildqualifier.format`
* `tycho.buildqualifier.provider`
* `tycho.disableP2Mirrors`
* `tycho.p2.transport`
* `tycho.p2.transport.min-cache-minutes`
* `tycho.pomless.parent`
* `tycho.pomless.testbundle`
* `tycho.pomless.aggregator.names`
