### PR TITLE
tycho-eclipserun-plugin: Use <applicationsArgs> literally

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -233,9 +233,12 @@ It was totally ignored in all latest versions.
 
 It was hardcoded to "tooling" always and had no practical meaning to change.
 
-#### EclipseRunMojo `argLine` and `appArgLine` options removed
+#### EclipseRunMojo `argLine` and `appArgLine` options removed / `applicationArgs` option fixed
 
-Replaced by `jvmArgs` and `applicationArgs` respectively.
+`argLine` and `appArgLine` have been replaced by list-based `jvmArgs` and `applicationArgs` respectively.
+
+`applicationArgs` (previously known as `applicationsArgs`) has been corrected to not perform any
+interpretation of whitepace and quotes anymore. Individual arguments are now used literally (just like `jvmArgs`).
 
 ## 2.7.3
 Fixes:

--- a/tycho-extras/tycho-eclipserun-plugin/src/main/java/org/eclipse/tycho/extras/eclipserun/EclipseRunMojo.java
+++ b/tycho-extras/tycho-eclipserun-plugin/src/main/java/org/eclipse/tycho/extras/eclipserun/EclipseRunMojo.java
@@ -170,16 +170,16 @@ public class EclipseRunMojo extends AbstractMojo {
 	 * List of applications arguments set on the command line. Example:
 	 * 
 	 * {@code
-	 * <applicationsArgs>
+	 * <applicationArgs>
 	 *   <arg>-buildfile</arg>
 	 *   <arg>build-test.xml</arg>
-	 * </applicationsArgs>
+	 * </applicationArgs>
 	 * }
 	 * 
 	 * @since 0.24.0
 	 */
-	@Parameter
-	private List<String> applicationsArgs;
+	@Parameter(alias = "applicationsArgs")
+	private List<String> applicationArgs;
 
 	/**
 	 * Kill the forked process after a certain number of seconds. If set to 0, wait
@@ -254,7 +254,7 @@ public class EclipseRunMojo extends AbstractMojo {
 	public EclipseRunMojo(File work, boolean clearWorkspaceBeforeLaunch, MavenProject project,
 			List<Dependency> dependencies, boolean addDefaultDependencies, String executionEnvironment,
 			List<Repository> repositories, MavenSession session, List<String> jvmArgs, boolean skip,
-			List<String> applicationsArgs, int forkedProcessTimeoutInSeconds, Map<String, String> environmentVariables,
+			List<String> applicationArgs, int forkedProcessTimeoutInSeconds, Map<String, String> environmentVariables,
 			EquinoxInstallationFactory installationFactory, EquinoxLauncher launcher,
 			ToolchainProvider toolchainProvider, EquinoxServiceFactory equinox, Logger logger,
 			ToolchainManager toolchainManager) {
@@ -268,7 +268,7 @@ public class EclipseRunMojo extends AbstractMojo {
 		this.session = session;
 		this.jvmArgs = jvmArgs;
 		this.skip = skip;
-		this.applicationsArgs = applicationsArgs;
+		this.applicationArgs = applicationArgs;
 		this.forkedProcessTimeoutInSeconds = forkedProcessTimeoutInSeconds;
 		this.environmentVariables = environmentVariables;
 		this.installationFactory = installationFactory;
@@ -401,8 +401,8 @@ public class EclipseRunMojo extends AbstractMojo {
 		File workspace = new File(work, "data");
 		addProgramArgs(cli, "-data", workspace.getAbsolutePath());
 
-		if (applicationsArgs != null) {
-			for (String arg : applicationsArgs) {
+		if (applicationArgs != null) {
+			for (String arg : applicationArgs) {
 				cli.addProgramArguments(arg);
 			}
 		}

--- a/tycho-extras/tycho-eclipserun-plugin/src/main/java/org/eclipse/tycho/extras/eclipserun/EclipseRunMojo.java
+++ b/tycho-extras/tycho-eclipserun-plugin/src/main/java/org/eclipse/tycho/extras/eclipserun/EclipseRunMojo.java
@@ -34,7 +34,6 @@ import org.apache.maven.toolchain.Toolchain;
 import org.apache.maven.toolchain.ToolchainManager;
 import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.util.FileUtils;
-import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.eclipse.sisu.equinox.EquinoxServiceFactory;
 import org.eclipse.sisu.equinox.launching.BundleStartLevel;
 import org.eclipse.sisu.equinox.launching.DefaultEquinoxInstallationDescription;
@@ -149,12 +148,12 @@ public class EclipseRunMojo extends AbstractMojo {
 	/**
 	 * List of JVM arguments set on the command line. Example:
 	 * 
-	 * <pre>
-	 * &lt;jvmArgs&gt;
-	 *   &lt;args&gt;-Xdebug&lt;/args&gt;
-	 *   &lt;args&gt;-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=1044&lt;/args&gt;
-	 * &lt;/jvmArgs&gt;
-	 * </pre>
+	 * {@code
+	 * <jvmArgs>
+	 *   <arg>-Xdebug<arg>
+	 *   <arg>-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=1044</arg>
+	 * </jvmArgs>
+	 * }
 	 * 
 	 * @since 0.25.0
 	 */
@@ -170,12 +169,12 @@ public class EclipseRunMojo extends AbstractMojo {
 	/**
 	 * List of applications arguments set on the command line. Example:
 	 * 
-	 * <pre>
-	 * &lt;applicationsArgs&gt;
-	 *   &lt;args&gt;-buildfile&lt;/args&gt;
-	 *   &lt;args&gt;build-test.xml&lt;/args&gt;
-	 * &lt;/applicationsArgs&gt;
-	 * </pre>
+	 * {@code
+	 * <applicationsArgs>
+	 *   <arg>-buildfile</arg>
+	 *   <arg>build-test.xml</arg>
+	 * </applicationsArgs>
+	 * }
 	 * 
 	 * @since 0.24.0
 	 */
@@ -403,8 +402,8 @@ public class EclipseRunMojo extends AbstractMojo {
 		addProgramArgs(cli, "-data", workspace.getAbsolutePath());
 
 		if (applicationsArgs != null) {
-			for (String args : applicationsArgs) {
-				cli.addProgramArguments(splitArgLine(args));
+			for (String arg : applicationsArgs) {
+				cli.addProgramArguments(arg);
 			}
 		}
 
@@ -413,14 +412,6 @@ public class EclipseRunMojo extends AbstractMojo {
 		}
 
 		return cli;
-	}
-
-	private String[] splitArgLine(String argumentLine) throws MojoExecutionException {
-		try {
-			return CommandLineUtils.translateCommandline(argumentLine);
-		} catch (Exception e) {
-			throw new MojoExecutionException("Error parsing commandline: " + e.getMessage(), e);
-		}
 	}
 
 	private void addProgramArgs(EquinoxLaunchConfiguration cli, String... arguments) {

--- a/tycho-extras/tycho-eclipserun-plugin/src/test/java/org/eclipse/tycho/extras/eclipserun/EclipseRunMojoTest.java
+++ b/tycho-extras/tycho-eclipserun-plugin/src/test/java/org/eclipse/tycho/extras/eclipserun/EclipseRunMojoTest.java
@@ -79,10 +79,10 @@ public class EclipseRunMojoTest extends AbstractTychoMojoTestCase {
 		assertTrue(vmArgs.contains("-DoptionWith=\"A space in the value\""));
 	}
 
-	public void testCreateCommandlineWithApplicationsArgs() throws IllegalAccessException, MojoExecutionException {
+	public void testCreateCommandlineWithApplicationArgs() throws IllegalAccessException, MojoExecutionException {
 		List<String> args = Arrays.asList("arg1", "literal arg with spaces",
 				"argument'with'literalquotes");
-		setVariableValueToObject(runMojo, "applicationsArgs", args);
+		setVariableValueToObject(runMojo, "applicationArgs", args);
 		LaunchConfiguration commandLine = runMojo.createCommandLine(installation);
 		List<String> programArgs = Arrays.asList(commandLine.getProgramArguments());
 		assertTrue(programArgs.contains("arg1"));

--- a/tycho-extras/tycho-eclipserun-plugin/src/test/java/org/eclipse/tycho/extras/eclipserun/EclipseRunMojoTest.java
+++ b/tycho-extras/tycho-eclipserun-plugin/src/test/java/org/eclipse/tycho/extras/eclipserun/EclipseRunMojoTest.java
@@ -79,6 +79,17 @@ public class EclipseRunMojoTest extends AbstractTychoMojoTestCase {
 		assertTrue(vmArgs.contains("-DoptionWith=\"A space in the value\""));
 	}
 
+	public void testCreateCommandlineWithApplicationsArgs() throws IllegalAccessException, MojoExecutionException {
+		List<String> args = Arrays.asList("arg1", "literal arg with spaces",
+				"argument'with'literalquotes");
+		setVariableValueToObject(runMojo, "applicationsArgs", args);
+		LaunchConfiguration commandLine = runMojo.createCommandLine(installation);
+		List<String> programArgs = Arrays.asList(commandLine.getProgramArguments());
+		assertTrue(programArgs.contains("arg1"));
+		assertTrue(programArgs.contains("literal arg with spaces"));
+		assertTrue(programArgs.contains("argument'with'literalquotes"));
+	}
+
 	public void testCreateCommandLineWithNullJvmArgs() throws MojoExecutionException {
 		LaunchConfiguration commandLine = runMojo.createCommandLine(installation);
 		assertEquals(0, commandLine.getVMArguments().length);


### PR DESCRIPTION
List-based `<applicationsArgs>` was introduced as a more deterministic
replacement to the old single-string-based `<appArgLine>` to have full
control over the arguments.

The old `<appArgLine>` has already been removed in
053b82b20a0958f935296a58390eb2ab8df2abd3.

However, even the individual entries of `<applicationsArgs>` are still
interpreted via `splitArgLine()`.

Remove this `splitArgLine()` handling and treat the arguments literally.

This is now symmetrical to the list-based `<jvmArgs>`, which already
treats elements literally.

Also adjust JavaDoc to use singular `<arg>` for the individual elements.

Fixes #1009