### PR TITLE
Don't fail if trying to set same custom EE more than once.

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/ee/ExecutionEnvironmentConfigurationImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/ee/ExecutionEnvironmentConfigurationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2014 SAP SE and others.
+ * Copyright (c) 2012, 2022 SAP SE and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -107,8 +107,7 @@ public class ExecutionEnvironmentConfigurationImpl implements ExecutionEnvironme
         }
         String profileName = getProfileName();
         Collection<String> profileNames = ExecutionEnvironmentUtils.getProfileNames(toolchainManager, session, logger);
-        boolean profileExists = profileNames
-                .contains(profileName);
+        boolean profileExists = profileNames.contains(profileName);
         if (!profileExists && ignoredByResolver) {
             throw new BuildFailureException(
                     "When using a custom execution environment profile, resolveWithExecutionEnvironmentConstraints must not be set to false");
@@ -124,10 +123,15 @@ public class ExecutionEnvironmentConfigurationImpl implements ExecutionEnvironme
                     "Cannot set full specification when a standard execution environment is configured");
         }
         if (this.customExecutionEnvironment != null) {
-            throw new IllegalStateException("Cannot set full specification for a custom profile more than once");
+            var tempEE = new CustomExecutionEnvironment(getProfileName(), systemCapabilities);
+            if (!tempEE.getProfileName().equals(customExecutionEnvironment.getProfileName())
+                    || !tempEE.getProfileProperties().equals(customExecutionEnvironment.getProfileProperties())
+                    || !tempEE.getSystemPackages().equals(customExecutionEnvironment.getSystemPackages()))
+                // fail only if the EE to be created will not match the existing custom EE
+                throw new IllegalStateException("Cannot set full specification for a custom profile more than once");
+        } else {
+            this.customExecutionEnvironment = new CustomExecutionEnvironment(getProfileName(), systemCapabilities);
         }
-
-        this.customExecutionEnvironment = new CustomExecutionEnvironment(getProfileName(), systemCapabilities);
     }
 
     @Override

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/ee/ExecutionEnvironmentConfigurationTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/ee/ExecutionEnvironmentConfigurationTest.java
@@ -21,6 +21,7 @@ import org.codehaus.plexus.logging.Logger;
 import org.codehaus.plexus.logging.console.ConsoleLogger;
 import org.eclipse.tycho.core.ee.shared.ExecutionEnvironmentConfiguration;
 import org.eclipse.tycho.core.ee.shared.SystemCapability;
+import org.eclipse.tycho.core.ee.shared.SystemCapability.Type;
 import org.eclipse.tycho.core.shared.BuildFailureException;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,7 +29,7 @@ import org.junit.Test;
 public class ExecutionEnvironmentConfigurationTest {
 
     private static final String DUMMY_ORIGIN = null;
-    private static final List<SystemCapability> DUMMY_CUSTOM_PROFILE_SPEC = Collections.<SystemCapability> emptyList();
+    private static final List<SystemCapability> DUMMY_CUSTOM_PROFILE_SPEC = Collections.emptyList();
 
     private static final String CUSTOM_PROFILE = "Custom-1.5";
     private static final String STANDARD_PROFILE = "OSGi/Minimum-1.1";
@@ -124,7 +125,7 @@ public class ExecutionEnvironmentConfigurationTest {
     public void disallowMultipleSetCustomProfileSpecification() throws Exception {
         subject.setProfileConfiguration(CUSTOM_PROFILE, DUMMY_ORIGIN);
         subject.setFullSpecificationForCustomProfile(DUMMY_CUSTOM_PROFILE_SPEC);
-        subject.setFullSpecificationForCustomProfile(DUMMY_CUSTOM_PROFILE_SPEC);
+        subject.setFullSpecificationForCustomProfile(List.of(new SystemCapability(Type.OSGI_EE, "dummy", "0.0.0")));
     }
 
     @Test(expected = IllegalStateException.class)


### PR DESCRIPTION
If building with useJDK=BREE and there is no jdk for given version
properly set compile fails with "Cannot set full specification for a
custom profile more than once" as there could be more than one plugin
setting it e.g. tycho-compiler-plugin and
tycho-p2-extras-plugin:compare-version-with-baselines .
This change creates temp EE and compare its values to the existing one
and if they match continue happily.