### PR TITLE
Remove now obsolet license-tool-plugin calls in Jenkins and repos

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
 	stages {
 		stage('Build') {
 			steps {
-				sh 'mvn --batch-mode -U -V -e clean install org.eclipse.dash:license-tool-plugin:license-check -Pits -Dmaven.repo.local=$WORKSPACE/.m2/repository'
+				sh 'mvn --batch-mode -U -V -e clean install -Pits -Dmaven.repo.local=$WORKSPACE/.m2/repository'
 			}
 			post {
 				always {

--- a/pom.xml
+++ b/pom.xml
@@ -570,16 +570,6 @@
 		</profile>
 	</profiles>
 
-	<pluginRepositories>
-		<pluginRepository>
-		  	<id>dash-licenses-snapshots</id>
-		  	<url>https://repo.eclipse.org/content/repositories/dash-licenses-snapshots/</url>
-		  	<snapshots>
-		  	  <enabled>true</enabled>
-		  	</snapshots>
-  		</pluginRepository>
-	</pluginRepositories>
-
 	<distributionManagement>
 		<site>
 			<id>tycho.site</id>


### PR DESCRIPTION
Because Tycho now uses the eclipse/dash-licenses' reusable licenses-check GH workflow (added via https://github.com/eclipse/tycho/pull/1049)
- calling the license-tool-plugin in the Jenkins build is not necessary any more (was actually already before since when a dedicated GH-workflow was used for that)
- the dash-licenses-snapshots repository can be removed (it is added by the workflow via a dedicated maven-settings file)