### PR TITLE
Fallback resolution to force keep uses

### DIFF
--- a/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/EquinoxResolverConfiguration.java
+++ b/tycho-core/src/main/java/org/eclipse/tycho/core/osgitools/EquinoxResolverConfiguration.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat Inc. and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.tycho.core.osgitools;
+
+import java.util.concurrent.TimeUnit;
+
+final class EquinoxResolverConfiguration {
+    //The following properties are not supported for general usage and intended to experimental testing when developing Tycho, so use with care
+
+    public EquinoxResolverConfiguration() {
+        keepUses = Boolean.getBoolean("tycho.equinox.resolver.uses");
+        batchSize = System.getProperty("tycho.equinox.resolver.batch.size", keepUses ? null : "1");
+    }
+
+    public EquinoxResolverConfiguration(EquinoxResolverConfiguration source, boolean forceKeepUses) {
+        keepUses = forceKeepUses;
+        batchSize = keepUses ? null : source.batchSize;
+    }
+
+    /**
+     * If set to true this keep the 'uses' constraints of a package, this will make it more hard for
+     * the resolver or even let him fail to compute a solution if different package providers are
+     * present
+     */
+    final boolean keepUses;
+
+    /**
+     * Keep the default batch size, but allow to override this if necessary, if 'uses' constrains
+     * are kept, do not restrict the batch size as this potentially fails the resolve
+     */
+    final String batchSize;
+
+    /**
+     * Set the batch timeout to an acceptable timeout before fallback to resolve one bundle at a
+     * time, but allow to override this if necessary
+     */
+    final static String BATCH_TIMEOUT = System.getProperty("tycho.equinox.resolver.batch.timeout",
+            String.valueOf(TimeUnit.SECONDS.toMillis(30)));
+
+    /**
+     * Allow to adjust the default thread count used in resolver operations
+     */
+    final static int THREAD_COUNT = Integer.getInteger("tycho.equinox.resolver.executor.threads", 1);
+}

--- a/tycho-core/src/test/java/org/eclipse/tycho/core/osgitools/EquinoxResolverTest.java
+++ b/tycho-core/src/test/java/org/eclipse/tycho/core/osgitools/EquinoxResolverTest.java
@@ -57,7 +57,8 @@ public class EquinoxResolverTest extends AbstractTychoMojoTestCase {
 
     public void test_noSystemBundle() throws BundleException {
         Properties properties = subject.getPlatformProperties(new Properties(), null, null, DUMMY_EE);
-        ModuleContainer container = subject.newState(new DefaultDependencyArtifacts(), properties, null, null);
+        ModuleContainer container = subject.newState(new DefaultDependencyArtifacts(), properties, null, null,
+                new EquinoxResolverConfiguration());
         assertEquals(1, container.getModules().stream().map(Module::getCurrentRevision)
                 .map(BundleRevision::getSymbolicName).filter(Constants.SYSTEM_BUNDLE_SYMBOLICNAME::equals).count());
     }

--- a/tycho-its/projects/resolver.usesNecessary/META-INF/MANIFEST.MF
+++ b/tycho-its/projects/resolver.usesNecessary/META-INF/MANIFEST.MF
@@ -1,0 +1,10 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Test Plugin
+Bundle-SymbolicName: test.plugin;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Bundle-Vendor: Test Vendor
+Automatic-Module-Name: test
+Require-Bundle: org.eclipse.platform;bundle-version="4.22.0",
+ org.eclipse.lsp4j,
+ org.eclipse.tm4e.core

--- a/tycho-its/projects/resolver.usesNecessary/build.properties
+++ b/tycho-its/projects/resolver.usesNecessary/build.properties
@@ -1,0 +1,1 @@
+bin.includes = META-INF/

--- a/tycho-its/projects/resolver.usesNecessary/build.target
+++ b/tycho-its/projects/resolver.usesNecessary/build.target
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target includeMode="feature" name="Test Plugin Build Target">
+	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/releases/2022-06/"/>
+			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.sdk.ide" version="0.0.0"/>
+		</location>
+
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/lsp4j/updates/releases/0.14.0/"/>
+			<unit id="com.google.gson" version="2.8.9.v20220111-1409"/>
+			<unit id="org.eclipse.lsp4j" version="0.0.0"/>
+		</location>
+
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/tm4e/releases/0.6.0/"/>
+			<unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0"/>
+			<unit id="com.google.gson" version="2.9.0"/>
+		</location>
+	</locations>
+	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+</target>

--- a/tycho-its/projects/resolver.usesNecessary/pom.xml
+++ b/tycho-its/projects/resolver.usesNecessary/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>test</groupId>
+	<artifactId>test.plugin</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
+
+	<properties>
+		<java.version>17</java.version>
+		<tycho-version>2.7.3</tycho-version>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<plugin>
+				<!-- https://www.eclipse.org/tycho/sitedocs/target-platform-configuration/target-platform-configuration-mojo.html -->
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<executionEnvironment>JavaSE-${java.version}</executionEnvironment>
+					<target>
+						<file>build.target</file>
+					</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/ResolverTests.java
+++ b/tycho-its/src/test/java/org/eclipse/tycho/test/resolver/ResolverTests.java
@@ -98,4 +98,10 @@ public class ResolverTests extends AbstractTychoIntegrationTest {
 		assertTrue("Highest version was not found", highestVersionFound);
 	}
 
+	@Test
+	public void testConsiderResolutionWithUsesDirectiveIfVanillaResolutionFails() throws Exception {
+		Verifier verifier = getVerifier("resolver.usesNecessary", false, false);
+		verifier.executeGoal("compile");
+		verifier.verifyErrorFreeLog();
+	}
 }


### PR DESCRIPTION
Uses is sometimes necessary for resolution to perform correctly. When
resolution ignoring uses fails, then fallback to full (longer)
resolution honoring uses which is more likely to succeed.