### PR TITLE
Dependencies need to consider full GAV(C) for deduplication

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/maven/MavenDependencyInjector.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/maven/MavenDependencyInjector.java
@@ -159,7 +159,7 @@ public final class MavenDependencyInjector {
     private static String getKey(Dependency dependency) {
 
         return dependency.getGroupId() + ":" + dependency.getArtifactId() + ":" + dependency.getType() + ":"
-                + Objects.requireNonNullElse(dependency.getClassifier(), "");
+                + dependency.getVersion() + ":" + Objects.requireNonNullElse(dependency.getClassifier(), "");
     }
 
     private List<Dependency> collectExternalDependencies(ArtifactDescriptor artifact, String scope,


### PR DESCRIPTION
Currently a dependency is considered equal if GAV(C) equals, as we
consider only the highest version. In rare cases it is possible to
specify the same dependency in different versions, for those cases the
full GAV(C) must be taken into consideration before deduplication is
applied.

Fix https://github.com/eclipse/tycho/issues/1129