### PR TITLE
[Maven-Target] Consider extra-repositories when fetching source-jars

### DIFF
--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/resolver/MavenTargetDefinitionContent.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/resolver/MavenTargetDefinitionContent.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -257,7 +256,7 @@ public class MavenTargetDefinitionContent implements TargetDefinitionContent {
                             Collection<?> sourceArtifacts = mavenDependenciesResolver.resolve(
                                     mavenArtifact.getGroupId(), mavenArtifact.getArtifactId(),
                                     mavenArtifact.getVersion(), mavenArtifact.getPackagingType(), "sources", null,
-                                    MavenDependenciesResolver.DEEP_NO_DEPENDENCIES, Collections.emptyList());
+                                    MavenDependenciesResolver.DEEP_NO_DEPENDENCIES, location.getRepositoryReferences());
                             Iterator<IArtifactFacade> sources = sourceArtifacts.stream()
                                     .filter(IArtifactFacade.class::isInstance).map(IArtifactFacade.class::cast)
                                     .iterator();


### PR DESCRIPTION
This PR should fix the fetch of source bundles when additional repositories are specified in a Maven-target.

In https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/282#issuecomment-1152122846 it was discovered that additional repositories are not considered when source-artifacts are downloaded.

I tried it locally and the resolution of the Eclipse-platform aggregator succeed and the source-jar was downloaded.
But when using the current Tycho master-snapshot the resolution of the Eclipse-platform aggregator  build succeeds as well (I likely have to wait until the corresponding feature is build). However the sources-jar is not downloaded with the current master, which happens with this fix and with this fix also the `<artifact-id>-sources.jar.lastUpdated` contains the additional repository.
So I'm relatively sure that this will fix the problem (and the code-change itself just looks reasonable to me).