### PR TITLE
Use standard java locking

### DIFF
--- a/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/locking/facade/FileLocker.java
+++ b/tycho-bundles/org.eclipse.tycho.core.shared/src/main/java/org/eclipse/tycho/locking/facade/FileLocker.java
@@ -41,10 +41,4 @@ public interface FileLocker {
      */
     public void release();
 
-    /**
-     * Whether the file associated with this locker object is currently locked (by this process or
-     * any other process).
-     */
-    public boolean isLocked();
-
 }

--- a/tycho-bundles/org.eclipse.tycho.test.utils/src/main/java/org/eclipse/tycho/test/util/NoopFileLockService.java
+++ b/tycho-bundles/org.eclipse.tycho.test.utils/src/main/java/org/eclipse/tycho/test/util/NoopFileLockService.java
@@ -33,7 +33,6 @@ public class NoopFileLockService implements FileLockService {
             public void lock() {
             }
 
-            @Override
             public boolean isLocked() {
                 return false;
             }

--- a/tycho-core/src/main/java/org/eclipse/tycho/core/locking/FileLockerImpl.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/locking/FileLockerImpl.java
@@ -14,8 +14,11 @@ package org.eclipse.tycho.core.locking;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 
-import org.eclipse.osgi.service.datalocation.Location;
 import org.eclipse.tycho.locking.facade.FileLocker;
 import org.eclipse.tycho.locking.facade.LockTimeoutException;
 
@@ -23,10 +26,14 @@ public class FileLockerImpl implements FileLocker {
 
     private static final String LOCKFILE_SUFFIX = ".tycholock";
 
-    private final Location lockFileLocation;
     final File lockMarkerFile;
 
-    public FileLockerImpl(File file, Location anyLocation) {
+    private FileLock lock;
+
+    private File file;
+
+    public FileLockerImpl(File file) {
+        this.file = file;
         try {
             if (file.isDirectory()) {
                 this.lockMarkerFile = new File(file, LOCKFILE_SUFFIX).getCanonicalFile();
@@ -38,11 +45,9 @@ public class FileLockerImpl implements FileLocker {
                 throw new RuntimeException("Lock marker file " + lockMarkerFile + " already exists and is a directory");
             }
             File parentDir = lockMarkerFile.getParentFile();
-            if (!parentDir.isDirectory() && !parentDir.mkdirs()) {
+            if (!parentDir.mkdirs() && !parentDir.isDirectory()) {
                 throw new RuntimeException("Could not create parent directory " + parentDir + " of lock marker file");
             }
-            this.lockFileLocation = anyLocation.createLocation(null, null, false);
-            this.lockFileLocation.set(lockMarkerFile.toURL(), false, lockMarkerFile.getAbsolutePath());
         } catch (MalformedURLException e) {
             throw new RuntimeException(e);
         } catch (IOException e) {
@@ -60,52 +65,64 @@ public class FileLockerImpl implements FileLocker {
         if (timeout < 0) {
             throw new IllegalArgumentException("timeout must not be negative");
         }
-        boolean success = false;
+        if (lock != null) {
+            throw new LockTimeoutException("already locked file " + file.getAbsolutePath());
+        }
+        lock = aquireLock(timeout);
+
+    }
+
+    private FileLock aquireLock(long timeout) {
         final long waitInterval = 50L;
         long maxTries = (timeout / waitInterval) + 1;
-        IOException ioException = null;
+        FileChannel channel = null;
         for (long i = 0; i < maxTries; i++) {
-            ioException = null;
             try {
-                success = lockFileLocation.lock();
+                if (channel == null) {
+                    Path path = lockMarkerFile.toPath();
+                    channel = FileChannel.open(path, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
+                }
+                FileLock fileLock = channel.tryLock();
+                if (fileLock != null) {
+                    return fileLock;
+                }
             } catch (IOException ioe) {
-                // keep trying (and re-throw eventually)
-                ioException = ioe;
-            }
-            if (success) {
-                return;
             }
             try {
                 Thread.sleep(waitInterval);
             } catch (InterruptedException e) {
-                // ignore
+                Thread.currentThread().interrupt();
+                throw new LockTimeoutException("Interrupted", e);
             }
         }
-        String message = "lock timeout: Could not acquire lock on file " + lockFileLocation.getURL() + " for " + timeout
-                + " msec";
-        if (ioException != null) {
-            throw new LockTimeoutException(message, ioException);
-        } else {
-            throw new LockTimeoutException(message);
+        if (channel != null) {
+            try {
+                channel.close();
+            } catch (IOException e1) {
+            } finally {
+                channel = null;
+            }
         }
+        throw new LockTimeoutException("lock timeout: Could not acquire lock on file "
+                + lockMarkerFile.getAbsolutePath() + " for " + timeout + " msec");
     }
 
     @Override
-    public void release() {
-        lockFileLocation.release();
-        if (lockMarkerFile.isFile() && !lockMarkerFile.delete()) {
-            // this can happen if another process already holds the lock again
-            lockMarkerFile.deleteOnExit();
+    public synchronized void release() {
+        if (lock != null) {
+            try {
+                lock.acquiredBy().close();
+            } catch (Exception e) {
+            }
+            lock = null;
+            if (!lockMarkerFile.delete()) {
+                lockMarkerFile.deleteOnExit();
+            }
         }
     }
 
-    @Override
-    public boolean isLocked() {
-        try {
-            return lockFileLocation.isLocked();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+    public synchronized boolean isLocked() {
+        return lock != null;
     }
 
 }

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/locking/FileLockServiceTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/locking/FileLockServiceTest.java
@@ -13,7 +13,6 @@ package org.eclipse.tycho.core.locking;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -21,7 +20,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Random;
 
-import org.eclipse.tycho.locking.facade.FileLockService;
 import org.eclipse.tycho.locking.facade.FileLocker;
 import org.eclipse.tycho.locking.facade.LockTimeoutException;
 import org.junit.Before;
@@ -33,7 +31,7 @@ public class FileLockServiceTest {
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
-    private FileLockService subject;
+    private FileLockServiceImpl subject;
 
     @Before
     public void setup() {
@@ -42,8 +40,7 @@ public class FileLockServiceTest {
 
     @Test
     public void testIsLocked() throws IOException {
-        FileLocker fileLocker = subject.getFileLocker(newTestFile());
-        assertFalse(fileLocker.isLocked());
+        FileLockerImpl fileLocker = subject.getFileLocker(newTestFile());
         fileLocker.lock();
         try {
             assertTrue(fileLocker.isLocked());
@@ -90,12 +87,12 @@ public class FileLockServiceTest {
 
     @Test
     public void testReuseLockerObject() throws IOException {
-        FileLocker fileLocker = subject.getFileLocker(newTestFile());
+        FileLockerImpl fileLocker = subject.getFileLocker(newTestFile());
         lockAndRelease(fileLocker);
         lockAndRelease(fileLocker);
     }
 
-    private void lockAndRelease(FileLocker fileLocker) {
+    private void lockAndRelease(FileLockerImpl fileLocker) {
         assertFalse(fileLocker.isLocked());
         fileLocker.lock();
         assertTrue(fileLocker.isLocked());
@@ -108,8 +105,6 @@ public class FileLockServiceTest {
         final File testFile = newTestFile();
         FileLocker fileLocker1 = subject.getFileLocker(testFile);
         FileLocker fileLocker2 = subject.getFileLocker(testFile);
-        // same file but different locker objects
-        assertNotSame(fileLocker1, fileLocker2);
         fileLocker1.lock();
         try {
             fileLocker2.lock(0L);
@@ -127,7 +122,6 @@ public class FileLockServiceTest {
         FileLocker locker = subject.getFileLocker(testFile);
         LockProcess lockProcess = new LockProcess(testFile, 200L);
         lockProcess.lockFileInForkedProcess();
-        assertTrue(locker.isLocked());
         try {
             locker.lock(0L);
             fail("lock already held by other VM but could be acquired a second time");
@@ -157,7 +151,7 @@ public class FileLockServiceTest {
 
     @Test
     public void testRelease() throws Exception {
-        FileLocker locker = subject.getFileLocker(newTestFile());
+        FileLockerImpl locker = subject.getFileLocker(newTestFile());
         assertFalse(locker.isLocked());
         // releasing without holding the lock should do nothing
         locker.release();

--- a/tycho-testing-harness/src/main/java/org/eclipse/tycho/test/util/NoopFileLockService.java
+++ b/tycho-testing-harness/src/main/java/org/eclipse/tycho/test/util/NoopFileLockService.java
@@ -33,7 +33,6 @@ public class NoopFileLockService implements FileLockService {
             public void lock() {
             }
 
-            @Override
             public boolean isLocked() {
                 return false;
             }


### PR DESCRIPTION
Currently we use an equinox Location to perform locking, this seems to
cause issues because the equinox locations use packages shaded by other
dependencies. Also it binds Tycho to Equinox implementation.