### PR TITLE
Use p2inf in DependencyComputerTest.testFragments

### DIFF
--- a/tycho-core/src/test/resources/projects/eeProfile.resolution.fragments/org.eclipse.swt/META-INF/p2.inf
+++ b/tycho-core/src/test/resources/projects/eeProfile.resolution.fragments/org.eclipse.swt/META-INF/p2.inf
@@ -1,0 +1,4 @@
+requires.4.namespace = org.eclipse.equinox.p2.iu
+requires.4.name = org.eclipse.swt.gtk.linux.x86
+requires.4.range = [$version$,$version$]
+requires.4.filter = (&(osgi.os=linux)(osgi.ws=gtk)(osgi.arch=x86_64)(!(org.eclipse.swt.buildtime=true)))


### PR DESCRIPTION
The DependencyComputerTest.testFragments simulates a build that includes
swt+jface but current SWT build uses a p2.inf to require additional
units. This currently makes this test behave a little bit different than
a actual swt build would behave. Because of this, this adds a p2.inf
file that is similar to what swt-build contains.