### PR TITLE
Consider build.props 'pom.model.packaging' to determine test-plugins

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -241,6 +241,15 @@ This can be useful if you like to execute the build with multiple threads (e.g. 
 
 ### Migration guide 2.x -> 3.x
 
+#### Remove `tycho.pomless.testbundle` switch from `build.properties` in favor of specification of project's packaging-type
+
+The boolean property `tycho.pomless.testbundle`, which allowed to specify in the `buid.properties` if a Plug-in is a Test-Plugin or not, has been removed.
+Instead one can specify the packaging-type of that Maven-project directly. To migrate simply apply the following replacements in the `build.properties`:<br>
+`tycho.pomless.testbundle = true` -> `pom.model.packaging = eclipse-test-plugin`<br>
+`tycho.pomless.testbundle = false` ->`pom.model.packaging = eclipse-plugin`
+
+This already works in the Tycho 2.7.x stream (but the generated artifactId does not yet have a 'test'-prefix).
+
 #### sisu-equinox is now sisu-osgi
 
 The sisu-equinox module is now cleaned up and made more generic so it could be used in a wider area of use case, therefore the equinox part is stripped and some API enhancements are performed.

--- a/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/AbstractTychoMapping.java
+++ b/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/AbstractTychoMapping.java
@@ -52,8 +52,11 @@ import org.sonatype.maven.polyglot.mapping.Mapping;
  */
 public abstract class AbstractTychoMapping implements Mapping, ModelReader {
 
-    private static final String TYCHO_POMLESS_PARENT = "tycho.pomless.parent";
-    private static final String PARENT_POM_DEFAULT_VALUE = System.getProperty(TYCHO_POMLESS_PARENT, "..");
+    // All build.properties entries specifically considered by Tycho. Extends the list in Mapping interface
+    protected static final String TYCHO_POMLESS_PARENT_PROPERTY = "tycho.pomless.parent";
+    protected static final String TYCHO_POMLESS_AGGREGATOR_NAMES_PROPERTY = "tycho.pomless.aggregator.names";
+
+    private static final String PARENT_POM_DEFAULT_VALUE = System.getProperty(TYCHO_POMLESS_PARENT_PROPERTY, "..");
     private static final String QUALIFIER_SUFFIX = ".qualifier";
     private static final String MODEL_PARENT = "TychoMapping.model.parent";
 
@@ -168,7 +171,7 @@ public abstract class AbstractTychoMapping implements Mapping, ModelReader {
         }
         Properties buildProperties = getBuildProperties(projectRoot);
         // assumption parent pom must be physically located in parent directory if not given by build.properties
-        String parentRef = buildProperties.getProperty(TYCHO_POMLESS_PARENT, PARENT_POM_DEFAULT_VALUE);
+        String parentRef = buildProperties.getProperty(TYCHO_POMLESS_PARENT_PROPERTY, PARENT_POM_DEFAULT_VALUE);
         File fileOrFolder = new File(projectRoot, parentRef).getCanonicalFile();
         PomReference parentPom;
         if (fileOrFolder.isFile()) {

--- a/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoAggregatorMapping.java
+++ b/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoAggregatorMapping.java
@@ -45,9 +45,9 @@ public class TychoAggregatorMapping extends AbstractTychoMapping {
 
     private static final String TYCHO_POM = "pom.tycho";
 
-    private static final Set<String> COMMON_NAMES = new HashSet<>(Arrays.asList(
-            System.getProperty("tycho.pomless.aggregator.names", "bundles,plugins,tests,features,sites,products,releng")
-                    .split(",")));
+    private static final Set<String> COMMON_NAMES = new HashSet<>(
+            Arrays.asList(System.getProperty(TYCHO_POMLESS_AGGREGATOR_NAMES_PROPERTY,
+                    "bundles,plugins,tests,features,sites,products,releng").split(",")));
 
     @Override
     protected boolean isValidLocation(String location) {

--- a/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoBundleMapping.java
+++ b/tycho-extras/tycho-pomless/src/main/java/org/eclipse/tycho/pomless/TychoBundleMapping.java
@@ -170,10 +170,12 @@ public class TychoBundleMapping extends AbstractTychoMapping {
 
     private boolean isTestBundle(String bundleSymbolicName, File bundleRoot) throws IOException {
         Properties buildProperties = getBuildProperties(bundleRoot);
-        String property = buildProperties.getProperty("tycho.pomless.testbundle");
-        if (property != null) {
-            //if property is given it take precedence over our guesses...
-            return Boolean.valueOf(property);
+        // Although user defined packaging-type takes precedence, check it to have a corresponding artifactId
+        String packagingProperty = buildProperties.getProperty(PACKAGING_PROPERTY);
+        if (PACKAGING.equalsIgnoreCase(packagingProperty)) {
+            return false;
+        } else if (PACKAGING_TEST.equalsIgnoreCase(packagingProperty)) {
+            return true;
         }
         return bundleSymbolicName.endsWith(".tests") || bundleSymbolicName.endsWith(".test");
         //TODO can we improve this? maybe also if the import/require bundle contains junit we should assume it's a test bundle?

--- a/tycho-its/projects/pomless-tests/.mvn/extensions.xml
+++ b/tycho-its/projects/pomless-tests/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions>
+  <extension>
+    <groupId>org.eclipse.tycho</groupId>
+    <artifactId>tycho-build</artifactId>
+    <version>${tycho-version}</version>
+  </extension>
+</extensions>

--- a/tycho-its/projects/pomless-tests/.mvn/maven.config
+++ b/tycho-its/projects/pomless-tests/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Dtycho-version=3.0.0-SNAPSHOT

--- a/tycho-its/projects/pomless-tests/pom.xml
+++ b/tycho-its/projects/pomless-tests/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>foo.bar</groupId>
+	<artifactId>simple</artifactId>
+	<version>1.0.0</version>
+
+	<packaging>pom</packaging>
+
+	<properties>
+		<tycho.version>${tycho-version}</tycho.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	<!-- 
+	This case tests demonstrates Tycho's capabilities to enhance the pom-model via build.properties.
+	The Plugin projects are stripped down to the minimum to keep this case small 
+	and are therefore not a good examples for real life projects.
+	-->
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho.version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<version>3.1.0</version>
+				<executions>
+					<execution>
+						<id>display-project-packaging-type</id>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<phase>generate-sources</phase>
+						<configuration>
+							<target>
+								<echo message="GAV=${project.groupId}:${project.artifactId}:${project.version}:${project.packaging}${line.separator}" file="${project.build.directory}/pommodel.data" append="false" />
+							</target>
+						</configuration>
+					</execution>
+
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	<modules>
+		<module>tests</module>
+	</modules>
+</project>

--- a/tycho-its/projects/pomless-tests/tests/foo.checks/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/pomless-tests/tests/foo.checks/META-INF/MANIFEST.MF
@@ -1,0 +1,4 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: foo.checks
+Bundle-Version: 1.0.0

--- a/tycho-its/projects/pomless-tests/tests/foo.checks/build.properties
+++ b/tycho-its/projects/pomless-tests/tests/foo.checks/build.properties
@@ -1,0 +1,1 @@
+bin.includes = META-INF/

--- a/tycho-its/projects/pomless-tests/tests/foo.not.tests/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/pomless-tests/tests/foo.not.tests/META-INF/MANIFEST.MF
@@ -1,0 +1,4 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: foo.not.tests
+Bundle-Version: 1.0.0

--- a/tycho-its/projects/pomless-tests/tests/foo.not.tests/build.properties
+++ b/tycho-its/projects/pomless-tests/tests/foo.not.tests/build.properties
@@ -1,0 +1,2 @@
+bin.includes = META-INF/
+pom.model.packaging = eclipse-plugin

--- a/tycho-its/projects/pomless-tests/tests/foo.test/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/pomless-tests/tests/foo.test/META-INF/MANIFEST.MF
@@ -1,0 +1,4 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: foo.test
+Bundle-Version: 1.0.0

--- a/tycho-its/projects/pomless-tests/tests/foo.test/build.properties
+++ b/tycho-its/projects/pomless-tests/tests/foo.test/build.properties
@@ -1,0 +1,1 @@
+bin.includes = META-INF/

--- a/tycho-its/projects/pomless-tests/tests/foo.tests.topic/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/pomless-tests/tests/foo.tests.topic/META-INF/MANIFEST.MF
@@ -1,0 +1,4 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: foo.tests.topic
+Bundle-Version: 1.0.0

--- a/tycho-its/projects/pomless-tests/tests/foo.tests.topic/build.properties
+++ b/tycho-its/projects/pomless-tests/tests/foo.tests.topic/build.properties
@@ -1,0 +1,2 @@
+bin.includes = META-INF/
+pom.model.packaging = eclipse-test-plugin

--- a/tycho-its/projects/pomless-tests/tests/foo.tests/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/pomless-tests/tests/foo.tests/META-INF/MANIFEST.MF
@@ -1,0 +1,4 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: foo.tests
+Bundle-Version: 1.0.0

--- a/tycho-its/projects/pomless-tests/tests/foo.tests/build.properties
+++ b/tycho-its/projects/pomless-tests/tests/foo.tests/build.properties
@@ -1,0 +1,1 @@
+bin.includes = META-INF/


### PR DESCRIPTION
In order to specify if a Plug-in project, that does not follow the naming-convention, is a 'test'-project, one can specify in the build.properties file `tycho.pomless.testbundle=true|false`.

IMHO it would be more natural, if one could instead/also specify the packaging-type in the build.properties:
`pom.model.packaging = eclipse-test-plugin|eclipse-plugin`

What do the others think? This could be an alternative or even a replacement for `tycho.pomless.testbundle`. At the moment `pom.model.packaging` (defined by takari-polyglot) is not used by Tycho.

Additionally this moves the specification of all 'tycho.pomless-*' properties to AbstractTychoMapping, so that it is easier to get an overview.
