### PR TITLE
Fix pom.model properties read for bundle-projects and add it-tests

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTychoResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/resolver/DefaultTychoResolver.java
@@ -12,9 +12,6 @@
  *******************************************************************************/
 package org.eclipse.tycho.core.resolver;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -70,7 +67,6 @@ public class DefaultTychoResolver implements TychoResolver {
     public static final String TYCHO_ENV_OSGI_WS = "tycho.env.osgi.ws";
     public static final String TYCHO_ENV_OSGI_OS = "tycho.env.osgi.os";
     public static final String TYCHO_ENV_OSGI_ARCH = "tycho.env.osgi.arch";
-    public static final String PROPERTY_PREFIX = "pom.model.property.";
 
     @Override
     public void setupProject(MavenSession session, MavenProject project, ReactorProject reactorProject) {
@@ -97,7 +93,6 @@ public class DefaultTychoResolver implements TychoResolver {
         reactorProject.setContextValue(TychoConstants.CTX_MERGED_PROPERTIES, properties);
 
         setTychoEnvironmentProperties(properties, project);
-        setBuildProperties(project);
 
         TargetPlatformConfiguration configuration = configurationReader.getTargetPlatformConfiguration(session,
                 project);
@@ -195,29 +190,4 @@ public class DefaultTychoResolver implements TychoResolver {
         project.getProperties().put(TYCHO_ENV_OSGI_OS, os);
         project.getProperties().put(TYCHO_ENV_OSGI_ARCH, arch);
     }
-
-    protected void setBuildProperties(MavenProject project) {
-        File pomfile = project.getFile();
-        if (pomfile != null) {
-            File buildPropertiesFile = new File(pomfile.getParentFile(), "build.properties");
-            if (buildPropertiesFile.isFile() && buildPropertiesFile.length() > 0) {
-                Properties buildProperties = new Properties();
-                try {
-                    try (FileInputStream stream = new FileInputStream(buildPropertiesFile)) {
-                        buildProperties.load(stream);
-                    }
-                    Properties projectProperties = project.getProperties();
-                    buildProperties.stringPropertyNames().forEach(key -> {
-                        if (key.startsWith(PROPERTY_PREFIX)) {
-                            projectProperties.setProperty(key.substring(PROPERTY_PREFIX.length()),
-                                    buildProperties.getProperty(key));
-                        }
-                    });
-                } catch (IOException e) {
-                    logger.warn("reading build.properties from project " + project.getName() + " failed", e);
-                }
-            }
-        }
-    }
-
 }

--- a/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/AbstractTychoMapping.java
+++ b/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/AbstractTychoMapping.java
@@ -280,15 +280,18 @@ public abstract class AbstractTychoMapping implements Mapping, ModelReader {
         String location = PolyglotModelUtil.getLocation(options);
         File file = new File(location);
         try {
-            if (file.isDirectory()) {
-                return getBuildProperties(file);
-            } else if (file.isFile()) {
-                return getBuildProperties(file.getParentFile());
-            }
+            return getEnhancementProperties(file);
         } catch (IOException e) {
             logger.warn("reading EnhancementProperties encountered a problem and was skipped for this reason", e);
         }
         return null;
+    }
+
+    protected Properties getEnhancementProperties(File file) throws IOException {
+        if (file.isDirectory()) {
+            return getBuildProperties(file);
+        }
+        return getBuildProperties(file.getParentFile());
     }
 
     private static void setLocation(Model model, File modelSource) {

--- a/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoBundleMapping.java
+++ b/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoBundleMapping.java
@@ -113,6 +113,12 @@ public class TychoBundleMapping extends AbstractTychoMapping {
 
     }
 
+    @Override
+    protected Properties getEnhancementProperties(File file) throws IOException {
+        //Look up build.properties in the project's root. The passed file points to the 'META-INF' folder.
+        return getBuildProperties(file.getParentFile());
+    }
+
     private static Plugin createBndPlugin(Model model) {
         //See https://github.com/bndtools/bnd/blob/master/maven/bnd-maven-plugin/README.md#bnd-process-goal 
         Build build = model.getBuild();

--- a/tycho-its/projects/pomless-model/.mvn/extensions.xml
+++ b/tycho-its/projects/pomless-model/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions>
+  <extension>
+    <groupId>org.eclipse.tycho</groupId>
+    <artifactId>tycho-build</artifactId>
+    <version>${tycho-version}</version>
+  </extension>
+</extensions>

--- a/tycho-its/projects/pomless-model/.mvn/maven.config
+++ b/tycho-its/projects/pomless-model/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Dtycho-version=3.0.0-SNAPSHOT
+-Dtycho.pomless.aggregator.names=bundles,bundles-with-enhanced-parents

--- a/tycho-its/projects/pomless-model/alternative-parent/pom.xml
+++ b/tycho-its/projects/pomless-model/alternative-parent/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>foo.bar</groupId>
+		<artifactId>simple</artifactId>
+		<version>1.0.0</version>
+	</parent>
+	<groupId>foo.other</groupId>
+	<artifactId>another-parent</artifactId>
+	<packaging>pom</packaging>
+	<name>Alternative Parent 2 from pomXML</name>
+	<properties>
+		<custom.user.property>alternative-parent-from-pomXML</custom.user.property>
+	</properties>
+</project>

--- a/tycho-its/projects/pomless-model/bundles-2/foo.bar.bundle-5/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/pomless-model/bundles-2/foo.bar.bundle-5/META-INF/MANIFEST.MF
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Plugin
+Bundle-SymbolicName: foo.bar.bundle-5
+Bundle-Version: 1.0.0
+Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/tycho-its/projects/pomless-model/bundles-2/foo.bar.bundle-5/build.properties
+++ b/tycho-its/projects/pomless-model/bundles-2/foo.bar.bundle-5/build.properties
@@ -1,0 +1,3 @@
+bin.includes = META-INF/
+pom.model.name = Bundle 5 pomless
+# Inherit pom.model.property.custom.user.property from parent

--- a/tycho-its/projects/pomless-model/bundles-2/pom.xml
+++ b/tycho-its/projects/pomless-model/bundles-2/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>foo.bar</groupId>
+		<artifactId>simple</artifactId>
+		<version>1.0.0</version>
+	</parent>
+	<artifactId>bundles-2</artifactId>
+	<version>1.1.0</version>
+	<packaging>pom</packaging>
+	<name>Aggregator 2 from pomXML</name>
+	<properties>
+		<custom.user.property>aggregator2-from-pomXML</custom.user.property>
+	</properties>
+	<modules>
+		<module>foo.bar.bundle-5</module>
+	</modules>
+</project>

--- a/tycho-its/projects/pomless-model/bundles-with-enhanced-parents/build.properties
+++ b/tycho-its/projects/pomless-model/bundles-with-enhanced-parents/build.properties
@@ -1,0 +1,4 @@
+pom.model.groupId = bundles-enhanced-pomless
+pom.model.version = 1.2.0
+pom.model.name = Aggregator 3 pomless
+pom.model.property.custom.user.property = aggregator3-pomless

--- a/tycho-its/projects/pomless-model/bundles-with-enhanced-parents/foo.bar.bundle-3/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/pomless-model/bundles-with-enhanced-parents/foo.bar.bundle-3/META-INF/MANIFEST.MF
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Plugin
+Bundle-SymbolicName: foo.bar.bundle-3
+Bundle-Version: 1.0.0
+Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/tycho-its/projects/pomless-model/bundles-with-enhanced-parents/foo.bar.bundle-3/build.properties
+++ b/tycho-its/projects/pomless-model/bundles-with-enhanced-parents/foo.bar.bundle-3/build.properties
@@ -1,0 +1,4 @@
+bin.includes = META-INF/
+tycho.pomless.parent = ../../alternative-parent
+pom.model.name = Bundle 3 pomless
+# Inherit pom.model.property.custom.user.property from parent

--- a/tycho-its/projects/pomless-model/bundles-with-enhanced-parents/foo.bar.bundle-4/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/pomless-model/bundles-with-enhanced-parents/foo.bar.bundle-4/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Plugin
+Bundle-SymbolicName: foo.bar.bundle-4
+Bundle-Version: 1.0.0
+Automatic-Module-Name: foo.bar.plugin
+Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/tycho-its/projects/pomless-model/bundles-with-enhanced-parents/foo.bar.bundle-4/build.properties
+++ b/tycho-its/projects/pomless-model/bundles-with-enhanced-parents/foo.bar.bundle-4/build.properties
@@ -1,0 +1,6 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .
+pom.model.name = Bundle 4 pomless
+# Inherit pom.model.property.custom.user.property from parent

--- a/tycho-its/projects/pomless-model/bundles/foo.bar.bundle-2/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/pomless-model/bundles/foo.bar.bundle-2/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Plugin
+Bundle-SymbolicName: foo.bar.bundle-2
+Bundle-Version: 1.0.0
+Automatic-Module-Name: foo.bar.plugin
+Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/tycho-its/projects/pomless-model/bundles/foo.bar.bundle-2/build.properties
+++ b/tycho-its/projects/pomless-model/bundles/foo.bar.bundle-2/build.properties
@@ -1,0 +1,4 @@
+bin.includes = META-INF/
+tycho.pomless.parent = ../../alternative-parent
+pom.model.name = Bundle 2 pomless
+pom.model.property.custom.user.property = bundle2-pomless

--- a/tycho-its/projects/pomless-model/bundles/foo.bar.bundle-2/pom.xml
+++ b/tycho-its/projects/pomless-model/bundles/foo.bar.bundle-2/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>foo.bar</groupId>
+		<artifactId>simple</artifactId>
+		<version>1.0.0</version>
+		<relativePath>../..</relativePath>
+	</parent>
+	<artifactId>foo.bar.bundle-2</artifactId>
+	<packaging>eclipse-plugin</packaging>
+	<name>Bundle 2 from pom.xml</name>
+	<properties>
+		<custom.user.property>bundle2-from-pomXML</custom.user.property>
+	</properties>
+</project>

--- a/tycho-its/projects/pomless-model/bundles/foo.bar.bundle/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/pomless-model/bundles/foo.bar.bundle/META-INF/MANIFEST.MF
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Plugin
+Bundle-SymbolicName: foo.bar.bundle
+Bundle-Version: 1.0.0
+Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/tycho-its/projects/pomless-model/bundles/foo.bar.bundle/build.properties
+++ b/tycho-its/projects/pomless-model/bundles/foo.bar.bundle/build.properties
@@ -1,0 +1,3 @@
+bin.includes = META-INF/
+pom.model.name = Bundle 1 pomless
+pom.model.property.custom.user.property = bundle1-pomless

--- a/tycho-its/projects/pomless-model/foo.bar.feature-2/build.properties
+++ b/tycho-its/projects/pomless-model/foo.bar.feature-2/build.properties
@@ -1,0 +1,3 @@
+bin.includes = feature.xml
+pom.model.name = Feature 2 pomless
+pom.model.property.custom.user.property = feature2-pomless

--- a/tycho-its/projects/pomless-model/foo.bar.feature-2/feature.xml
+++ b/tycho-its/projects/pomless-model/foo.bar.feature-2/feature.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="foo.bar.feature-2"
+      label="Feature"
+      version="1.0.0">
+
+   <description url="http://www.example.com/description">
+      [Enter Feature Description here.]
+   </description>
+
+   <copyright url="http://www.example.com/copyright">
+      [Enter Copyright Description here.]
+   </copyright>
+
+   <license url="http://www.example.com/license">
+      [Enter License Description here.]
+   </license>
+
+   <plugin
+         id="foo.bar.plugin-2"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
+</feature>

--- a/tycho-its/projects/pomless-model/foo.bar.feature-2/pom.xml
+++ b/tycho-its/projects/pomless-model/foo.bar.feature-2/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>foo.bar</groupId>
+		<artifactId>simple</artifactId>
+		<version>1.0.0</version>
+	</parent>
+	<artifactId>foo.bar.feature-2</artifactId>
+	<packaging>eclipse-feature</packaging>
+	<name>Feature 2 from pom.xml</name>
+	<properties>
+		<custom.user.property>feature2-from-pomXML</custom.user.property>
+	</properties>
+</project>

--- a/tycho-its/projects/pomless-model/foo.bar.feature/build.properties
+++ b/tycho-its/projects/pomless-model/foo.bar.feature/build.properties
@@ -1,0 +1,3 @@
+bin.includes = feature.xml
+pom.model.name = Feature 1 pomless
+pom.model.property.custom.user.property = feature1-pomless

--- a/tycho-its/projects/pomless-model/foo.bar.feature/feature.xml
+++ b/tycho-its/projects/pomless-model/foo.bar.feature/feature.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="foo.bar.feature"
+      label="Feature"
+      version="1.0.0">
+
+   <description url="http://www.example.com/description">
+      [Enter Feature Description here.]
+   </description>
+
+   <copyright url="http://www.example.com/copyright">
+      [Enter Copyright Description here.]
+   </copyright>
+
+   <license url="http://www.example.com/license">
+      [Enter License Description here.]
+   </license>
+
+   <plugin
+         id="foo.bar.plugin"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
+</feature>

--- a/tycho-its/projects/pomless-model/foo.bar.plugin-2/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/pomless-model/foo.bar.plugin-2/META-INF/MANIFEST.MF
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Plugin
+Bundle-SymbolicName: foo.bar.plugin-2
+Bundle-Version: 1.0.0
+Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/tycho-its/projects/pomless-model/foo.bar.plugin-2/build.properties
+++ b/tycho-its/projects/pomless-model/foo.bar.plugin-2/build.properties
@@ -1,0 +1,3 @@
+bin.includes = META-INF/
+pom.model.name = Plugin 2 pomless
+pom.model.property.custom.user.property = plugin2-pomless

--- a/tycho-its/projects/pomless-model/foo.bar.plugin-2/pom.xml
+++ b/tycho-its/projects/pomless-model/foo.bar.plugin-2/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>foo.bar</groupId>
+		<artifactId>simple</artifactId>
+		<version>1.0.0</version>
+	</parent>
+	<artifactId>foo.bar.plugin-2</artifactId>
+	<packaging>eclipse-plugin</packaging>
+	<name>Plugin 2 from pom.xml</name>
+	<properties>
+		<custom.user.property>plugin2-from-pomXML</custom.user.property>
+	</properties>
+</project>

--- a/tycho-its/projects/pomless-model/foo.bar.plugin/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/pomless-model/foo.bar.plugin/META-INF/MANIFEST.MF
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Plugin
+Bundle-SymbolicName: foo.bar.plugin
+Bundle-Version: 1.0.0
+Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/tycho-its/projects/pomless-model/foo.bar.plugin/build.properties
+++ b/tycho-its/projects/pomless-model/foo.bar.plugin/build.properties
@@ -1,0 +1,3 @@
+bin.includes = META-INF/
+pom.model.name = Plugin 1 pomless
+pom.model.property.custom.user.property = plugin1-pomless

--- a/tycho-its/projects/pomless-model/foo.bar.product-2/build.properties
+++ b/tycho-its/projects/pomless-model/foo.bar.product-2/build.properties
@@ -1,0 +1,2 @@
+pom.model.name = Product 2 pomless
+pom.model.property.custom.user.property = product2-pomless

--- a/tycho-its/projects/pomless-model/foo.bar.product-2/foo.bar.product
+++ b/tycho-its/projects/pomless-model/foo.bar.product-2/foo.bar.product
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product name="Product" uid="foo.bar.product-2" id="org.eclipse.platform.ide" application="org.eclipse.ui.ide.workbench" version="1.0.0" useFeatures="true" includeLaunchers="false" autoIncludeRequirements="true">
+
+   <configIni use="default">
+   </configIni>
+
+   <launcherArgs>
+      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
+      </vmArgsMac>
+   </launcherArgs>
+
+   <features>
+      <feature id="foo.bar.feature-2"/>
+   </features>
+
+
+</product>

--- a/tycho-its/projects/pomless-model/foo.bar.product-2/pom.xml
+++ b/tycho-its/projects/pomless-model/foo.bar.product-2/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>foo.bar</groupId>
+		<artifactId>simple</artifactId>
+		<version>1.0.0</version>
+	</parent>
+	<artifactId>foo.bar.product-2</artifactId>
+	<packaging>eclipse-repository</packaging>
+	<name>Product 2 from pom.xml</name>
+	<properties>
+		<custom.user.property>product2-from-pomXML</custom.user.property>
+	</properties>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-director-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>materialize-products</id>
+						<goals>
+							<goal>materialize-products</goal>
+						</goals>
+						<configuration>
+							<products>
+								<product>
+									<id>foo.bar.product-2</id>
+								</product>
+							</products>
+						</configuration>
+					</execution>
+					<execution>
+						<id>archive-products</id>
+						<goals>
+							<goal>archive-products</goal>
+						</goals>
+						<configuration>
+							<products>
+								<product>
+									<id>foo.bar.product-2</id>
+								</product>
+							</products>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/projects/pomless-model/foo.bar.product/build.properties
+++ b/tycho-its/projects/pomless-model/foo.bar.product/build.properties
@@ -1,0 +1,2 @@
+pom.model.name = Product 1 pomless
+pom.model.property.custom.user.property = product1-pomless

--- a/tycho-its/projects/pomless-model/foo.bar.product/foo.bar.product
+++ b/tycho-its/projects/pomless-model/foo.bar.product/foo.bar.product
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product name="Product" uid="foo.bar.product" id="org.eclipse.platform.ide" application="org.eclipse.ui.ide.workbench" version="1.0.0" useFeatures="true" includeLaunchers="false" autoIncludeRequirements="true">
+
+   <configIni use="default">
+   </configIni>
+
+   <launcherArgs>
+      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
+      </vmArgsMac>
+   </launcherArgs>
+
+   <features>
+      <feature id="foo.bar.feature"/>
+   </features>
+
+
+</product>

--- a/tycho-its/projects/pomless-model/foo.bar.target-2/build.properties
+++ b/tycho-its/projects/pomless-model/foo.bar.target-2/build.properties
@@ -1,0 +1,2 @@
+pom.model.name = Target 2 pomless
+pom.model.property.custom.user.property = target2-pomless

--- a/tycho-its/projects/pomless-model/foo.bar.target-2/foo.bar.target
+++ b/tycho-its/projects/pomless-model/foo.bar.target-2/foo.bar.target
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="foo.bar.target-2">
+	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/releases/2022-06/"/>
+			<unit id="org.eclipse.osgi" version="0.0.0"/>
+		</location>
+	</locations>
+</target>

--- a/tycho-its/projects/pomless-model/foo.bar.target-2/pom.xml
+++ b/tycho-its/projects/pomless-model/foo.bar.target-2/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>foo.bar</groupId>
+		<artifactId>simple</artifactId>
+		<version>1.0.0</version>
+	</parent>
+	<artifactId>foo.bar.target-2</artifactId>
+	<packaging>eclipse-target-definition</packaging>
+	<name>Target 2 from pom.xml</name>
+	<properties>
+		<custom.user.property>target2-from-pomXML</custom.user.property>
+	</properties>
+</project>

--- a/tycho-its/projects/pomless-model/foo.bar.target/build.properties
+++ b/tycho-its/projects/pomless-model/foo.bar.target/build.properties
@@ -1,0 +1,2 @@
+pom.model.name = Target 1 pomless
+pom.model.property.custom.user.property = target1-pomless

--- a/tycho-its/projects/pomless-model/foo.bar.target/foo.bar.target
+++ b/tycho-its/projects/pomless-model/foo.bar.target/foo.bar.target
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="foo.bar.target">
+	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/releases/2022-06/"/>
+			<unit id="org.eclipse.osgi" version="0.0.0"/>
+		</location>
+	</locations>
+</target>

--- a/tycho-its/projects/pomless-model/pom.xml
+++ b/tycho-its/projects/pomless-model/pom.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>foo.bar</groupId>
+	<artifactId>simple</artifactId>
+	<version>1.0.0</version>
+
+	<packaging>pom</packaging>
+
+	<properties>
+		<tycho.version>${tycho-version}</tycho.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<custom.user.property>the-default-value</custom.user.property>
+	</properties>
+	<!-- 
+	This case tests demonstrates Tycho's capabilities to enhance the pom-model via build.properties.
+	The Plugin projects are stripped down to the minimum to keep this case small 
+	and are therefore not a good examples for real life projects.
+	-->
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho.version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho.version}</version>
+				<configuration>
+					<target>
+						<artifact>
+							<groupId>foo.bar</groupId>
+							<artifactId>foo.bar</artifactId>
+							<version>1.0.0</version>
+						</artifact>
+					</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<version>3.1.0</version>
+				<executions>
+					<execution>
+						<id>display-project-pom-model-attributes</id>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<phase>generate-sources</phase>
+						<configuration>
+							<target>
+								<echo message="GAV=${project.groupId}:${project.artifactId}:${project.version}:${project.packaging}${line.separator}" file="${project.build.directory}/pommodel.data" append="false" />
+								<echo message="project.name=${project.name}${line.separator}" file="${project.build.directory}/pommodel.data" append="true" />
+								<echo message="custom.user.property=${custom.user.property}${line.separator}" file="${project.build.directory}/pommodel.data" append="true" />
+							</target>
+						</configuration>
+					</execution>
+
+				</executions>
+			</plugin>
+		</plugins>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-p2-director-plugin</artifactId>
+					<version>${tycho.version}</version>
+					<executions>
+						<execution>
+							<id>materialize-products</id>
+							<goals>
+								<goal>materialize-products</goal>
+							</goals>
+							<phase>none</phase>
+						</execution>
+						<execution>
+							<id>archive-products</id>
+							<goals>
+								<goal>archive-products</goal>
+							</goals>
+							<phase>none</phase>
+						</execution>
+						<execution>
+							<id>default-assemble-repository</id>
+							<goals>
+								<goal>assemble-repository</goal>
+							</goals>
+							<phase>none</phase>
+						</execution>
+						<execution>
+							<id>default-archive-repository</id>
+							<goals>
+								<goal>archive-repository</goal>
+							</goals>
+							<phase>none</phase>
+						</execution>
+					</executions>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+	<modules>
+		<module>foo.bar.target</module>
+		<module>foo.bar.target-2</module>
+
+		<module>bundles</module>
+		<module>bundles-2</module>
+		<module>bundles-with-enhanced-parents</module>
+
+		<module>foo.bar.plugin</module>
+		<module>foo.bar.plugin-2</module>
+		<module>foo.bar.feature</module>
+		<module>foo.bar.feature-2</module>
+		<module>foo.bar.product</module>
+		<module>foo.bar.product-2</module>
+	</modules>
+</project>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/buildextension/PomlessTest.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/buildextension/PomlessTest.java
@@ -1,9 +1,19 @@
 package org.eclipse.tycho.test.buildextension;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 import org.apache.maven.it.Verifier;
 import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
@@ -20,5 +30,117 @@ public class PomlessTest extends AbstractTychoIntegrationTest {
 		verifier.verifyErrorFreeLog();
 		File file = new File(verifier.getBasedir(), "bnd/target/classes/module-info.class");
 		assertTrue("module-info.class is not generated!", file.isFile());
+	}
+
+	@Test
+	public void testPomlessModel() throws Exception {
+		// This methods tests:
+		// - build.properties (pom.model attributes and properties) are read for:
+		// -> Plug-ins, Features, Products(Repos), Targets, Aggregators
+		// - tycho.pomless.parent is considered
+		// - explicit pom.xml is always preferred
+
+		Verifier verifier = getVerifier("pomless-model", false, true);
+		verifier.executeGoals(List.of("clean", "package"));
+		verifier.verifyErrorFreeLog();
+
+		Map<Path, ModelData> projectData = extractPomModelProperties(Path.of(verifier.getBasedir()));
+
+		assertProjectData("bundles/foo.bar.bundle", projectData, //
+				"foo.bar:foo.bar.bundle:1.0.0:eclipse-plugin", "Bundle 1 pomless", "bundle1-pomless");
+		assertProjectData("bundles/foo.bar.bundle-2", projectData, //
+				"foo.bar:foo.bar.bundle-2:1.0.0:eclipse-plugin", "Bundle 2 from pom.xml", "bundle2-from-pomXML");
+
+		assertProjectData("bundles-2/foo.bar.bundle-5", projectData, //
+				"foo.bar:foo.bar.bundle-5:1.0.0:eclipse-plugin", "Bundle 5 pomless", "aggregator2-from-pomXML");
+
+		assertProjectData("bundles-with-enhanced-parents/foo.bar.bundle-3", projectData, //
+				"foo.other:foo.bar.bundle-3:1.0.0:eclipse-plugin", "Bundle 3 pomless",
+				"alternative-parent-from-pomXML");
+		assertProjectData("bundles-with-enhanced-parents/foo.bar.bundle-4", projectData, //
+				"bundles-enhanced-pomless:foo.bar.bundle-4:1.0.0:eclipse-plugin", "Bundle 4 pomless",
+				"aggregator3-pomless");
+
+		assertProjectData("foo.bar.plugin", projectData, //
+				"foo.bar:foo.bar.plugin:1.0.0:eclipse-plugin", "Plugin 1 pomless", "plugin1-pomless");
+		assertProjectData("foo.bar.plugin-2", projectData, //
+				"foo.bar:foo.bar.plugin-2:1.0.0:eclipse-plugin", "Plugin 2 from pom.xml", "plugin2-from-pomXML");
+
+		assertProjectData("foo.bar.feature", projectData, //
+				"foo.bar:foo.bar.feature:1.0.0:eclipse-feature", "Feature 1 pomless", "feature1-pomless");
+		assertProjectData("foo.bar.feature-2", projectData, //
+				"foo.bar:foo.bar.feature-2:1.0.0:eclipse-feature", "Feature 2 from pom.xml", "feature2-from-pomXML");
+
+		assertProjectData("foo.bar.target", projectData, //
+				"foo.bar:foo.bar:1.0.0:eclipse-target-definition", "Target 1 pomless", "target1-pomless");
+		assertProjectData("foo.bar.target-2", projectData, //
+				"foo.bar:foo.bar.target-2:1.0.0:eclipse-target-definition", "Target 2 from pom.xml",
+				"target2-from-pomXML");
+
+		assertProjectData("foo.bar.product", projectData, //
+				"foo.bar:foo.bar.product:1.0.0:eclipse-repository", "Product 1 pomless", "product1-pomless");
+		assertProjectData("foo.bar.product-2", projectData, //
+				"foo.bar:foo.bar.product-2:1.0.0:eclipse-repository", "Product 2 from pom.xml", "product2-from-pomXML");
+
+		assertProjectData(".", projectData, //
+				"foo.bar:simple:1.0.0:pom", "simple", "the-default-value");
+		assertProjectData("bundles", projectData, //
+				"foo.bar:bundles:1.0.0:pom", "[aggregator] bundles", "the-default-value");
+		assertProjectData("bundles-2", projectData, //
+				"foo.bar:bundles-2:1.1.0:pom", "Aggregator 2 from pomXML", "aggregator2-from-pomXML");
+		assertProjectData("bundles-with-enhanced-parents", projectData, //
+				"bundles-enhanced-pomless:bundles-with-enhanced-parents:1.2.0:pom", "Aggregator 3 pomless",
+				"aggregator3-pomless");
+
+		assertThat(projectData, is(aMapWithSize(0))); // Ensure no more projects are found
+	}
+
+	private static Map<Path, ModelData> extractPomModelProperties(Path buildRootDir) throws IOException {
+		Map<Path, ModelData> projectData = new HashMap<>();
+		try (var paths = Files.walk(buildRootDir).filter(Files::isRegularFile)) {
+			var files = paths.filter(p -> "pommodel.data".equals(p.getFileName().toString()));
+			for (Path file : (Iterable<Path>) files::iterator) {
+				ModelData data = ModelData.extract(file, buildRootDir);
+				projectData.put(data.path, data);
+			}
+		}
+		return projectData;
+	}
+
+	private static void assertProjectData(String path, Map<Path, ModelData> projectData, String expectedGAV,
+			String expectedName, String expectedProperty) {
+		ModelData data = projectData.remove(Path.of(path));
+		assertEquals(expectedGAV, data.gav);
+		assertEquals(expectedName, data.name);
+		assertEquals(expectedProperty, data.propertyValue);
+	}
+
+	private static final class ModelData {
+
+		static ModelData extract(Path file, Path basedir) throws IOException {
+			assertTrue(file.endsWith(Path.of("target", "pommodel.data")));
+			Path relativePath = basedir.relativize(file).getParent().getParent();
+			Properties properties = new Properties();
+			try (var in = Files.newInputStream(file)) {
+				properties.load(in);
+			}
+			assertEquals(3, properties.size(), "Unexpected number of model properties");
+			String gav = properties.getProperty("GAV");
+			String name = properties.getProperty("project.name");
+			String propertyValue = properties.getProperty("custom.user.property");
+			return new ModelData(relativePath != null ? relativePath : Path.of("."), gav, name, propertyValue);
+		}
+
+		final Path path;
+		final String gav;
+		final String name;
+		final String propertyValue;
+
+		public ModelData(Path path, String gav, String name, String propertyValue) {
+			this.path = path;
+			this.gav = gav;
+			this.name = name;
+			this.propertyValue = propertyValue;
+		}
 	}
 }


### PR DESCRIPTION
The `TychoBundleMapping` tried to look up the buiild.properties of a 'eclipse-plugin' project in its META-INF folder instead of the project root and therefore made it impossible to set pom.model attributes as described in the [Tycho-wiki](https://github.com/eclipse/tycho/wiki/Tycho-Pomless), at least from the build.properties in the project root.

- Add extensive integration test to ensure all pom.model attributes are correctly read

- Remove `DefaultTychoResolver.setBuildProperties()` because its functionality is already provided by `AbstractTychoMapping` and it is currently not working. It seems to have operated on another project and its properties than those that are used later during execution.