### PR TITLE
Disable Issue697Test

### DIFF
--- a/tycho-its/src/test/java/org/eclipse/tycho/test/issue697/Issue697Test.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/issue697/Issue697Test.java
@@ -4,11 +4,13 @@ import java.util.List;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class Issue697Test extends AbstractTychoIntegrationTest {
 
 	@Test
+	@Ignore
 	public void test() throws Exception {
 		Verifier verifier = getVerifier("issue697");
 


### PR DESCRIPTION
Fails the build with
``` Caused by:
org.eclipse.tycho.core.shared.DependencyResolutionException: resolving
de.monticore:dsltool-api:jar:0.0.1 failed!
[org.apache.maven.artifact.resolver.ArtifactResolutionException: Could
not transfer artifact de.monticore:dsltool-api:jar:0.0.1 from/to rwth
(https://nexus.se.rwth-aachen.de/repository/monticore/): transfer failed
for https://nexus.se.rwth-aachen.de/repository/monticore/de/monticore/dsltool-api/0.0.1/dsltool-api-0.0.1.jar
  de.monticore:dsltool-api:jar:0.0.1

from the specified remote repositories:
  central (https://repo.maven.apache.org/maven2, releases=true,
snapshots=false),
  rwth (https://nexus.se.rwth-aachen.de/repository/monticore/,
releases=true, snapshots=true)
```