### PR TITLE
Tycho reports wrong type in case of maven GAV restored from UI

### DIFF
--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/resolver/P2ResolverFactoryImpl.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/resolver/P2ResolverFactoryImpl.java
@@ -229,6 +229,11 @@ public class P2ResolverFactoryImpl implements P2ResolverFactory {
 
                         @Override
                         public String getType() {
+                            String type = properties.get(TychoConstants.PROP_TYPE);
+                            if (type != null && !type.isBlank()) {
+                                return type;
+                            }
+                            //fallback for older repository formats
                             return properties.get(TychoConstants.PROP_EXTENSION);
                         }
 


### PR DESCRIPTION
Wrong metadata type is injected, found while debugging https://github.com/eclipse/tycho/issues/1043