### PR TITLE
Clean up and reduce file-system interactions of Tycho-Mappings

### DIFF
--- a/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/AbstractXMLTychoMapping.java
+++ b/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/AbstractXMLTychoMapping.java
@@ -17,6 +17,10 @@ package org.eclipse.tycho.pomless;
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -40,13 +44,11 @@ public abstract class AbstractXMLTychoMapping extends AbstractTychoMapping {
     private static final DocumentBuilderFactory FACTORY = DocumentBuilderFactory.newInstance();
 
     @Override
-    protected void initModel(Model model, Reader artifactReader, File artifactFile)
-            throws ModelParseException, IOException {
+    protected void initModel(Model model, Reader artifactReader, File artifactFile) throws IOException {
         initModelFromXML(model, parseXML(artifactReader, artifactFile.toURI().toASCIIString()), artifactFile);
     }
 
-    protected abstract void initModelFromXML(Model model, Element xml, File artifactFile)
-            throws ModelParseException, IOException;
+    protected abstract void initModelFromXML(Model model, Element xml, File artifactFile) throws IOException;
 
     protected static Element parseXML(Reader artifactReader, String documentURI) throws IOException {
         try {
@@ -95,5 +97,12 @@ public abstract class AbstractXMLTychoMapping extends AbstractTychoMapping {
     @Override
     public float getPriority() {
         return 1;
+    }
+
+    protected static Stream<File> filesWithExtension(Path directory, String extension) throws IOException {
+        Predicate<String> nameFilter = n -> !n.startsWith(".polyglot.") && n.endsWith(extension);
+        return Files.walk(directory, 1) //
+                .filter(p -> nameFilter.test(p.getFileName().toString())) // 
+                .filter(Files::isRegularFile).map(Path::toFile);
     }
 }

--- a/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoPomlessLifecycleParticipant.java
+++ b/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoPomlessLifecycleParticipant.java
@@ -14,7 +14,6 @@
  *******************************************************************************/
 package org.eclipse.tycho.pomless;
 
-import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -42,9 +41,8 @@ public class TychoPomlessLifecycleParticipant extends AbstractMavenLifecyclePart
         File moduleProjectDirectory = session.getRequest().getMultiModuleProjectDirectory();
         if (moduleProjectDirectory != null) {
             File extensionsFile = new File(moduleProjectDirectory, ".mvn/extensions.xml");
-            CoreExtensionsXpp3Reader parser = new CoreExtensionsXpp3Reader();
-            try (InputStream is = new BufferedInputStream(new FileInputStream(extensionsFile))) {
-                List<CoreExtension> extensions = parser.read(is).getExtensions();
+            try (InputStream is = new FileInputStream(extensionsFile)) {
+                List<CoreExtension> extensions = new CoreExtensionsXpp3Reader().read(is).getExtensions();
                 for (CoreExtension coreExtension : extensions) {
                     if ("org.eclipse.tycho.extras".equals(coreExtension.getGroupId())
                             && "tycho-pomless".equals(coreExtension.getArtifactId())) {


### PR DESCRIPTION
This PR has the goal to clean-up/simplify Tycho's pomless Mappings a bit and to reduce the number of file-system interactions, for example by performing the check if a File exists after it has been checked if it even matches the name pattern. Interactions with the file system are usually very expensive an can require significant amount of time if done often.
That being said the changes applied are only from looking at the code without having done any measurements. So there might not be a noticeable improvement.