### PR TITLE
Convert artifact handlers from xml to plexus-component

### DIFF
--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/AbstractArtifactHandler.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/AbstractArtifactHandler.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.p2maven.repository;
+
+import org.apache.maven.artifact.handler.ArtifactHandler;
+
+public class AbstractArtifactHandler implements ArtifactHandler {
+
+	protected static final String LANGUAGE_XML = "xml";
+	protected static final String LANGUAGE_JAVA = "java";
+	protected static final String EXTENSION_JAR = "jar";
+	protected static final String EXTENSION_ZIP = "zip";
+	protected static final String EXTENSION_XML = "xml";
+
+	private final String packaging;
+	private final String extension;
+	private final String language;
+	private final boolean addedToClasspath;
+
+	public AbstractArtifactHandler(String packaging, String extension, String language, boolean addedToClasspath) {
+		this.packaging = packaging;
+		this.extension = extension;
+		this.language = language;
+		this.addedToClasspath = addedToClasspath;
+	}
+
+	@Override
+	public String getExtension() {
+		return extension;
+	}
+
+	@Override
+	public String getDirectory() {
+		return getPackaging() + "s";
+	}
+
+	@Override
+	public String getClassifier() {
+		return null;
+	}
+
+	@Override
+	public String getPackaging() {
+		return packaging;
+	}
+
+	@Override
+	public boolean isIncludesDependencies() {
+		return false;
+	}
+
+	@Override
+	public String getLanguage() {
+		return language;
+	}
+
+	@Override
+	public boolean isAddedToClasspath() {
+		return addedToClasspath;
+	}
+
+}

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/EclipseFeatureArtifactHandler.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/EclipseFeatureArtifactHandler.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.p2maven.repository;
+
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.tycho.ArtifactType;
+
+@Component(role = ArtifactHandler.class, hint = ArtifactType.TYPE_ECLIPSE_FEATURE)
+public class EclipseFeatureArtifactHandler extends AbstractArtifactHandler {
+
+	public EclipseFeatureArtifactHandler() {
+		super(ArtifactType.TYPE_ECLIPSE_FEATURE, EXTENSION_JAR, LANGUAGE_XML, false);
+	}
+
+}

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/EclipsePluginArtifactHandler.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/EclipsePluginArtifactHandler.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.p2maven.repository;
+
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.tycho.ArtifactType;
+
+@Component(role = ArtifactHandler.class, hint = ArtifactType.TYPE_ECLIPSE_PLUGIN)
+public class EclipsePluginArtifactHandler extends AbstractArtifactHandler {
+
+	public EclipsePluginArtifactHandler() {
+		super(ArtifactType.TYPE_ECLIPSE_PLUGIN, EXTENSION_JAR, LANGUAGE_JAVA, true);
+	}
+
+}

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/EclipseRepositoryArtifactHandler.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/EclipseRepositoryArtifactHandler.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.p2maven.repository;
+
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.tycho.ArtifactType;
+
+@Component(role = ArtifactHandler.class, hint = ArtifactType.TYPE_ECLIPSE_REPOSITORY)
+public class EclipseRepositoryArtifactHandler extends AbstractArtifactHandler {
+
+	public EclipseRepositoryArtifactHandler() {
+		super(ArtifactType.TYPE_ECLIPSE_REPOSITORY, EXTENSION_ZIP, LANGUAGE_XML, false);
+	}
+
+}

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/EclipseTargetDefinitionArtifactHandler.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/EclipseTargetDefinitionArtifactHandler.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.p2maven.repository;
+
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.tycho.ArtifactType;
+
+@Component(role = ArtifactHandler.class, hint = ArtifactType.TYPE_ECLIPSE_TARGET_DEFINITION)
+public class EclipseTargetDefinitionArtifactHandler extends AbstractArtifactHandler {
+
+	public EclipseTargetDefinitionArtifactHandler() {
+		super(ArtifactType.TYPE_ECLIPSE_TARGET_DEFINITION, "target", LANGUAGE_XML, false);
+	}
+
+}

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/EclipseTestPluginArtifactHandler.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/EclipseTestPluginArtifactHandler.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.p2maven.repository;
+
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.tycho.ArtifactType;
+
+@Component(role = ArtifactHandler.class, hint = ArtifactType.TYPE_ECLIPSE_TEST_PLUGIN)
+public class EclipseTestPluginArtifactHandler extends AbstractArtifactHandler {
+
+	public EclipseTestPluginArtifactHandler() {
+		super(ArtifactType.TYPE_ECLIPSE_TEST_PLUGIN, EXTENSION_JAR, LANGUAGE_JAVA, true);
+	}
+
+}

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/P2ArtifactsArtifactHandler.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/P2ArtifactsArtifactHandler.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.p2maven.repository;
+
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.tycho.ArtifactType;
+
+@Component(role = ArtifactHandler.class, hint = ArtifactType.TYPE_P2_ARTIFACTS)
+public class P2ArtifactsArtifactHandler extends AbstractArtifactHandler {
+
+	public P2ArtifactsArtifactHandler() {
+		super(ArtifactType.TYPE_P2_ARTIFACTS, EXTENSION_XML, LANGUAGE_XML, false);
+	}
+
+}

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/P2InstallableUnitArtifactHandler.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/P2InstallableUnitArtifactHandler.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.p2maven.repository;
+
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.tycho.PackagingType;
+
+@Component(role = ArtifactHandler.class, hint = PackagingType.TYPE_P2_IU)
+public class P2InstallableUnitArtifactHandler extends AbstractArtifactHandler {
+
+	public P2InstallableUnitArtifactHandler() {
+		super(PackagingType.TYPE_P2_IU, EXTENSION_ZIP, LANGUAGE_XML, false);
+	}
+
+}

