### PR TITLE
Fix goal execution suppression in pomless-model tests

### DIFF
--- a/tycho-its/projects/pomless-model/pom.xml
+++ b/tycho-its/projects/pomless-model/pom.xml
@@ -84,6 +84,13 @@
 							</goals>
 							<phase>none</phase>
 						</execution>
+					</executions>
+				</plugin>
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-p2-repository-plugin</artifactId>
+					<version>${tycho.version}</version>
+					<executions>
 						<execution>
 							<id>default-assemble-repository</id>
 							<goals>


### PR DESCRIPTION
The suppressed executions where bound to the wrong phase. Suppressing those relatively long-running goals speeds up the test execution.