### PR TITLE
Embed m2e lifecycle-mapping-metadata in Tycho plug-ins

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,11 @@ This page describes the noteworthy improvements provided by each release of Ecli
 
 ## 3.0.0 (under development)
 
+### Eclipse M2E lifecycle-mapping metadata included
+
+All Tycho plugins are now shipped with embedded M2E lifecycle-mapping-metadata files.
+Therefore M2E now knows by default how to handle them and it is not necessary anymore to install any connector (usually `org.sonatype.tycho.m2e` was used) for them.
+
 ### Support for BND in tycho-build extension (aka pomless builds)
 
 The Tycho Build Extension (aka pomless build) now detects bnd.bnd files in the root of a pomless bundle and automatically generates an appropriate maven execution automatically.

--- a/target-platform-configuration/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/target-platform-configuration/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>target-platform</goal>
+          <goal>target-platform-configuration</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-compiler-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-compiler-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>validate-classpath</goal>
+          <goal>testCompile</goal>
+          <goal>compile</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-ds-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-ds-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>declarative-services</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-extras/target-platform-validation-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-extras/target-platform-validation-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>validate-target-platform</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-extras/tycho-custom-bundle-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-extras/tycho-custom-bundle-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>custom-bundle</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-extras/tycho-dependency-tools-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-extras/tycho-dependency-tools-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>list-dependencies</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-extras/tycho-document-bundle-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-extras/tycho-document-bundle-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>javadoc</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-extras/tycho-eclipserun-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-extras/tycho-eclipserun-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>eclipse-run</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-extras/tycho-p2-extras-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-extras/tycho-p2-extras-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>mirror</goal>
+          <goal>publish-features-and-bundles</goal>
+          <goal>compare-version-with-baselines</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-extras/tycho-version-bump-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-extras/tycho-version-bump-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>update-target</goal>
+          <goal>update-product</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-gpg-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-gpg-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>sign-p2-artifacts</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-p2/tycho-p2-director-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-p2/tycho-p2-director-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>archive-products</goal>
+          <goal>materialize-products</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-p2/tycho-p2-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-p2/tycho-p2-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>update-site-p2-metadata</goal>
+          <goal>p2-metadata</goal>
+          <goal>category-p2-metadata</goal>
+          <goal>update-local-index</goal>
+          <goal>feature-p2-metadata</goal>
+          <goal>p2-metadata-default</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-p2/tycho-p2-publisher-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-p2/tycho-p2-publisher-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>attach-artifacts</goal>
+          <goal>publish-ee-profile</goal>
+          <goal>publish-osgi-ee</goal>
+          <goal>publish-products</goal>
+          <goal>publish-categories</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-p2/tycho-p2-repository-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-p2/tycho-p2-repository-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>archive-repository</goal>
+          <goal>assemble-maven-repository</goal>
+          <goal>fix-artifacts-metadata</goal>
+          <goal>verify-repository</goal>
+          <goal>remap-artifacts-to-m2-repo</goal>
+          <goal>assemble-repository</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-packaging-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-packaging-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>build-qualifier-aggregator</goal>
+          <goal>package-plugin</goal>
+          <goal>package-feature</goal>
+          <goal>validate-version</goal>
+          <goal>build-qualifier</goal>
+          <goal>validate-id</goal>
+          <goal>package-iu</goal>
+          <goal>update-consumer-pom</goal>
+          <goal>package-target-definition</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-release/tycho-versions-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-release/tycho-versions-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>update-pom</goal>
+          <goal>update-eclipse-metadata</goal>
+          <goal>set-version</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-source-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-source-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>plugin-source</goal>
+          <goal>feature-source</goal>
+          <goal>generate-pde-source-header</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-surefire/tycho-surefire-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>integration-test</goal>
+          <goal>test</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>


### PR DESCRIPTION
The embedded metadata simply advice M2E to ignore executions of each Tycho Mojo.
In the Eclipse IDE Plug-in development support is PDE's duty and therefore Tycho Plug-ins have nothing to do.
Because the metadata embedded in a plugin are considered with lowest priority, a user can simply overrule this decision, if it is desired to execute a Tycho Plugin within the IDE.

Providing mappings for all Plug-ins is probably not necessary for most cases, but since theoretically one can explicitly bind a plug-in to any phase, it can also appear in a phase M2E is interested in (i.e. M2E is interested in all phases from validate until before test).

I used the simple app posted to https://github.com/eclipse-m2e/m2e-core/issues/830 to generate all mappings, so they should be complete (I verified that manually).

Fixes https://github.com/eclipse/tycho/issues/945
