### PR TITLE
Record initial state of units + some cleanup

### DIFF
--- a/target-platform-configuration/src/main/java/org/eclipse/tycho/target/TargetPlatformConfigurationInstallableUnitProvider.java
+++ b/target-platform-configuration/src/main/java/org/eclipse/tycho/target/TargetPlatformConfigurationInstallableUnitProvider.java
@@ -15,6 +15,7 @@ package org.eclipse.tycho.target;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -34,6 +35,7 @@ import org.eclipse.equinox.p2.metadata.VersionRange;
 import org.eclipse.equinox.p2.publisher.eclipse.BundlesAction;
 import org.eclipse.tycho.ArtifactType;
 import org.eclipse.tycho.core.TargetPlatformConfiguration;
+import org.eclipse.tycho.core.TychoProject;
 import org.eclipse.tycho.core.resolver.DefaultTargetPlatformConfigurationReader;
 import org.eclipse.tycho.p2maven.InstallableUnitProvider;
 
@@ -53,8 +55,15 @@ public class TargetPlatformConfigurationInstallableUnitProvider implements Insta
     @Requirement
     private Logger logger;
 
+    @Requirement(role = TychoProject.class)
+    private Map<String, TychoProject> projectTypes;
+
     @Override
     public Collection<IInstallableUnit> getInstallableUnits(MavenProject project) throws CoreException {
+        if (projectTypes.get(project.getPackaging()) == null) {
+            //not a tycho project...
+            return Collections.emptyList();
+        }
         TargetPlatformConfiguration configuration = configurationReader
                 .getTargetPlatformConfiguration(legacySupport.getSession(), project);
         List<IRequirement> extraRequirements = configuration.getExtraRequirements().stream().map(key -> {

--- a/tycho-build/src/main/java/org/eclipse/tycho/build/TychoGraphBuilder.java
+++ b/tycho-build/src/main/java/org/eclipse/tycho/build/TychoGraphBuilder.java
@@ -37,6 +37,7 @@ import org.apache.maven.model.building.DefaultModelProblem;
 import org.apache.maven.model.building.ModelProblem;
 import org.apache.maven.model.building.ModelProblem.Severity;
 import org.apache.maven.model.building.Result;
+import org.apache.maven.plugin.LegacySupport;
 import org.apache.maven.project.DuplicateProjectException;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
@@ -72,6 +73,9 @@ public class TychoGraphBuilder extends DefaultGraphBuilder {
 
 	@Requirement
 	private MavenProjectDependencyProcessor dependencyProcessor;
+
+	@Requirement
+	private LegacySupport legacySupport;
 
 	@Override
 	public Result<ProjectDependencyGraph> build(MavenSession session) {
@@ -121,7 +125,9 @@ public class TychoGraphBuilder extends DefaultGraphBuilder {
 			executor = Optional.empty();
 		}
 		Set<MavenProject> selectedProjects = ConcurrentHashMap.newKeySet();
+		MavenSession oldMavenSession = legacySupport.getSession();
 		try {
+			legacySupport.setSession(session);
 			ProjectDependencyClosure dependencyClosure;
 			try {
 				dependencyClosure = dependencyProcessor.computeProjectDependencyClosure(projects);
@@ -193,6 +199,7 @@ public class TychoGraphBuilder extends DefaultGraphBuilder {
 
 			}
 		} finally {
+			legacySupport.setSession(oldMavenSession);
 			executor.ifPresent(ExecutorService::shutdownNow);
 		}
 

--- a/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/IDependencyMetadata.java
+++ b/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/IDependencyMetadata.java
@@ -18,7 +18,7 @@ import java.util.Set;
 public interface IDependencyMetadata {
 
     enum DependencyMetadataType {
-        SEED, RESOLVE;
+        INITIAL, SEED, RESOLVE;
     }
 
     Set<? /* IInstallableUnit */> getDependencyMetadata(DependencyMetadataType type);

--- a/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/PlatformPropertiesUtils.java
+++ b/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/PlatformPropertiesUtils.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.tycho;
 
+import java.util.Objects;
 import java.util.Properties;
 
 /**
@@ -147,6 +148,7 @@ public class PlatformPropertiesUtils {
     public static final String WS_UNKNOWN = "unknown";//$NON-NLS-1$
 
     public static String getWS(Properties properties) {
+        Objects.requireNonNull(properties);
         String ws = properties.getProperty(OSGI_WS);
         if (ws != null)
             return ws;
@@ -172,10 +174,10 @@ public class PlatformPropertiesUtils {
     }
 
     public static String getOS(Properties properties) {
+        Objects.requireNonNull(properties);
         String os = properties.getProperty(OSGI_OS);
         if (os != null)
             return os;
-
         String osName = System.getProperties().getProperty("os.name"); //$NON-NLS-1$
         if (osName.regionMatches(true, 0, Constants.OS_WIN32, 0, 3))
             return Constants.OS_WIN32;
@@ -199,6 +201,7 @@ public class PlatformPropertiesUtils {
     }
 
     public static String getArch(Properties properties) {
+        Objects.requireNonNull(properties);
         String arch = properties.getProperty(OSGI_ARCH);
         if (arch != null)
             return arch;

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/impl/test/ReactorProjectStub.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl.test/src/test/java/org/eclipse/tycho/p2/impl/test/ReactorProjectStub.java
@@ -46,6 +46,8 @@ public class ReactorProjectStub extends ReactorProjectIdentities implements Reac
 
     private Set<?> secondaryDependencyMetadata = new LinkedHashSet<>();
 
+    private Set<?> initialMetadata;
+
     public ReactorProjectStub(File basedir, String groupId, String artifactId, String version, String packagingType) {
         this.basedir = basedir;
         this.groupId = groupId;
@@ -101,6 +103,8 @@ public class ReactorProjectStub extends ReactorProjectIdentities implements Reac
             return dependencyMetadata;
         case RESOLVE:
             return secondaryDependencyMetadata;
+        case INITIAL:
+            return initialMetadata;
         default:
             return Collections.emptySet();
         }
@@ -111,14 +115,25 @@ public class ReactorProjectStub extends ReactorProjectIdentities implements Reac
                 dependencyMetadata.getDependencyMetadata(DependencyMetadataType.SEED));
         this.secondaryDependencyMetadata = new LinkedHashSet<>(
                 dependencyMetadata.getDependencyMetadata(DependencyMetadataType.RESOLVE));
+        LinkedHashSet<Object> initial = new LinkedHashSet<>();
+        initial.addAll(this.dependencyMetadata);
+        initial.addAll(this.secondaryDependencyMetadata);
+        this.initialMetadata = initial;
     }
 
     @Override
     public void setDependencyMetadata(DependencyMetadataType type, Collection<?> units) {
-        if (type == DependencyMetadataType.SEED)
+        switch (type) {
+        case SEED:
             this.dependencyMetadata = new LinkedHashSet<>(units);
-        else if (type == DependencyMetadataType.RESOLVE)
+            break;
+        case RESOLVE:
             this.secondaryDependencyMetadata = new LinkedHashSet<>(units);
+            break;
+        case INITIAL:
+            this.initialMetadata = new LinkedHashSet<>(units);
+            break;
+        }
     }
 
     // TODO share with real implementation?

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/target/TargetPlatformFactoryImpl.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/target/TargetPlatformFactoryImpl.java
@@ -46,6 +46,7 @@ import org.eclipse.equinox.p2.repository.artifact.IArtifactRepository;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactRepositoryManager;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepositoryManager;
+import org.eclipse.tycho.IDependencyMetadata.DependencyMetadataType;
 import org.eclipse.tycho.ReactorProject;
 import org.eclipse.tycho.ReactorProjectIdentities;
 import org.eclipse.tycho.artifacts.TargetPlatform;
@@ -386,14 +387,15 @@ public class TargetPlatformFactoryImpl implements TargetPlatformFactory {
 
         for (ReactorProject project : reactorProjects) {
             @SuppressWarnings("unchecked")
-            Set<IInstallableUnit> projectIUs = (Set<IInstallableUnit>) project.getDependencyMetadata();
+            Set<IInstallableUnit> projectIUs = (Set<IInstallableUnit>) project
+                    .getDependencyMetadata(DependencyMetadataType.INITIAL);
+
             if (projectIUs == null)
                 continue;
-
             for (IInstallableUnit iu : projectIUs) {
-                ReactorProjectIdentities otherOrigin = reactorUIs.put(iu, project.getIdentities());
-
-                if (otherOrigin != null && !otherOrigin.equals(project.getIdentities())) {
+                ReactorProjectIdentities identities = project.getIdentities();
+                ReactorProjectIdentities otherOrigin = reactorUIs.put(iu, identities);
+                if (otherOrigin != null && !otherOrigin.equals(identities)) {
                     Set<File> duplicateLocations = duplicateReactorUIs.get(iu);
                     if (duplicateLocations == null) {
                         duplicateLocations = new LinkedHashSet<>();

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DefaultReactorProject.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/DefaultReactorProject.java
@@ -59,13 +59,15 @@ public class DefaultReactorProject implements ReactorProject {
         if (project == null) {
             return null;
         }
-
-        ReactorProject reactorProject = (ReactorProject) project.getContextValue(CTX_REACTOR_PROJECT);
-        if (reactorProject == null) {
-            reactorProject = new DefaultReactorProject(project);
-            project.setContextValue(CTX_REACTOR_PROJECT, reactorProject);
+        synchronized (project) {
+            ReactorProject reactorProject = (ReactorProject) project.getContextValue(CTX_REACTOR_PROJECT);
+            if (reactorProject == null) {
+                reactorProject = new DefaultReactorProject(project);
+                project.setContextValue(CTX_REACTOR_PROJECT, reactorProject);
+            }
+            return reactorProject;
         }
-        return reactorProject;
+
     }
 
     public static List<ReactorProject> adapt(MavenSession session) {
@@ -232,4 +234,5 @@ public class DefaultReactorProject implements ReactorProject {
     public String getName() {
         return project.getName();
     }
+
 }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/EquinoxResolver.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/EquinoxResolver.java
@@ -20,6 +20,7 @@ import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -117,6 +118,7 @@ public class EquinoxResolver {
 
     public ModuleContainer newResolvedState(ReactorProject project, MavenSession mavenSession, ExecutionEnvironment ee,
             DependencyArtifacts artifacts) throws BundleException {
+        Objects.requireNonNull(artifacts, "DependencyArtifacts can't be null!");
         ScheduledExecutorService executorService = Executors.newScheduledThreadPool(THREAD_COUNT);
         try {
             Properties properties = getPlatformProperties(project, mavenSession, artifacts, ee);

--- a/tycho-p2/tycho-p2-facade/src/main/java/org/eclipse/tycho/p2/resolver/P2DependencyResolver.java
+++ b/tycho-p2/tycho-p2-facade/src/main/java/org/eclipse/tycho/p2/resolver/P2DependencyResolver.java
@@ -151,9 +151,12 @@ public class P2DependencyResolver extends AbstractLogEnabled implements Dependen
                 map.getValue().addAll(metadata.getDependencyMetadata(map.getKey()));
             }
         }
+        Set<Object> initial = new HashSet<>();
         for (Entry<DependencyMetadataType, Set<Object>> entry : typeMap.entrySet()) {
             reactorProject.setDependencyMetadata(entry.getKey(), entry.getValue());
+            initial.addAll(entry.getValue());
         }
+        reactorProject.setDependencyMetadata(DependencyMetadataType.INITIAL, initial);
     }
 
     protected Map<String, IDependencyMetadata> getDependencyMetadata(final MavenSession session,


### PR DESCRIPTION
Currently at the initialization phase we record the units of the project
itself but these are overwritten later on. As some parts rely on using
the initial units we should store them under a special key.