### PR TITLE
Improvements to tycho-its

### DIFF
--- a/tycho-its/pom.xml
+++ b/tycho-its/pom.xml
@@ -204,11 +204,6 @@
 			<version>2.2</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.maven.shared</groupId>
-			<artifactId>maven-shared-utils</artifactId>
-			<version>3.3.4</version>
-		</dependency>
-		<dependency>
 			<groupId>org.sonatype.sisu</groupId>
 			<artifactId>sisu-inject-plexus</artifactId>
 			<version>2.6.0</version>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryDownloadTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/p2Repository/P2RepositoryDownloadTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -34,7 +35,7 @@ public class P2RepositoryDownloadTest extends AbstractTychoIntegrationTest {
 		File indexFile = new File(localRepository, FileBasedTychoRepositoryIndex.ARTIFACTS_INDEX_RELPATH);
 		String[] bundles = { "org.eclipse.swt", "com.google.guava" };
 		if (indexFile.exists()) {
-			List<String> lines = FileUtils.readLines(indexFile, StandardCharsets.UTF_8);
+			List<String> lines = Files.readAllLines(indexFile.toPath(), StandardCharsets.UTF_8);
 			FileUtils.writeLines(indexFile, lines.stream().filter(line -> {
 				for (String bundle : bundles) {
 					if (line.contains("p2.osgi.bundle:" + bundle)) {

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/product/ProductMixedVersionsTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/product/ProductMixedVersionsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Christoph Läubrich and others.
+ * Copyright (c) 2021, 2022 Christoph Läubrich and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,9 +17,9 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Arrays;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
 import org.eclipse.tycho.test.util.ResourceUtil.P2Repositories;
@@ -36,7 +36,7 @@ public class ProductMixedVersionsTest extends AbstractTychoIntegrationTest {
 		File product = new File(verifier.getBasedir(), "product/target/products/com.test.sample.product");
 		File[] bundleInfoFiles = assertFileExists(product,
 				"**/configuration/org.eclipse.equinox.simpleconfigurator/bundles.info");
-		for (String bundleInfo : FileUtils.readLines(bundleInfoFiles[0], StandardCharsets.UTF_8)) {
+		for (String bundleInfo : Files.readAllLines(bundleInfoFiles[0].toPath(), StandardCharsets.UTF_8)) {
 			String[] parts = bundleInfo.split(",");
 			if (parts.length == 5 && "org.apache.activemq.activemq-core".equals(parts[0])) {
 				assertEquals("Version of activemq bundle does not match", "5.2.0", parts[1]);

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/selundqma/SeLundqmaTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/selundqma/SeLundqmaTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 Sonatype Inc. and others.
+ * Copyright (c) 2008, 2022 Sonatype Inc. and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  * Contributors:
  *    Sonatype Inc. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.tycho.test.SeLundqma;
+package org.eclipse.tycho.test.selundqma;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;


### PR DESCRIPTION
* Fix package names to be all lowercase
* Remove maven-shared-utils - it's being replaced in maven land too and
is used only in its. Removing it makes commons-io go to lower version as
it's transitive dependency and thus new methods used no longer exist.
Luckily, there is direct replacement in java.nio thus no need to pay
more attention to it.