--- a/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/P2MetadataArtifactHandler.java
+++ b/p2-maven-plugin/src/main/java/org/eclipse/tycho/p2maven/repository/P2MetadataArtifactHandler.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.tycho.p2maven.repository;
+
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.codehaus.plexus.component.annotations.Component;
+import org.eclipse.tycho.ArtifactType;
+
+@Component(role = ArtifactHandler.class, hint = ArtifactType.TYPE_P2_METADATA)
+public class P2MetadataArtifactHandler extends AbstractArtifactHandler {
+
+	public P2MetadataArtifactHandler() {
+		super(ArtifactType.TYPE_P2_METADATA, EXTENSION_XML, LANGUAGE_XML, false);
+	}
+
+}

--- a/tycho-bundles/org.eclipse.tycho.core.shared/.classpath
+++ b/tycho-bundles/org.eclipse.tycho.core.shared/.classpath
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src/main/java"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-18">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="src" path="src/main/java/"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/ArtifactType.java
+++ b/tycho-bundles/org.eclipse.tycho.embedder.shared/src/main/java/org/eclipse/tycho/ArtifactType.java
@@ -19,11 +19,13 @@ package org.eclipse.tycho;
  */
 public final class ArtifactType {
 
+    public static final String TYPE_ECLIPSE_REPOSITORY = "eclipse-repository";
     public static final String TYPE_ECLIPSE_PLUGIN = "eclipse-plugin";
-    public static final String TYPE_BUNDLE_FRAGMENT = "bundle-fragment";
+    public static final String TYPE_ECLIPSE_TARGET_DEFINITION = "eclipse-target-definition";
     public static final String TYPE_ECLIPSE_TEST_PLUGIN = "eclipse-test-plugin";
     public static final String TYPE_ECLIPSE_FEATURE = "eclipse-feature";
     public static final String TYPE_ECLIPSE_PRODUCT = "eclipse-product";
+    public static final String TYPE_BUNDLE_FRAGMENT = "bundle-fragment";
     public static final String TYPE_INSTALLABLE_UNIT = "p2-installable-unit";
     public static final String TYPE_P2_ARTIFACTS = "p2-artifacts";
     public static final String TYPE_P2_METADATA = "p2-metadata";

--- a/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/target/TargetPlatformFactoryImpl.java
+++ b/tycho-bundles/org.eclipse.tycho.p2.resolver.impl/src/main/java/org/eclipse/tycho/p2/target/TargetPlatformFactoryImpl.java
@@ -31,6 +31,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -111,7 +112,8 @@ public class TargetPlatformFactoryImpl implements TargetPlatformFactory {
         this.monitor = new DuplicateFilteringLoggingProgressMonitor(logger); // entails that this class is not thread-safe
 
         this.remoteAgent = remoteAgent;
-        this.remoteRepositoryIdManager = remoteAgent.getService(IRepositoryIdManager.class);
+        this.remoteRepositoryIdManager = Objects.requireNonNull(remoteAgent.getService(IRepositoryIdManager.class),
+                "IRepositoryIdManager not registered with agent " + remoteAgent + "!");
         this.offline = mavenContext.isOffline();
 
         this.remoteMetadataRepositoryManager = remoteAgent.getService(IMetadataRepositoryManager.class);

--- a/tycho-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/tycho-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -64,21 +64,6 @@
         </lifecycles>
       </configuration>
     </component>
-    <component>
-      <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
-      <role-hint>eclipse-plugin</role-hint>
-      <implementation>
-        org.apache.maven.artifact.handler.DefaultArtifactHandler
-      </implementation>
-      <configuration>
-        <extension>jar</extension>
-        <type>eclipse-plugin</type>
-        <packaging>eclipse-plugin</packaging>
-        <language>java</language>
-        <addedToClasspath>true</addedToClasspath>
-        <includesDependencies>false</includesDependencies>
-      </configuration>
-    </component>
 
     <component>
       <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
@@ -134,22 +119,6 @@
         </lifecycles>
       </configuration>
     </component>
-    <component>
-      <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
-      <role-hint>eclipse-test-plugin</role-hint>
-      <implementation>
-        org.apache.maven.artifact.handler.DefaultArtifactHandler
-      </implementation>
-      <configuration>
-        <extension>jar</extension>
-        <type>eclipse-test-plugin</type>
-        <packaging>eclipse-test-plugin</packaging>
-        <language>java</language>
-        <addedToClasspath>true</addedToClasspath>
-        <includesDependencies>false</includesDependencies>
-      </configuration>
-    </component>
-
 
     <component>
       <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
@@ -190,21 +159,6 @@
             </phases>
           </lifecycle>
         </lifecycles>
-      </configuration>
-    </component>
-    <component>
-      <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
-      <role-hint>eclipse-feature</role-hint>
-      <implementation>
-        org.apache.maven.artifact.handler.DefaultArtifactHandler
-      </implementation>
-      <configuration>
-        <extension>jar</extension>
-        <type>eclipse-feature</type>
-        <packaging>eclipse-feature</packaging>
-        <language>java</language>
-        <addedToClasspath>false</addedToClasspath>
-        <includesDependencies>false</includesDependencies>
       </configuration>
     </component>
 
@@ -253,21 +207,6 @@
         </lifecycles>
       </configuration>
     </component>
-    <component>
-      <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
-      <role-hint>eclipse-repository</role-hint>
-      <implementation>
-        org.apache.maven.artifact.handler.DefaultArtifactHandler
-      </implementation>
-      <configuration>
-        <extension>zip</extension>
-        <type>eclipse-repository</type>
-        <packaging>eclipse-repository</packaging>
-        <language>java</language>
-        <addedToClasspath>false</addedToClasspath>
-        <includesDependencies>false</includesDependencies>
-      </configuration>
-    </component>
     
     <component>
       <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
@@ -294,22 +233,6 @@
         </lifecycles>
       </configuration>
     </component>
-    <component>
-      <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
-      <role-hint>eclipse-target-definition</role-hint>
-      <implementation>
-        org.apache.maven.artifact.handler.DefaultArtifactHandler
-      </implementation>
-      <configuration>
-        <extension>target</extension>
-        <type>eclipse-target-definition</type>
-        <packaging>eclipse-target-definition</packaging>
-        <language>java</language>
-        <addedToClasspath>false</addedToClasspath>
-        <includesDependencies>false</includesDependencies>
-      </configuration>
-    </component>
-
 
     <component>
       <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
@@ -347,52 +270,6 @@
             </phases>
           </lifecycle>
         </lifecycles>
-      </configuration>
-    </component>
-    <component>
-      <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
-      <role-hint>p2-installable-unit</role-hint>
-      <implementation>
-        org.apache.maven.artifact.handler.DefaultArtifactHandler
-      </implementation>
-      <configuration>
-        <extension>zip</extension>
-        <type>p2-installable-unit</type>
-        <packaging>p2-installable-unit</packaging>
-        <language>java</language>
-        <addedToClasspath>false</addedToClasspath>
-        <includesDependencies>false</includesDependencies>
-      </configuration>
-    </component>
-
-
-    <component>
-      <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
-      <role-hint>p2-artifacts</role-hint>
-      <implementation>
-        org.apache.maven.artifact.handler.DefaultArtifactHandler
-      </implementation>
-      <configuration>
-        <extension>xml</extension>
-        <type>p2-artifacts</type>
-        <language>P2</language>
-        <addedToClasspath>false</addedToClasspath>
-        <includesDependencies>false</includesDependencies>
-      </configuration>
-    </component>
-    
-     <component>
-      <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
-      <role-hint>p2-metadata</role-hint>
-      <implementation>
-        org.apache.maven.artifact.handler.DefaultArtifactHandler
-      </implementation>
-      <configuration>
-        <extension>xml</extension>
-        <type>p2-metadata</type>
-        <language>P2</language>
-        <addedToClasspath>false</addedToClasspath>
-        <includesDependencies>false</includesDependencies>
       </configuration>
     </component>
 


### PR DESCRIPTION
Currently we declare artifact handlers in the tycho-maven-plugin xml by
hand written code.

This has the drawback, that one always needs to include the
tycho-maven-plugin to use the artifact types, if one uses a tycho-mojo
standalone (e.g. eclipse-run-mojo) they are missing.

With declaring them in the code, next to the p2 plugin, they are
available for all mojos.