### PR TITLE
Execute tycho-ds-plugin for eclipse-test-plugins

### DIFF
--- a/tycho-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/tycho-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -106,6 +106,9 @@
               <compile>
                 org.eclipse.tycho:tycho-compiler-plugin:${project.version}:compile
               </compile>
+              <process-classes>
+              	org.eclipse.tycho:tycho-ds-plugin:${project.version}:declarative-services
+              </process-classes>
               <process-test-resources>
                 org.apache.maven.plugins:maven-resources-plugin:${resources-plugin.version}:testResources
               </process-test-resources>


### PR DESCRIPTION
Projects with `Eclipse-test-plugin` packaging-type can have DS-components as well (e.g. for testing purposes).

@laeubi what do you think about enabling the `org.eclipse.tycho:tycho-ds-plugin` by default for them as well?
I have not tested this change yet, but I noticed it is missing in the build of https://github.com/eclipse-equinox/equinox/pull/68.