### PR TITLE
Reproducer for issue 1093: misleading error message

### DIFF
--- a/tycho-its/projects/issue1093/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/issue1093/META-INF/MANIFEST.MF
@@ -1,0 +1,4 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: issue1093
+Bundle-Version: 1.0.0.qualifier

--- a/tycho-its/projects/issue1093/build.properties
+++ b/tycho-its/projects/issue1093/build.properties
@@ -1,0 +1,2 @@
+bin.includes = META-INF/,\
+               non-existing-file.txt

--- a/tycho-its/projects/issue1093/pom.xml
+++ b/tycho-its/projects/issue1093/pom.xml
@@ -1,0 +1,19 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.eclipse.tychoits</groupId>
+	<artifactId>issue1093</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/issue1093/Issue1093Test.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/issue1093/Issue1093Test.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Holger Voormann and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.tycho.test.issue1093;
+
+import java.util.List;
+
+import static org.junit.Assert.fail;
+
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
+import org.eclipse.tycho.test.AbstractTychoIntegrationTest;
+import org.junit.Test;
+
+public class Issue1093Test extends AbstractTychoIntegrationTest {
+
+    @Test
+    public void test() throws Exception {
+        Verifier verifier = getVerifier("issue1093", false);
+        try {
+        	verifier.executeGoals(List.of("clean", "verify"));
+            fail();
+        } catch (VerificationException e) {
+            // expected
+            verifier.verifyTextInLog("non-existing-file.txt does not exist");
+        }
+    }
+}


### PR DESCRIPTION
Plugin without Java code with a `build.properties` file containing:
```
bin.includes = META-INF/,\
               non-existing-file.txt
```
**Actual**: Build fails with the error message ...`/target/classes does not exist`

**Expected**: Build fails with an error message like ...`non-existing-file.txt does not exist`