### PR TITLE
Add a verification of building platform with current PR change

### DIFF
--- a/.github/workflows/verify-platform.yml
+++ b/.github/workflows/verify-platform.yml
@@ -1,0 +1,66 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Verify Eclipse Platform Build
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+on:
+  pull_request:
+    branches: 
+     - 'master'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout tycho code
+      uses: actions/checkout@v3
+      with:
+       path: 'tycho'
+    - name: Checkout platform code
+      uses: actions/checkout@v3
+      with:
+       path: 'platform'
+       submodules: 'recursive'
+       lfs: true
+       repository: 'eclipse-platform/eclipse.platform.releng.aggregator'
+       fetch-depth: 0
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'adopt'
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+    - name: Cache local Maven repository
+      uses: actions/cache@v3
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-verify-platform-${{ hashFiles('**/pom.xml', '**/*.target') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-verify-platform-
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v4.4
+      with:
+        maven-version: 3.8.6
+    - name: Build Tycho
+      working-directory: 'tycho'
+      run: >- 
+        mvn -U -V -e -B -ntp
+        -DskipTests
+        --file pom.xml
+        -T1C
+        --global-toolchains ${{ github.workspace }}/tycho/toolchains-gh.xml
+        clean install
+    - name: Run Platform Build
+      working-directory: 'platform'
+      run: >- 
+        mvn -U -V -e -B -ntp
+        --global-toolchains ${{ github.workspace }}/tycho/toolchains-gh.xml
+        --file pom.xml
+        -DskipTests
+        clean verify


### PR DESCRIPTION
We sometimes has the unfortunate situation that even if all Tycho test
succeed the platform build fails because it has a much more complex
setup. To mitigate this, this change adds a verification step that
compiles Tycho and runs the platform build afterwards with this version.