### PR TITLE
Exclude org.osgi.service.log / sanitize service return value

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,12 @@
 				<groupId>biz.aQute.bnd</groupId>
 				<artifactId>biz.aQute.bndlib</artifactId>
 				<version>6.3.1</version>
+				<exclusions>
+					<exclusion>
+						<groupId>org.osgi</groupId>
+						<artifactId>org.osgi.service.log</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/MirrorMojo.java
+++ b/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/MirrorMojo.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
@@ -221,7 +222,8 @@ public class MirrorMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        final MirrorApplicationService mirrorService = p2.getService(MirrorApplicationService.class);
+        final MirrorApplicationService mirrorService = Objects.requireNonNull(
+                p2.getService(MirrorApplicationService.class), "MirrorApplicationService is not available");
 
         RepositoryReferences sourceDescriptor = null;
         if (this.projectTypes.containsKey(project.getPackaging()) && this.repositoryReferenceTool != null


### PR DESCRIPTION
It seems bnd pulls in the problematic dependency that recently caused issues see:

- https://github.com/bndtools/bnd/issues/5335

because of that, we should exclude it in the pom