### PR TITLE
[Build] Use eclipse/dash-licenses' reusable licenses-check workflow

### DIFF
--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -1,7 +1,6 @@
-# This workflow will build a Java project with Maven
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+# This workflow will check for Maven projects if the licenses of all (transitive) dependencies are vetted.
 
-name: License check
+name: License vetting status check
 
 on:
   push:
@@ -12,26 +11,13 @@ on:
     branches: 
      - 'master'
      - 'tycho-*'
+  issue_comment:
+    types: [created]
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        java-version: '11'
-        distribution: 'adopt'
-    - name: Cache local Maven repository
-      uses: actions/cache@v3
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
-    - name: License check
-      run: | 
-        mvn -U -V -e -B -ntp org.eclipse.dash:license-tool-plugin:license-check --file pom.xml -Ddash.fail=true
+  call-license-check:
+    uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
+    with:
+      projectId: technology.tycho
+    secrets:
+      gitlabAPIToken: ${{ secrets.TYCHO_GITLAB_API_TOKEN }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '**/*.target') }}
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Set up Maven


### PR DESCRIPTION
The workflow checks if all licenses are vetted on each push to the master branch and on each new (push to a) PR.
Furthermore committers can request a review of unvetted licenses by adding the following comment to a PR (open or closed):
```
/request-license-review
```
If a committer requests a license-review the license vetting summary files created by the dash-tools plug-in are attached to the workflow. So if you are interested in the summary you can comment `/request-license-review` and download the summary, even if you know all licenses are vetted. The workflow handles this case gracefully.

The workflow works quite well for m2e, but for the near future I cannot foresee version updates so in order to test it more we need to use it in more projects.

@akurtakov, @mickaelistria if you agree I can open a corresponding EFN help-desk issue to ask for inclusion of the GITLAB_API token for tycho.

In the meantime this workflow can be used already. Only the license review requests will be rejected.
At the moment the workflow does not run on pushes to the specified branches, but I have already opened a PR to address this, which hopefully gets merged soon: https://github.com/eclipse/dash-licenses/pull/177

Additionally with this PR *.target files are considered when computing the dependency cache key.