### PR TITLE
Fix Mojo Configuration of DS Plugin is ignored

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/DeclarativeServicesConfiguration.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/DeclarativeServicesConfiguration.java
@@ -25,4 +25,10 @@ public interface DeclarativeServicesConfiguration {
      */
     Version getSpecificationVersion();
 
+    /**
+     * 
+     * @return the path where generated data should be placed
+     */
+    String getPath();
+
 }

--- a/tycho-ds-plugin/src/main/java/org/eclipse/tycho/ds/DeclarativeServicesMojo.java
+++ b/tycho-ds-plugin/src/main/java/org/eclipse/tycho/ds/DeclarativeServicesMojo.java
@@ -71,7 +71,7 @@ public class DeclarativeServicesMojo extends AbstractMojo {
 	/**
 	 * The desired path where to place component definitions
 	 */
-	@Parameter(property = "tycho.ds.path", defaultValue = "OSGI-INF")
+	@Parameter(property = "tycho.ds.path", defaultValue = DeclarativeServiceConfigurationReader.DEFAULT_PATH)
 	private String path = "OSGI-INF";
 
 	@Parameter(property = "project", readonly = true)
@@ -97,8 +97,9 @@ public class DeclarativeServicesMojo extends AbstractMojo {
 					return;
 				}
 				File outputDirectory = new File(project.getBuild().getOutputDirectory());
-				File targetDirectory = new File(outputDirectory, path);
-				File projectBaseDir = new File(project.getBasedir(), path);
+				String childPath = configuration.getPath();
+				File targetDirectory = new File(outputDirectory, childPath);
+				File projectBaseDir = new File(project.getBasedir(), childPath);
 				try (Jar mavenProjectJar = new Jar(project.getName(), outputDirectory, null);
 						Analyzer analyzer = new Analyzer(mavenProjectJar)) {
 					Map<String, Resource> directory = analyzer.getJar().getDirectory("OSGI-INF");


### PR DESCRIPTION
Currently the mojo config is assumed to be *attributes* of the
configuration element, but actually the are child *elements*

Also adding some more debug output in case something is ignored and user
wants to find out why