### PR TITLE
[Backport]' Embed m2e lifecycle-mapping-metadata in Tycho plug-ins' and 'Fix goal execution suppression in pomless tests'

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 This page describes the noteworthy improvements provided by each release of Eclipse Tycho.
 
 ## 2.7.4
+
 Fixes:
 - Tycho reports wrong type in case of maven GAV restored from UI
 - Support bnd processing in pomless builds
@@ -13,6 +14,12 @@ Fixes:
 - Not all (direct) requirements of a feature are considered when building an update-site
 - Fix Mojo Configuration of DS Plugin is ignored
 - Check that components declared in the manifest exits
+
+### Eclipse M2E lifecycle-mapping metadata embedded
+
+All Tycho plugins are now shipped with embedded M2E lifecycle-mapping-metadata files.
+Therefore M2E now knows by default how to handle them and it is not necessary anymore to install any connector (usually `org.sonatype.tycho.m2e` was used) for them.
+
 
 ## 2.7.3
 Fixes:

--- a/target-platform-configuration/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/target-platform-configuration/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>target-platform</goal>
+          <goal>target-platform-configuration</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-compiler-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-compiler-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>validate-classpath</goal>
+          <goal>testCompile</goal>
+          <goal>compile</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-ds-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-ds-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>declarative-services</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-extras/target-platform-validation-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-extras/target-platform-validation-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>validate-target-platform</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-extras/tycho-custom-bundle-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-extras/tycho-custom-bundle-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>custom-bundle</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-extras/tycho-dependency-tools-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-extras/tycho-dependency-tools-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>list-dependencies</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-extras/tycho-document-bundle-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-extras/tycho-document-bundle-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>javadoc</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-extras/tycho-eclipserun-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-extras/tycho-eclipserun-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>eclipse-run</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-extras/tycho-p2-extras-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-extras/tycho-p2-extras-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>mirror</goal>
+          <goal>publish-features-and-bundles</goal>
+          <goal>compare-version-with-baselines</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-extras/tycho-version-bump-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-extras/tycho-version-bump-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>update-target</goal>
+          <goal>update-product</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-gpg-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-gpg-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>sign-p2-artifacts</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-its/projects/pomless-model/.mvn/maven.config
+++ b/tycho-its/projects/pomless-model/.mvn/maven.config
@@ -1,2 +1,1 @@
--Dtycho-version=3.0.0-SNAPSHOT
 -Dtycho.pomless.aggregator.names=bundles,bundles-with-enhanced-parents

--- a/tycho-its/projects/pomless-model/pom.xml
+++ b/tycho-its/projects/pomless-model/pom.xml
@@ -9,7 +9,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho.version>${tycho-version}</tycho.version>
+		<tycho.version>2.7.4-SNAPSHOT</tycho.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<custom.user.property>the-default-value</custom.user.property>
 	</properties>
@@ -84,6 +84,13 @@
 							</goals>
 							<phase>none</phase>
 						</execution>
+					</executions>
+				</plugin>
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-p2-repository-plugin</artifactId>
+					<version>${tycho.version}</version>
+					<executions>
 						<execution>
 							<id>default-assemble-repository</id>
 							<goals>

--- a/tycho-its/projects/pomless/pom.xml
+++ b/tycho-its/projects/pomless/pom.xml
@@ -10,7 +10,7 @@
 	</modules>
 
   <properties>
-    <tycho-version>3.0.0-SNAPSHOT</tycho-version>
+    <tycho-version>2.7.4-SNAPSHOT</tycho-version>
   </properties>
 	
 	<build>

--- a/tycho-p2/tycho-p2-director-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-p2/tycho-p2-director-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>archive-products</goal>
+          <goal>materialize-products</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-p2/tycho-p2-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-p2/tycho-p2-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>update-site-p2-metadata</goal>
+          <goal>p2-metadata</goal>
+          <goal>category-p2-metadata</goal>
+          <goal>update-local-index</goal>
+          <goal>feature-p2-metadata</goal>
+          <goal>p2-metadata-default</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-p2/tycho-p2-publisher-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-p2/tycho-p2-publisher-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>attach-artifacts</goal>
+          <goal>publish-ee-profile</goal>
+          <goal>publish-osgi-ee</goal>
+          <goal>publish-products</goal>
+          <goal>publish-categories</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-p2/tycho-p2-repository-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-p2/tycho-p2-repository-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>archive-repository</goal>
+          <goal>assemble-maven-repository</goal>
+          <goal>fix-artifacts-metadata</goal>
+          <goal>verify-repository</goal>
+          <goal>remap-artifacts-to-m2-repo</goal>
+          <goal>assemble-repository</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-packaging-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-packaging-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>build-qualifier-aggregator</goal>
+          <goal>package-plugin</goal>
+          <goal>package-feature</goal>
+          <goal>validate-version</goal>
+          <goal>build-qualifier</goal>
+          <goal>validate-id</goal>
+          <goal>package-iu</goal>
+          <goal>update-consumer-pom</goal>
+          <goal>package-target-definition</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-release/tycho-versions-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-release/tycho-versions-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>update-pom</goal>
+          <goal>update-eclipse-metadata</goal>
+          <goal>set-version</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-source-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-source-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>plugin-source</goal>
+          <goal>feature-source</goal>
+          <goal>generate-pde-source-header</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>

--- a/tycho-surefire/tycho-surefire-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/tycho-surefire/tycho-surefire-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>integration-test</goal>
+          <goal>test</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore />
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>


### PR DESCRIPTION
Backport of https://github.com/eclipse/tycho/pull/1105 and https://github.com/eclipse/tycho/pull/1106.